### PR TITLE
Update v2

### DIFF
--- a/functions/Get-PasswordStateList.ps1
+++ b/functions/Get-PasswordStateList.ps1
@@ -22,9 +22,9 @@ function Get-PasswordStateList {
     )]
     [CmdletBinding()]
     param (
-        [parameter(ValueFromPipelineByPropertyName, Position = 0,ParameterSetName='SearchByID')][int32]$PasswordListID,
-        [parameter(ValueFromPipelineByPropertyName, Position = 0,ParameterSetName='SearchBy')][ValidateSet('ID','Name')][string]$Searchby = 'ID',
-        [parameter(ValueFromPipelineByPropertyName, Position = 1,ParameterSetName='SearchBy')][string]$SearchName
+        [parameter(ValueFromPipelineByPropertyName, Position = 0)][int32]$PasswordListID,
+        [parameter(ValueFromPipelineByPropertyName, Position = 1,ParameterSetName='SearchBy')][ValidateSet('ID','Name')][string]$Searchby = 'ID',
+        [parameter(ValueFromPipelineByPropertyName, Position = 2,ParameterSetName='SearchBy')][string]$SearchName
     )
 
     begin {

--- a/functions/Get-PasswordStatePasswords.ps1
+++ b/functions/Get-PasswordStatePasswords.ps1
@@ -17,7 +17,7 @@ function Get-PasswordStatePasswords {
     )]
     [Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSAvoidUsingUserNameAndPassWordParams', '', Justification = 'PasswordID isnt a password')]
     param (
-        [Parameter(ParameterSetName='GetAllPasswordsFromList', Mandatory = $false)][int32]$PasswordlistID
+        [Parameter(ParameterSetName='GetAllPasswordsFromList', Mandatory = $false,ValueFromPipeline=$True,ValueFromPipelinebyPropertyName=$True)][int32[]]$PasswordlistID
     )
 
     begin {


### PR DESCRIPTION
Fixed 2 minor issues:

I've removed the parameter set name: SearchByID in function  Get-PasswordStateList , cause of breaking reverse compatibility. You had to give in a parameter.

Changed function Get-PasswordStatePasswords slightly to accept pipeline. Now you can do get-passwordstatelist | get-passwordtatepassword, or get-passwordstatelist -id 1 | get-passwordstatepassword
