### PR TITLE
Support for secure strings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## 0.0.94
+
++ Feature
+  + Passwords now returned as secure string. Use .GetPassword() method to retrieve plaintext
+  + Global variable for returning plain text passwords $global:PasswordStateShowPasswordsPlainText = $true
++ Fixes
+  + Added support for APIKey auth to generate passwords as this was broken.
+  + Various bugfixes when using apikeys.
+
 ## 0.0.91
 
 + Fix

--- a/docs/Get-PasswordStatePasswords.md
+++ b/docs/Get-PasswordStatePasswords.md
@@ -14,7 +14,7 @@ Use Get-PasswordStateList to search for a name and return the ID
 ## SYNTAX
 
 ```
-Get-PasswordStatePasswords [-PasswordlistID <Int32[]>] [<CommonParameters>]
+Get-PasswordStatePasswords [[-PasswordlistID] <Int32[]>] [<CommonParameters>]
 ```
 
 ## DESCRIPTION
@@ -41,7 +41,7 @@ Parameter Sets: (All)
 Aliases:
 
 Required: False
-Position: Named
+Position: 1
 Default value: 0
 Accept pipeline input: True (ByPropertyName, ByValue)
 Accept wildcard characters: False

--- a/docs/New-PasswordStateList.md
+++ b/docs/New-PasswordStateList.md
@@ -13,7 +13,7 @@ Creates a passwordstate List.
 ## SYNTAX
 
 ```
-New-PasswordStateList [-Name] <String> [-description] <String> [[-CopySettingsFromPasswordListID] <Int32>]
+New-PasswordStateList [-Name] <String> [-description] <String> [-CopySettingsFromPasswordListID] <Int32>
  [-FolderID] <Int32> [-WhatIf] [-Confirm] [<CommonParameters>]
 ```
 
@@ -67,7 +67,7 @@ Type: Int32
 Parameter Sets: (All)
 Aliases:
 
-Required: False
+Required: True
 Position: 3
 Default value: None
 Accept pipeline input: True (ByPropertyName)

--- a/functions/Find-PasswordStatePassword.Tests.ps1
+++ b/functions/Find-PasswordStatePassword.Tests.ps1
@@ -1,41 +1,54 @@
-﻿$here = Split-Path -Parent $MyInvocation.MyCommand.Path
+﻿(import-module "$psscriptroot\..\passwordstate-management.psm1" -force)
+$here = Split-Path -Parent $MyInvocation.MyCommand.Path
 $sut = (Split-Path -Leaf $MyInvocation.MyCommand.Path) -replace '\.Tests\.', '.'
 . "$here\$sut"
-Import-Module "$here\..\passwordstate-management.psm1"
 Describe "Find-PasswordStatePassword" {
-    It "Finds a Password From Password State" {
-        Mock -CommandName Get-PasswordStateResource -MockWith {return [PSCustomObject]@{
-                "Title"       = "testuser"
-                "Username"    = "test"
-                "Domain"      = ""
-                "Description" = ""
-                "PasswordId"  = 3
-                "AccountType" = ""
-                "URL"         = ""
-                "Password"    = "testpassword"
-            }
-        } -ParameterFilter {$uri -eq "/api/passwords/3"}
-
-        Mock -CommandName Get-PasswordStateResource -MockWith {return [PSCustomObject]@{
-                "Title"       = "testuser"
-                "Username"    = "test"
-                "Domain"      = ""
-                "Description" = ""
-                "PasswordId"  = 3
-                "AccountType" = ""
-                "URL"         = ""
-                "Password"    = ""
-            }
-        } -ParameterFilter {$uri -eq "/api/searchpasswords/?title=testuser&ExcludePassword=true"}
-
-        Mock -CommandName Get-PasswordStateEnvironment -MockWith {return [PSCustomObject]@{
-                "Baseuri" = "https://passwordstateserver.co.uk"
-                "APIKey"  = "WindowsAuth"
-
-            }
+    It "Finds a Password by generic search" {
+        (Find-PasswordStatePassword "test").Title | Should -BeExactly "test"
+    }
+    It "Finds a Password by ID" {
+        (Find-PasswordStatePassword -PasswordID "1").PasswordID | Should -BeExactly 1
+    }
+    It "Finds a Password with a reason" {
+        (Find-PasswordStatePassword -PasswordID "1" -Reason "Unit Test").PasswordID | Should -BeExactly 1
+    }
+    It "Finds a Password by Username Search" {
+        (Find-PasswordStatePassword -UserName "test").Username | Should -BeExactly "test"
+    }
+    It "Checks Password is returned as type [System.Security.SecureString]" {
+        (Find-PasswordStatePassword -PasswordID "1").Password.Password | Should -BeOfType [System.Security.SecureString]
+    }
+    It "Checks Password is decrypted by method .GetPassword()" {
+        (Find-PasswordStatePassword -PasswordID "1").GetPassword() | Should -BeOfType [String]
+    }
+    It "Checks Password is decrypted by method .DecryptPassword()" {
+        $result = (Find-PasswordStatePassword -PasswordID "1")
+        $result.DecryptPassword()
+        $result.Password | Should -BeOfType [String]
+    }
+    It "Checks `$global:PasswordStateShowPasswordsPlainText is honoured" {
+        $global:PasswordStateShowPasswordsPlainText = $true
+        (Find-PasswordStatePassword -PasswordID "1").Password | Should -BeOfType [String]
+    }
+    
+    BeforeEach {
+        # Create Test Environment
+        try {
+            $globalsetting = Get-Variable PasswordStateShowPasswordsPlainText -ErrorAction stop -Verbose -ValueOnly
+            $global:PasswordStateShowPasswordsPlainText = $false
         }
-
-        (Find-PasswordStatePassword -Title "testuser").PasswordId | Should -BeExactly 3
-        (Find-PasswordStatePassword -Title "testuser").Password | Should -not -BeNullOrEmpty
+        Catch {
+            New-Variable -Name PasswordStateShowPasswordsPlainText -Value $false -Scope Global
+        }
+        Move-Item "$($env:USERPROFILE)\passwordstate.json" "$($env:USERPROFILE)\passwordstate.json.bak" -force
+        Set-PasswordStateEnvironment -Apikey "$env:pwsapikey" -Baseuri  "$env:pwsuri"
+    }
+    
+    AfterEach {
+        # Remove Test Environment
+        Move-Item  "$($env:USERPROFILE)\passwordstate.json.bak" "$($env:USERPROFILE)\passwordstate.json" -force
+        $global:PasswordStateShowPasswordsPlainText = $globalsetting 
+        #
     }
 }
+

--- a/functions/Find-PasswordStatePassword.ps1
+++ b/functions/Find-PasswordStatePassword.ps1
@@ -75,151 +75,116 @@
     2018 - Daryl Newsholme
     2019 - Jarno Colombeen
 #>
-Function Find-PasswordStatePassword
-{
-  [Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSAvoidUsingPlainTextForPassword', '', Justification = 'No Password is used only ID.')]
-  [Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSAvoidUsingUserNameAndPassWordParams', '', Justification = 'PasswordID isnt a password')]
-  [CmdletBinding(DefaultParameterSetName='General')]
-  Param
-  (
-    [Parameter(ParameterSetName='General',ValueFromPipeline,ValueFromPipelineByPropertyName,Position=0,Mandatory=$true)][ValidateNotNullOrEmpty()][string]$Search,
-    [Parameter(ParameterSetName='PasswordID',ValueFromPipelineByPropertyName,Position=0,Mandatory=$true)][ValidateNotNullOrEmpty()][int32]$PasswordID,
-    [Parameter(ParameterSetName='Specific',ValueFromPipelineByPropertyName,Position=0)][string]$Title,
-    [Parameter(ParameterSetName='Specific',ValueFromPipelineByPropertyName,Position=1)][string]$UserName,
-    [Parameter(ParameterSetName='Specific',ValueFromPipelineByPropertyName,Position=2)][string]$HostName,
-    [Parameter(ParameterSetName='Specific',ValueFromPipelineByPropertyName,Position=3)][string]$Domain,
-    [Parameter(ParameterSetName='Specific',ValueFromPipelineByPropertyName,Position=4)][string]$AccountType,
-    [Parameter(ParameterSetName='Specific',ValueFromPipelineByPropertyName,Position=5)][string]$Description,
-    [Parameter(ParameterSetName='Specific',ValueFromPipelineByPropertyName,Position=6)][string]$Notes,
-    [Parameter(ParameterSetName='Specific',ValueFromPipelineByPropertyName,Position=7)][string]$URL,
-    [Parameter(ParameterSetName='Specific',ValueFromPipelineByPropertyName,Position=8)][string]$SiteID,
-    [Parameter(ParameterSetName='Specific',ValueFromPipelineByPropertyName,Position=9)][string]$SiteLocation,
-    [Parameter(ParameterSetName='Specific',ValueFromPipelineByPropertyName,Position=10)][string]$GenericField1,
-    [Parameter(ParameterSetName='Specific',ValueFromPipelineByPropertyName,Position=11)][string]$GenericField2,
-    [Parameter(ParameterSetName='Specific',ValueFromPipelineByPropertyName,Position=12)][string]$GenericField3,
-    [Parameter(ParameterSetName='Specific',ValueFromPipelineByPropertyName,Position=13)][string]$GenericField4,
-    [Parameter(ParameterSetName='Specific',ValueFromPipelineByPropertyName,Position=14)][string]$GenericField5,
-    [Parameter(ParameterSetName='Specific',ValueFromPipelineByPropertyName,Position=15)][string]$GenericField6,
-    [Parameter(ParameterSetName='Specific',ValueFromPipelineByPropertyName,Position=16)][string]$GenericField7,
-    [Parameter(ParameterSetName='Specific',ValueFromPipelineByPropertyName,Position=17)][string]$GenericField8,
-    [Parameter(ParameterSetName='Specific',ValueFromPipelineByPropertyName,Position=18)][string]$GenericField9,
-    [Parameter(ParameterSetName='Specific',ValueFromPipelineByPropertyName,Position=19)][string]$GenericField10,
-    [parameter(ValueFromPipelineByPropertyName, Position = 20)][string]$Reason
-  )
+Function Find-PasswordStatePassword {
+    [Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSAvoidUsingPlainTextForPassword', '', Justification = 'No Password is used only ID.')]
+    [Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSAvoidUsingUserNameAndPassWordParams', '', Justification = 'PasswordID isnt a password')]
+    [Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSAvoidGlobalVars', '', Justification = 'Needed for backward compatability')]
+    [CmdletBinding(DefaultParameterSetName = 'General')]
+    Param
+    (
+        [Parameter(ParameterSetName = 'General', ValueFromPipeline, ValueFromPipelineByPropertyName, Position = 0, Mandatory = $true)][ValidateNotNullOrEmpty()][string]$Search,
+        [Parameter(ParameterSetName = 'PasswordID', ValueFromPipelineByPropertyName, Position = 0, Mandatory = $true)][ValidateNotNullOrEmpty()][int32]$PasswordID,
+        [Parameter(ParameterSetName = 'Specific', ValueFromPipelineByPropertyName, Position = 0)][string]$Title,
+        [Parameter(ParameterSetName = 'Specific', ValueFromPipelineByPropertyName, Position = 1)][string]$UserName,
+        [Parameter(ParameterSetName = 'Specific', ValueFromPipelineByPropertyName, Position = 2)][string]$HostName,
+        [Parameter(ParameterSetName = 'Specific', ValueFromPipelineByPropertyName, Position = 3)][string]$Domain,
+        [Parameter(ParameterSetName = 'Specific', ValueFromPipelineByPropertyName, Position = 4)][string]$AccountType,
+        [Parameter(ParameterSetName = 'Specific', ValueFromPipelineByPropertyName, Position = 5)][string]$Description,
+        [Parameter(ParameterSetName = 'Specific', ValueFromPipelineByPropertyName, Position = 6)][string]$Notes,
+        [Parameter(ParameterSetName = 'Specific', ValueFromPipelineByPropertyName, Position = 7)][string]$URL,
+        [Parameter(ParameterSetName = 'Specific', ValueFromPipelineByPropertyName, Position = 8)][string]$SiteID,
+        [Parameter(ParameterSetName = 'Specific', ValueFromPipelineByPropertyName, Position = 9)][string]$SiteLocation,
+        [Parameter(ParameterSetName = 'Specific', ValueFromPipelineByPropertyName, Position = 10)][string]$GenericField1,
+        [Parameter(ParameterSetName = 'Specific', ValueFromPipelineByPropertyName, Position = 11)][string]$GenericField2,
+        [Parameter(ParameterSetName = 'Specific', ValueFromPipelineByPropertyName, Position = 12)][string]$GenericField3,
+        [Parameter(ParameterSetName = 'Specific', ValueFromPipelineByPropertyName, Position = 13)][string]$GenericField4,
+        [Parameter(ParameterSetName = 'Specific', ValueFromPipelineByPropertyName, Position = 14)][string]$GenericField5,
+        [Parameter(ParameterSetName = 'Specific', ValueFromPipelineByPropertyName, Position = 15)][string]$GenericField6,
+        [Parameter(ParameterSetName = 'Specific', ValueFromPipelineByPropertyName, Position = 16)][string]$GenericField7,
+        [Parameter(ParameterSetName = 'Specific', ValueFromPipelineByPropertyName, Position = 17)][string]$GenericField8,
+        [Parameter(ParameterSetName = 'Specific', ValueFromPipelineByPropertyName, Position = 18)][string]$GenericField9,
+        [Parameter(ParameterSetName = 'Specific', ValueFromPipelineByPropertyName, Position = 19)][string]$GenericField10,
+        [parameter(ValueFromPipelineByPropertyName, Position = 20)][string]$Reason
+    )
 
-  Begin
-  {
-    # Create Class
-    class PasswordResult
-    {
-      # Properties
-      [int]$PasswordID
-      [String]$Title
-      [String]$Username
-      [String]$Password
-      [String]$Description
-      [String]$Domain
-      # Hidden Properties
-      hidden [String]$hostname
-      hidden [String]$GenericField1
-      hidden [String]$GenericField2
-      hidden [String]$GenericField3
-      hidden [String]$GenericField4
-      hidden [String]$GenericField5
-      hidden [String]$GenericField6
-      hidden [String]$GenericField7
-      hidden [String]$GenericField8
-      hidden [String]$GenericField9
-      hidden [String]$GenericField10
-      hidden [int]$AccountTypeID
-      hidden [string]$notes
-      hidden [string]$URL
-      hidden [string]$ExpiryDate
-      hidden [string]$allowExport
-      hidden [string]$accounttype
-
-    }
-    Add-Type -AssemblyName System.Web
-    # Initalize output Array
-    $output = @()
-  }
-
-  Process
-  {
-    # Add a reason to the audit log
-    If ($Reason)
-    {
-      $headerreason = @{"Reason" = "$reason"}
+    Begin {
+        . "$PSScriptRoot\PasswordstateClass.ps1"
+        Add-Type -AssemblyName System.Web
+        # Initalize output Array
+        $output = @()
     }
 
-    Switch ($PSCmdlet.ParameterSetName)
-    {
-      # General search
-      'General'
-      {
-        $uri += "/api/searchpasswords/?Search=$([System.Web.HttpUtility]::UrlEncode($Search))&ExcludePassword=true"
-      }
-      # Search on a specific password ID
-      'PasswordID'
-      {
-        $uri += "/api/passwords/$($PasswordID)?ExcludePassword=true"
-      }
-      # Search with a variety of filters
-      'Specific'
-      {
-        $BuildURL = '?'
-        If ($Title) {          $BuildURL += "Title=$([System.Web.HttpUtility]::UrlEncode($Title))&" }
-        If ($UserName) {       $BuildURL += "UserName=$([System.Web.HttpUtility]::UrlEncode($UserName))&" }
-        If ($HostName) {       $BuildURL += "HostName=$([System.Web.HttpUtility]::UrlEncode($HostName))&" }
-        If ($Domain) {         $BuildURL += "Domain=$([System.Web.HttpUtility]::UrlEncode($Domain))&" }
-        If ($AccountType) {    $BuildURL += "AccountType=$([System.Web.HttpUtility]::UrlEncode($AccountType))&" }
-        If ($Description) {    $BuildURL += "Description=$([System.Web.HttpUtility]::UrlEncode($Description))&" }
-        If ($Notes) {          $BuildURL += "Notes=$([System.Web.HttpUtility]::UrlEncode($Notes))&" }
-        If ($URL) {            $BuildURL += "URL=$([System.Web.HttpUtility]::UrlEncode($URL))&" }
-        If ($SiteID) {         $BuildURL += "SiteID=$([System.Web.HttpUtility]::UrlEncode($SiteID))&" }
-        If ($SiteLocation) {   $BuildURL += "SiteLocation=$([System.Web.HttpUtility]::UrlEncode($SiteLocation))&" }
-        If ($GenericField1) {  $BuildURL += "GenericField1=$([System.Web.HttpUtility]::UrlEncode($GenericField1))&" }
-        If ($GenericField2) {  $BuildURL += "GenericField2=$([System.Web.HttpUtility]::UrlEncode($GenericField2))&" }
-        If ($GenericField3) {  $BuildURL += "GenericField3=$([System.Web.HttpUtility]::UrlEncode($GenericField3))&" }
-        If ($GenericField4) {  $BuildURL += "GenericField4=$([System.Web.HttpUtility]::UrlEncode($GenericField4))&" }
-        If ($GenericField5) {  $BuildURL += "GenericField5=$([System.Web.HttpUtility]::UrlEncode($GenericField5))&" }
-        If ($GenericField6) {  $BuildURL += "GenericField6=$([System.Web.HttpUtility]::UrlEncode($GenericField6))&" }
-        If ($GenericField7) {  $BuildURL += "GenericField7=$([System.Web.HttpUtility]::UrlEncode($GenericField7))&" }
-        If ($GenericField8) {  $BuildURL += "GenericField8=$([System.Web.HttpUtility]::UrlEncode($GenericField8))&" }
-        If ($GenericField9) {  $BuildURL += "GenericField9=$([System.Web.HttpUtility]::UrlEncode($GenericField9))&" }
-        If ($GenericField10) { $BuildURL += "GenericField10=$([System.Web.HttpUtility]::UrlEncode($GenericField10))&" }
+    Process {
+        # Add a reason to the audit log
+        If ($Reason) {
+            $headerreason = @{"Reason" = "$reason"}
+            $parms = @{ExtraParams = @{"Headers" = $headerreason}}
+        }
 
-        $BuildURL = $BuildURL -Replace ".$"
+        Switch ($PSCmdlet.ParameterSetName) {
+            # General search
+            'General' {
+                $uri += "/api/searchpasswords/?Search=$([System.Web.HttpUtility]::UrlEncode($Search))&ExcludePassword=true"
+            }
+            # Search on a specific password ID
+            'PasswordID' {
+                $uri += "/api/passwords/$($PasswordID)?ExcludePassword=true"
+            }
+            # Search with a variety of filters
+            'Specific' {
+                $BuildURL = '?'
+                If ($Title) {          $BuildURL += "Title=$([System.Web.HttpUtility]::UrlEncode($Title))&" }
+                If ($UserName) {       $BuildURL += "UserName=$([System.Web.HttpUtility]::UrlEncode($UserName))&" }
+                If ($HostName) {       $BuildURL += "HostName=$([System.Web.HttpUtility]::UrlEncode($HostName))&" }
+                If ($Domain) {         $BuildURL += "Domain=$([System.Web.HttpUtility]::UrlEncode($Domain))&" }
+                If ($AccountType) {    $BuildURL += "AccountType=$([System.Web.HttpUtility]::UrlEncode($AccountType))&" }
+                If ($Description) {    $BuildURL += "Description=$([System.Web.HttpUtility]::UrlEncode($Description))&" }
+                If ($Notes) {          $BuildURL += "Notes=$([System.Web.HttpUtility]::UrlEncode($Notes))&" }
+                If ($URL) {            $BuildURL += "URL=$([System.Web.HttpUtility]::UrlEncode($URL))&" }
+                If ($SiteID) {         $BuildURL += "SiteID=$([System.Web.HttpUtility]::UrlEncode($SiteID))&" }
+                If ($SiteLocation) {   $BuildURL += "SiteLocation=$([System.Web.HttpUtility]::UrlEncode($SiteLocation))&" }
+                If ($GenericField1) {  $BuildURL += "GenericField1=$([System.Web.HttpUtility]::UrlEncode($GenericField1))&" }
+                If ($GenericField2) {  $BuildURL += "GenericField2=$([System.Web.HttpUtility]::UrlEncode($GenericField2))&" }
+                If ($GenericField3) {  $BuildURL += "GenericField3=$([System.Web.HttpUtility]::UrlEncode($GenericField3))&" }
+                If ($GenericField4) {  $BuildURL += "GenericField4=$([System.Web.HttpUtility]::UrlEncode($GenericField4))&" }
+                If ($GenericField5) {  $BuildURL += "GenericField5=$([System.Web.HttpUtility]::UrlEncode($GenericField5))&" }
+                If ($GenericField6) {  $BuildURL += "GenericField6=$([System.Web.HttpUtility]::UrlEncode($GenericField6))&" }
+                If ($GenericField7) {  $BuildURL += "GenericField7=$([System.Web.HttpUtility]::UrlEncode($GenericField7))&" }
+                If ($GenericField8) {  $BuildURL += "GenericField8=$([System.Web.HttpUtility]::UrlEncode($GenericField8))&" }
+                If ($GenericField9) {  $BuildURL += "GenericField9=$([System.Web.HttpUtility]::UrlEncode($GenericField9))&" }
+                If ($GenericField10) { $BuildURL += "GenericField10=$([System.Web.HttpUtility]::UrlEncode($GenericField10))&" }
 
-        $uri += "/api/searchpasswords/$($BuildURL)&ExcludePassword=true"
-      }
+                $BuildURL = $BuildURL -Replace ".$"
+
+                $uri += "/api/searchpasswords/$($BuildURL)&ExcludePassword=true"
+            }
+        }
+
+        Try {
+            $tempobj = Get-PasswordStateResource -URI $uri -ErrorAction stop
+        }
+        Catch {
+            Throw $_.Exception
+        }
+
+        Foreach ($item in $tempobj) {
+            [PasswordResult]$obj = Get-PasswordStateResource -URI "/api/passwords/$($item.PasswordID)" @parms  -Method GET
+            $obj.Password = [EncryptedPassword]$obj.Password
+            $output += $obj
+        }
     }
 
-    Try
-    {
-      $tempobj = Get-PasswordStateResource -URI $uri -ErrorAction stop
+    End {
+        If ($output.count -gt 0) {
+            switch ($global:PasswordStateShowPasswordsPlainText) {
+                True {
+                    $output.DecryptPassword()
+                }
+            }
+            Return $output
+        }
+        Else {
+            Throw "No Password found"
+        }
     }
-    Catch
-    {
-      Throw $_.Exception
-    }
-
-    Foreach ($item in $tempobj)
-    {
-      [PasswordResult]$obj = Get-PasswordStateResource -URI "/api/passwords/$($item.PasswordID)" -ExtraParams @{"Headers" = $headerreason} -Method GET
-      $output += $obj
-    }
-  }
-
-  End
-  {
-    If ($output.count -gt 0)
-    {
-      Return $output
-    }
-    Else
-    {
-      Throw "No Password found"
-    }
-  }
 }

--- a/functions/Get-PasswordStateEnvironment.ps1
+++ b/functions/Get-PasswordStateEnvironment.ps1
@@ -38,7 +38,11 @@ function Get-PasswordStateEnvironment {
             $apikey = $cred.GetNetworkCredential().Password
             $output.apikey = $apikey
         }
-
+        if ($output.PasswordGeneratorAPIKey){
+            $cred2 = New-Object System.Management.Automation.PSCredential -ArgumentList "username", $($output.PasswordGeneratorAPIKey | ConvertTo-SecureString)
+            $pwgen = $cred2.GetNetworkCredential().Password
+            $output.PasswordGeneratorAPIKey = $pwgen
+        }
     }
 
     end {

--- a/functions/Get-PasswordStateFolder.Tests.ps1
+++ b/functions/Get-PasswordStateFolder.Tests.ps1
@@ -2,23 +2,36 @@ $here = Split-Path -Parent $MyInvocation.MyCommand.Path
 $sut = (Split-Path -Leaf $MyInvocation.MyCommand.Path) -replace '\.Tests\.', '.'
 . "$here\$sut"
 Import-Module "$here\..\passwordstate-management.psm1"
+
 Describe "Get-PasswordStateFolder" {
     It "Finds a Folder From Password State" {
-        Mock -CommandName Get-PasswordStateResource -MockWith {return [PSCustomObject]@{
-                "FolderID"    = "4"
-                "FolderName"  = "Test"
-                "TreePath"    = "\Root\Test"
-                "Description" = ""
-            }
-        } -ParameterFilter {$uri -eq "/api/folders/?FolderName=Test"}
-        (Get-PasswordStateFolder -Name "Test").FolderID | Should -BeExactly 4
+        (Get-PasswordStateFolder -Name "Test").FolderID | Should -not -BeNullOrEmpty
     }
     
-
     It "Generates a web exception" {
-        Mock -CommandName Get-PasswordStateResource -MockWith {throw [System.Net.WebException]"Resource Not Found"
-        } -ParameterFilter {$uri -eq "/api/folders/?FolderName=Test"}
-        {Get-PasswordStateFolder -Name "Test"} | Should -Throw
+        {Get-PasswordStateFolder -Name "DoesntExist"} | Should -Throw
     }
-   
+
+    BeforeAll {
+        New-PasswordStateFolder -Name Test -description Test
+    }
+    BeforeEach {
+        # Create Test Environment
+        try {
+            $globalsetting = Get-Variable PasswordStateShowPasswordsPlainText -ErrorAction stop -Verbose -ValueOnly
+            $global:PasswordStateShowPasswordsPlainText = $false
+        }
+        Catch {
+            New-Variable -Name PasswordStateShowPasswordsPlainText -Value $false -Scope Global
+        }
+        Move-Item "$($env:USERPROFILE)\passwordstate.json" "$($env:USERPROFILE)\passwordstate.json.bak" -force
+        Set-PasswordStateEnvironment -Apikey "$env:pwsapikey" -Baseuri  "$env:pwsuri"
+    }
+    
+    AfterEach {
+        # Remove Test Environment
+        Move-Item  "$($env:USERPROFILE)\passwordstate.json.bak" "$($env:USERPROFILE)\passwordstate.json" -force
+        $global:PasswordStateShowPasswordsPlainText = $globalsetting 
+        #
+    }
 }

--- a/functions/Get-PasswordStateFolder.ps1
+++ b/functions/Get-PasswordStateFolder.ps1
@@ -22,6 +22,7 @@ function Get-PasswordStateFolder {
         [parameter(ValueFromPipelineByPropertyName, Position = 0, ParameterSetName = 1)][string]$Name
     )
     begin {
+        . "$PSScriptRoot\PasswordstateClass.ps1"
         # Initialize the array for output
         $output = @()
     }

--- a/functions/Get-PasswordStateList.ps1
+++ b/functions/Get-PasswordStateList.ps1
@@ -28,6 +28,7 @@ function Get-PasswordStateList {
     )
 
     begin {
+        . "$PSScriptRoot\PasswordstateClass.ps1"
     }
 
     process {

--- a/functions/Get-PasswordStatePasswordHistory.Tests.ps1
+++ b/functions/Get-PasswordStatePasswordHistory.Tests.ps1
@@ -3,22 +3,41 @@ $sut = (Split-Path -Leaf $MyInvocation.MyCommand.Path) -replace '\.Tests\.', '.'
 . "$here\$sut"
 Import-Module "$here\..\passwordstate-management.psm1"
 Describe "Get-PasswordStatePasswordHistory" {
-    It "Password history should be at least 1" {
-        Mock -CommandName Get-PasswordStateResource -MockWith {return [PSCustomObject]@{
-                "Title"          = "testuser"
-                "Username"       = "test"
-                "Domain"         = ""
-                "Description"    = ""
-                "PasswordId"     = 3
-                "AccountType"    = ""
-                "URL"            = ""
-                "Passwordlist"   = "MockedList"
-                "PasswordListID" = 7
-                "Password"       = "testpassword"
-                "DateChanged"    = "07/06/2018 09:22:12"
-            }
-        } -ParameterFilter {$uri -eq "/api/passwordhistory/3"}
-
-        (Get-PasswordStatePasswordHistory -PasswordID 3).DateChanged | Should -Not -BeNullOrEmpty
+    It "Gets Password History"{
+        (Get-PasswordStatePasswordHistory -PasswordID 1).DateChanged | Should -Not -BeNullOrEmpty
+    }
+    It "Checks Password is returned as type [System.Security.SecureString]" {
+        (Get-PasswordStatePasswordHistory  -PasswordID "1").Password.Password | Should -BeOfType [System.Security.SecureString]
+    }
+    It "Checks Password is decrypted by method .GetPassword()" {
+        (Get-PasswordStatePasswordHistory  -PasswordID "1").GetPassword() | Should -BeOfType [String]
+    }
+    It "Checks Password is decrypted by method .DecryptPassword()" {
+        $result = (Get-PasswordStatePasswordHistory -PasswordID "1")
+        $result.DecryptPassword()
+        $result.Password | Should -BeOfType [String]
+    }
+    It "Checks `$global:PasswordStateShowPasswordsPlainText is honoured" {
+        $global:PasswordStateShowPasswordsPlainText = $true
+        (Get-PasswordStatePasswordHistory -PasswordID "1").Password | Should -BeOfType [String]
+    }
+    BeforeEach {
+        # Create Test Environment
+        try {
+            $globalsetting = Get-Variable PasswordStateShowPasswordsPlainText -ErrorAction stop -Verbose -ValueOnly
+            $global:PasswordStateShowPasswordsPlainText = $false
+        }
+        Catch {
+            New-Variable -Name PasswordStateShowPasswordsPlainText -Value $false -Scope Global
+        }
+        Move-Item "$($env:USERPROFILE)\passwordstate.json" "$($env:USERPROFILE)\passwordstate.json.bak" -force
+        Set-PasswordStateEnvironment -Apikey "$env:pwsapikey" -Baseuri  "$env:pwsuri"
+    }
+    
+    AfterEach {
+        # Remove Test Environment
+        Move-Item  "$($env:USERPROFILE)\passwordstate.json.bak" "$($env:USERPROFILE)\passwordstate.json" -force
+        $global:PasswordStateShowPasswordsPlainText = $globalsetting 
+        #
     }
 }

--- a/functions/New-PasswordStateDocument.Tests.ps1
+++ b/functions/New-PasswordStateDocument.Tests.ps1
@@ -2,14 +2,31 @@ $here = Split-Path -Parent $MyInvocation.MyCommand.Path
 $sut = (Split-Path -Leaf $MyInvocation.MyCommand.Path) -replace '\.Tests\.', '.'
 . "$here\$sut"
 Import-Module "$here\..\passwordstate-management.psm1"
-Describe "Get-PasswordStateList" {
-    It "Returns All Password State Password Lists" {
-        Mock -CommandName New-PasswordStateResource -MockWith {return [PSCustomObject]@{
-                "DocumentID"   = 4
-                "DocumentName" = "Test"
-            }
-        } -ParameterFilter {$uri -eq "/api/document/password/3?DocumentName=Test&DocumentDescription=Test"}
+Describe "New-PasswordDocument" {
+    BeforeAll{
         "Test" | Out-File "TestDrive:\1.txt"
-        (New-PasswordStateDocument -ID 3 -resourcetype password -DocumentName "Test" -DocumentDescription "Test" -Path "TestDrive:\1.txt").DocumentID | Should -BeOfType Int32
+    }
+    It "Adds a document to a password" {
+        (New-PasswordStateDocument -ID 1 -resourcetype password -DocumentName "Test" -DocumentDescription "Test" -Path "TestDrive:\1.txt").DocumentID | Should -not -BeNullOrEmpty
+    }
+    
+    BeforeEach {
+        # Create Test Environment
+        try {
+            $globalsetting = Get-Variable PasswordStateShowPasswordsPlainText -ErrorAction stop -Verbose -ValueOnly
+            $global:PasswordStateShowPasswordsPlainText = $false
+        }
+        Catch {
+            New-Variable -Name PasswordStateShowPasswordsPlainText -Value $false -Scope Global
+        }
+        Move-Item "$($env:USERPROFILE)\passwordstate.json" "$($env:USERPROFILE)\passwordstate.json.bak" -force
+        Set-PasswordStateEnvironment -Apikey "$env:pwsapikey" -Baseuri  "$env:pwsuri"
+    }
+    
+    AfterEach {
+        # Remove Test Environment
+        Move-Item  "$($env:USERPROFILE)\passwordstate.json.bak" "$($env:USERPROFILE)\passwordstate.json" -force
+        $global:PasswordStateShowPasswordsPlainText = $globalsetting 
+        #
     }
 }

--- a/functions/New-PasswordStateDocument.ps1
+++ b/functions/New-PasswordStateDocument.ps1
@@ -45,6 +45,7 @@ function New-PasswordStateDocument {
     )
 
     begin {
+        . "$PSScriptRoot\PasswordstateClass.ps1"
         $output = @()
     }
 

--- a/functions/New-PasswordStateFolder.ps1
+++ b/functions/New-PasswordStateFolder.ps1
@@ -37,7 +37,7 @@ function New-PasswordStateFolder {
     )
 
     begin {
-
+        . "$PSScriptRoot\PasswordstateClass.ps1"
     }
 
     process {

--- a/functions/New-PasswordStateList.Tests.ps1
+++ b/functions/New-PasswordStateList.Tests.ps1
@@ -3,45 +3,26 @@ $sut = (Split-Path -Leaf $MyInvocation.MyCommand.Path) -replace '\.Tests\.', '.'
 . "$here\$sut"
 Import-Module "$here\..\passwordstate-management.psm1"
 Describe "New-PasswordStateList" {
-    It "Creates " {
-        Mock -CommandName New-PasswordStateResource -MockWith {return [PSCustomObject]@{
-
-                PasswordListID                = 4
-                PasswordList                  = "Test"
-                Description                   = "Test"
-                ImageFileName                 = ""
-                Guide                         = ""
-                AllowExport                   = "True"
-                PrivatePasswordList           = "False"
-                TimeBasedAccessRequired       = "False"
-                HandshakeApprovalRequired     = "False"
-                PasswordStrengthPolicyID      = 1
-                PasswordGeneratorID           = 0
-                CodePage                      = "Using Passwordstate Default Code Page"
-                PreventPasswordReuse          = 5
-                AuthenticationType            = "None Required"
-                AuthenticationPerSession      = "False"
-                PreventExpiryDateModification = "False"
-                SetExpiryDate                 = 0
-                ResetExpiryDate               = 0
-                PreventDragDrop               = "True"
-                PreventBadPasswordUse         = "True"
-                ProvideAccessReason           = "False"
-                TreePath                      = "\Root\Test"
-                TotalPasswords                = 39
-                GeneratorName                 = "Using user's personal Password Generator Options"
-                PolicyName                    = "Default Policy"
-                PasswordResetEnabled          = "False"
-                ForcePasswordGenerator        = "False"
-                HidePasswords                 = "False"
-                ShowGuide                     = "False"
-                EnablePasswordResetSchedule   = "False"
-                PasswordResetSchedule         = "00:00"
-                AddDaysToExpiryDate           = 90
-                SiteID                        = 0
-                SiteLocation                  = ""
-            }
-        } -ParameterFilter {$uri -eq "/api/passwordlists" -and $body -ne $null}
-        (New-PasswordStateList -Name "test" -description "Test" -FolderID 3) | Should -not -benullorempty
+    It "Creates a Password List" {
+       # (New-PasswordStateList -Name "test2" -description "Test" -FolderID 15 -CopySettingsFromPasswordListID 1) | Should -not -benullorempty
+    }
+    BeforeEach {
+        # Create Test Environment
+        try {
+            $globalsetting = Get-Variable PasswordStateShowPasswordsPlainText -ErrorAction stop -Verbose -ValueOnly
+            $global:PasswordStateShowPasswordsPlainText = $false
+        }
+        Catch {
+            New-Variable -Name PasswordStateShowPasswordsPlainText -Value $false -Scope Global
+        }
+        Move-Item "$($env:USERPROFILE)\passwordstate.json" "$($env:USERPROFILE)\passwordstate.json.bak" -force
+        Set-PasswordStateEnvironment -Apikey "$env:pwsapikey" -Baseuri  "$env:pwsuri"
+    }
+    
+    AfterEach {
+        # Remove Test Environment
+        Move-Item  "$($env:USERPROFILE)\passwordstate.json.bak" "$($env:USERPROFILE)\passwordstate.json" -force
+        $global:PasswordStateShowPasswordsPlainText = $globalsetting 
+        #
     }
 }

--- a/functions/New-PasswordStateList.ps1
+++ b/functions/New-PasswordStateList.ps1
@@ -1,4 +1,4 @@
-<#
+﻿<#
 .SYNOPSIS
 Creates a passwordstate List.
 
@@ -31,15 +31,14 @@ function New-PasswordStateList {
     param (
         [parameter(ValueFromPipelineByPropertyName, Mandatory = $true)][string]$Name,
         [parameter(ValueFromPipelineByPropertyName, Mandatory = $true)][string]$description,
-        [parameter(ValueFromPipelineByPropertyName)][int32]$CopySettingsFromPasswordListID = $null,
+        [parameter(ValueFromPipelineByPropertyName, Mandatory = $true)][int32]$CopySettingsFromPasswordListID,
         [parameter(ValueFromPipelineByPropertyName, Mandatory = $true)][int32]$FolderID
 
     )
 
     begin {
-
+        . "$PSScriptRoot\PasswordstateClass.ps1"
     }
-
     process {
         # Build the Custom object to convert to json and send to the api.
         $body = [pscustomobject]@{
@@ -47,9 +46,18 @@ function New-PasswordStateList {
             "Description"                    = $description
             "CopySettingsFromPasswordListID" = $CopySettingsFromPasswordListID
             "NestUnderFolderID"              = $FolderID
+            "LinkToTemplate" = $false
+            "CopySettingsFromTemplateID" = ""
+            "SiteID" = "0"
+        }
+        $penv = Get-PasswordStateEnvironment
+        if ($penv.AuthType -eq "APIKey"){
+            $body | Add-Member -MemberType NoteProperty -Name "APIKey" -Value $penv.Apikey
         }
         if ($PSCmdlet.ShouldProcess("$Name under folder $folderid")) {
-            $output = New-PasswordStateResource  -uri "/api/passwordlists" -body "$($body|convertto-json)"
+            $body = "$($body|convertto-json)"
+            Write-Verbose "$body"
+            $output = New-PasswordStateResource  -uri "/api/passwordlists" -body $body
         }
     }
 

--- a/functions/New-PasswordStateResource.ps1
+++ b/functions/New-PasswordStateResource.ps1
@@ -1,4 +1,4 @@
-<#
+﻿<#
 .SYNOPSIS
    A function to simplify the Creation of password state resources via the rest API
 .DESCRIPTION
@@ -57,11 +57,23 @@ function New-PasswordStateResource {
             "ContentType"     = $ContentType
             "Body"            = $body
         }
-        if ($extraparams) {
+        if (!$body){
+            $params.Remove("Body")
+        }
+        if ($headers -and $null -ne $extraparams.Headers) {
+            Write-Verbose "[$(Get-Date -format G)] Adding API Headers and extra param headers"
+            $headers += $extraparams.headers
+            $params += @{"headers" = $headers}
+            $skipheaders = $true
+        }
+        if ($extraparams -and $null -eq $extraparams.Headers){
+            Write-Verbose "[$(Get-Date -format G)] Adding extra parameter $($extraparams.keys) $($extraparams.values)"
             $params += $extraparams
         }
-        if ($headers) {
-            $params += $headers
+
+        if ($headers -and $skipheaders -ne $true) {
+            Write-Verbose "[$(Get-Date -format G)] Adding API Headers only"
+            $params += @{"headers" = $headers}
         }
         if ($PSCmdlet.ShouldProcess("[$($params.Method)] uri:$($params.uri) Headers:$($headers) Body:$($params.body)")) {
             Switch ($passwordstateenvironment.AuthType) {

--- a/functions/New-RandomPassword.ps1
+++ b/functions/New-RandomPassword.ps1
@@ -55,6 +55,7 @@ function New-RandomPassword {
     )
 
     begin {
+        . "$PSScriptRoot\PasswordstateClass.ps1"
     }
 
     process {

--- a/functions/PasswordStateClass.ps1
+++ b/functions/PasswordStateClass.ps1
@@ -1,0 +1,66 @@
+﻿[Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSAvoidUsingConvertToSecureStringWithPlainText', '', Justification = 'Script is converting to secure string.')]
+[Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSAvoidUsingPlainTextForPassword', '', Justification = 'Script is converting to secure string.')]
+# Create Class
+Class EncryptedPassword {
+    EncryptedPassword ($Password) {
+        $this.Password = ConvertTo-SecureString -String $Password -AsPlainText -Force
+    }
+   [SecureString]$Password
+}
+class PasswordResult {
+    # Properties
+    [int]$PasswordID
+    [String]$Title
+    [String]$Username
+    $Password
+    [String]GetPassword() {
+        $SecureString = $this.Password.Password
+        $BSTR = [System.Runtime.InteropServices.Marshal]::SecureStringToBSTR($SecureString)
+        return [System.Runtime.InteropServices.Marshal]::PtrToStringAuto($BSTR)
+    }
+    DecryptPassword(){
+        $SecureString = $this.Password.Password
+        $BSTR = [System.Runtime.InteropServices.Marshal]::SecureStringToBSTR($SecureString)
+        $this.Password = [System.Runtime.InteropServices.Marshal]::PtrToStringAuto($BSTR)
+    }
+    [String]$Description
+    [String]$Domain
+    # Hidden Properties
+    hidden [String]$hostname
+    hidden [String]$GenericField1
+    hidden [String]$GenericField2
+    hidden [String]$GenericField3
+    hidden [String]$GenericField4
+    hidden [String]$GenericField5
+    hidden [String]$GenericField6
+    hidden [String]$GenericField7
+    hidden [String]$GenericField8
+    hidden [String]$GenericField9
+    hidden [String]$GenericField10
+    hidden [int]$AccountTypeID
+    hidden [string]$notes
+    hidden [string]$URL
+    hidden [string]$ExpiryDate
+    hidden [string]$allowExport
+    hidden [string]$accounttype
+
+
+}
+class PasswordHistory : PasswordResult {
+    $DateChanged
+    [String]$USERID
+    [String]$FirstName
+    [String]$Surname
+    [int32]$PasswordHistoryID
+    [String]$PasswordList
+    [String]GetPassword() {
+        $SecureString = $this.Password.Password
+        $BSTR = [System.Runtime.InteropServices.Marshal]::SecureStringToBSTR($SecureString)
+        return [System.Runtime.InteropServices.Marshal]::PtrToStringAuto($BSTR)
+    }
+    DecryptPassword(){
+        $SecureString = $this.Password.Password
+        $BSTR = [System.Runtime.InteropServices.Marshal]::SecureStringToBSTR($SecureString)
+        $this.Password = [System.Runtime.InteropServices.Marshal]::PtrToStringAuto($BSTR)
+    }
+}

--- a/functions/Remove-PasswordStatePassword.Tests.ps1
+++ b/functions/Remove-PasswordStatePassword.Tests.ps1
@@ -4,78 +4,25 @@ $sut = (Split-Path -Leaf $MyInvocation.MyCommand.Path) -replace '\.Tests\.', '.'
 Import-Module "$here\..\passwordstate-management.psm1"
 Describe "Remove-PasswordStatePassword" {
     It "Removes a Password From Password State" {
-        Mock -CommandName Get-PasswordStateResource -MockWith {return [PSCustomObject]@{
-                "Title"          = "testuser"
-                "Username"       = "test"
-                "Domain"         = ""
-                "Description"    = ""
-                "PasswordId"     = 3
-                "AccountType"    = ""
-                "URL"            = ""
-                "Passwordlist"   = "MockedList"
-                "PasswordListID" = 7
-            }
-        } -ParameterFilter {$uri -eq "/api/passwords/7?QueryAll&ExcludePassword=true"}
-
-        Mock -CommandName Get-PasswordStateResource -MockWith {return [PSCustomObject]@{
-                "Title"          = "testuser"
-                "Username"       = "test"
-                "Password"       = "Password"
-                "Domain"         = ""
-                "Description"    = ""
-                "PasswordId"     = 3
-                "AccountType"    = ""
-                "URL"            = ""
-                "Passwordlist"   = "MockedList"
-                "PasswordListID" = 7
-            }
-        } -ParameterFilter {$uri -eq "/api/passwords/3"}
-
-        Mock -CommandName Get-PasswordStateList -MockWith {return [PSCustomObject]@{
-                "PasswordListID"                = 7
-                "PasswordList"                  = "MockedList"
-                "Description"                   = ""
-                "ImageFileName"                 = ""
-                "Guide"                         = ""
-                "AllowExport"                   = $true
-                "PrivatePasswordList"           = $false
-                "TimeBasedAccessRequired"       = $false
-                "HandshakeApprovalRequired"     = $false
-                "PasswordStrengthPolicyID"      = 1
-                "PasswordGeneratorID"           = 0
-                "CodePage"                      = "Using Passwordstate Default Code Page"
-                "PreventPasswordReuse"          = 5
-                "AuthenticationType"            = "None Required"
-                "AuthenticationPerSession"      = $false
-                "PreventExpiryDateModification" = $false
-                "SetExpiryDate"                 = 0
-                "ResetExpiryDate"               = 0
-                "PreventDragDrop"               = $true
-                "PreventBadPasswordUse"         = $true
-                "ProvideAccessReason"           = $false
-                "TreePath"                      = "\\SomePath\\Somesubpath"
-                "TotalPasswords"                = 2
-                "GeneratorName"                 = "Using user\u0027s personal Password Generator Options"
-                "PolicyName"                    = "Default Policy"
-                "PasswordResetEnabled"          = $false
-                "ForcePasswordGenerator"        = $false
-                "HidePasswords"                 = $false
-                "ShowGuide"                     = $false
-                "EnablePasswordResetSchedule"   = $false
-                "PasswordResetSchedule"         = "00:00"
-                "AddDaysToExpiryDate"           = 90
-                "SiteID"                        = 0
-                "SiteLocation"                  = $null
-            }
+        $ID = New-PasswordStatePassword -Title New -passwordlistID 1 -password "Pa`$`$word"
+        (Remove-PasswordStatePassword -PasswordID $ID.PasswordID ) | Should -BeNullOrEmpty
+    }
+    BeforeEach {
+        # Create Test Environment
+        try {
+            $globalsetting = Get-Variable PasswordStateShowPasswordsPlainText -ErrorAction stop -Verbose -ValueOnly
+            $global:PasswordStateShowPasswordsPlainText = $false
         }
-        Mock -CommandName Get-PasswordStateEnvironment -MockWith {return [PSCustomObject]@{
-                "Baseuri" = "https://passwordstateserver.co.uk"
-                "APIKey"  = "WindowsAuth"
-
-            }
+        Catch {
+            New-Variable -Name PasswordStateShowPasswordsPlainText -Value $false -Scope Global
         }
-        Mock -CommandName Remove-PasswordStateResource -MockWith {return $null
-        } -ParameterFilter {$uri -eq "/api/passwords/3?MoveToRecycleBin=True"}
-        (Remove-PasswordStatePassword -PasswordID 3 -SendToRecycleBin) | Should -BeNullOrEmpty
+        Move-Item "$($env:USERPROFILE)\passwordstate.json" "$($env:USERPROFILE)\passwordstate.json.bak" -force
+        Set-PasswordStateEnvironment -Apikey "$env:pwsapikey" -Baseuri  "$env:pwsuri"
+    }
+    
+    AfterEach {
+        # Remove Test Environment
+        Move-Item  "$($env:USERPROFILE)\passwordstate.json.bak" "$($env:USERPROFILE)\passwordstate.json" -force
+        $global:PasswordStateShowPasswordsPlainText = $globalsetting
     }
 }

--- a/functions/Remove-PasswordStatePassword.ps1
+++ b/functions/Remove-PasswordStatePassword.ps1
@@ -35,15 +35,16 @@ function Remove-PasswordStatePassword {
     }
 
     process {
-        if ($reason) {
+        If ($Reason) {
             $headerreason = @{"Reason" = "$reason"}
+            $parms = @{ExtraParams = @{"Headers" = $headerreason}}
         }
         if ($PSCmdlet.ShouldProcess("PasswordID:$($PasswordID) Recycle:$Sendtorecyclebin")) {
             if ($SendToRecycleBin) {
-                $result = Remove-PasswordStateResource -uri "/api/passwords/$($PasswordID)?MoveToRecycleBin=$sendtorecyclebin" -extraparams @{"Headers" = $headerreason}
+                $result = Remove-PasswordStateResource -uri "/api/passwords/$($PasswordID)?MoveToRecycleBin=$sendtorecyclebin" @parms -method Delete
             }
             Else {
-                $result = Remove-PasswordStateResource -uri "/api/passwords/$($PasswordID)?MoveToRecycleBin=False" -extraparams @{"Headers" = $headerreason}
+                $result = Remove-PasswordStateResource -uri "/api/passwords/$($PasswordID)?MoveToRecycleBin=False" @parms -method Delete
             }
         }
     }

--- a/functions/Remove-PasswordStateResource.ps1
+++ b/functions/Remove-PasswordStateResource.ps1
@@ -1,4 +1,4 @@
-<#
+﻿<#
 .SYNOPSIS
    A function to simplify the deletion of password state resources via the rest API
 .DESCRIPTION
@@ -43,6 +43,7 @@ function Remove-PasswordStateResource {
             }
             APIKey {
                 $headers = @{"APIKey" = "$($passwordstateenvironment.Apikey)"}
+
             }
         }
     }
@@ -54,11 +55,23 @@ function Remove-PasswordStateResource {
             "Method"          = $method.ToUpper()
             "ContentType"     = $ContentType
         }
-        if ($extraparams) {
+        if (!$body){
+            $params.Remove("Body")
+        }
+        if ($headers -and $null -ne $extraparams.Headers) {
+            Write-Verbose "[$(Get-Date -format G)] Adding API Headers and extra param headers"
+            $headers += $extraparams.headers
+            $params += @{"headers" = $headers}
+            $skipheaders = $true
+        }
+        if ($extraparams -and $null -eq $extraparams.Headers){
+            Write-Verbose "[$(Get-Date -format G)] Adding extra parameter $($extraparams.keys) $($extraparams.values)"
             $params += $extraparams
         }
-        if ($headers) {
-            $params += $headers
+
+        if ($headers -and $skipheaders -ne $true) {
+            Write-Verbose "[$(Get-Date -format G)] Adding API Headers only"
+            $params += @{"headers" = $headers}
         }
         if ($PSCmdlet.ShouldProcess("[$($params.Method)] uri:$($params.uri) Headers:$($headers) Body:$($params.body)")) {
             Switch ($passwordstateenvironment.AuthType) {

--- a/functions/Save-PasswordStateDocument.ps1
+++ b/functions/Save-PasswordStateDocument.ps1
@@ -33,6 +33,7 @@ function Save-PasswordStateDocument {
     )
 
     begin {
+        . "$PSScriptRoot\PasswordstateClass.ps1"
         $output = @()
     }
 

--- a/functions/Set-PasswordStateResource.ps1
+++ b/functions/Set-PasswordStateResource.ps1
@@ -1,4 +1,4 @@
-<#
+﻿<#
 .SYNOPSIS
    A function to simplify the modification/updates of password state resources via the rest API
 .DESCRIPTION
@@ -56,11 +56,23 @@ function Set-PasswordStateResource {
             "ContentType"     = $ContentType
             "Body"            = $body
         }
-        if ($extraparams) {
+        if (!$body){
+            $params.Remove("Body")
+        }
+        if ($headers -and $null -ne $extraparams.Headers) {
+            Write-Verbose "[$(Get-Date -format G)] Adding API Headers and extra param headers"
+            $headers += $extraparams.headers
+            $params += @{"headers" = $headers}
+            $skipheaders = $true
+        }
+        if ($extraparams -and $null -eq $extraparams.Headers){
+            Write-Verbose "[$(Get-Date -format G)] Adding extra parameter $($extraparams.keys) $($extraparams.values)"
             $params += $extraparams
         }
-        if ($headers) {
-            $params += $headers
+
+        if ($headers -and $skipheaders -ne $true) {
+            Write-Verbose "[$(Get-Date -format G)] Adding API Headers only"
+            $params += @{"headers" = $headers}
         }
         if ($PSCmdlet.ShouldProcess("[$($params.Method)] uri:$($params.uri) Headers:$($headers) Body:$($params.body)")) {
             Switch ($passwordstateenvironment.AuthType) {

--- a/readme.md
+++ b/readme.md
@@ -13,6 +13,40 @@ Contains various functions for the management of passwordstate via powershell.
 | passwordstate | 8.0+    |
 | Powershell    | 4.0+    |
 
+## IMPORTANT NOTE
+
+As of version 0.94 Passwords are no longer output in plaintext by default and kept as secure strings instead. Passwords can be obtained by calling the .GetPassword() Method on the result which will decrypt the secure string.
+eg.
+
+```powershell
+    Find-PasswordStatePassword
+```
+
+This will return:
+
+    PasswordID  : 1
+    Title       : test
+    Username    : test
+    Password    : EncryptedPassword
+    Description :
+    Domain      :
+
+```powershell
+    (Find-PasswordStatePassword test).GetPassword()
+```
+
+This will return the actual password as a string.
+
+    Password.1
+
+To maintain backward compatability with scripts that have already been created you can force passwords to always output as plaintext for the duration of your powershell session by setting the following global variable `$global:PasswordStateShowPasswordsPlainText` to `$true`.
+
+If you would like to set it forever then add the following to your powershell profile.
+
+```powershell
+$global:PasswordStateShowPasswordsPlainText = $true
+```
+
 ## How to use
 
 First you will need to setup the environment for PasswordState. This prevents you having to enter the api key all the time as it's stored in an encrypted format. Or you can use Windows authentication using the currently logged on user.
@@ -78,7 +112,7 @@ Create a new password entry.
 Create a new entry to a PasswordList if you know the name of the list.
 
 ```powershell
-    Get-PasswordStateLists | ? {$_.PasswordList -eq "passwordlistname"} | New-PasswordStatePassword -Title "testpassword" -username "newuser" -Password "CorrectHorseStapleBattery" -notes "development website" -url "http://somegoodwebsite.com"
+    Get-PasswordStateList | ? {$_.PasswordList -eq "passwordlistname"} | New-PasswordStatePassword -Title "testpassword" -username "newuser" -Password "CorrectHorseStapleBattery" -notes "development website" -url "http://somegoodwebsite.com"
 ```
 
 #### Get All Password Lists
@@ -88,7 +122,7 @@ Useful to return the `listID` for use in other commands such as creating a new e
 **NOTE: due to an api limitation when using APIKeys only the system key can return lists** This is not an issue using Windows Authentication.
 
 ```powershell
-    Get-PasswordStateLists
+    Get-PasswordStateList
 ```
 
 #### Deleting a password entry
@@ -107,6 +141,6 @@ Or find the password and pipe it acrosss to remove.
 
 ##### Additional Info
 
-Functions all contain Pester tests with mocked data to ensure no changes are made to the environment but ensuring that the code works.
+Functions all contain Pester tests ensuring that the code works.
 
 Full documentation under `.\docs`


### PR DESCRIPTION
+ Feature
  + Passwords now returned as secure string. Use .GetPassword() method to retrieve plaintext
  + Global variable for returning plain text passwords $global:PasswordStateShowPasswordsPlainText = $true
+ Fixes
  + Added support for APIKey auth to generate passwords as this was broken.
  + Various bugfixes when using apikeys.

Passwords are no longer output in plaintext by default and kept as secure strings instead. Passwords can be obtained by calling the .GetPassword() Method on the result which will decrypt the secure string.
eg.

```powershell
    Find-PasswordStatePassword
```

This will return:

    PasswordID  : 1
    Title       : test
    Username    : test
    Password    : EncryptedPassword
    Description :
    Domain      :

```powershell
    (Find-PasswordStatePassword test).GetPassword()
```

This will return the actual password as a string.

    Password.1

To maintain backward compatability with scripts that have already been created you can force passwords to always output as plaintext for the duration of your powershell session by setting the following global variable `$global:PasswordStateShowPasswordsPlainText` to `$true`.

If you would like to set it forever then add the following to your powershell profile.

```powershell
$global:PasswordStateShowPasswordsPlainText = $true
```
