### PR TITLE
Fix for failing to cast type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.0.98
+
++ Fix for get-Passwordstatepasswords not correctly casting to secure type.
+
 ## 0.0.97
 
 + Added initial support for linux with fix for kerberos auth on winapi.

--- a/functions/Get-PasswordStatePasswords.ps1
+++ b/functions/Get-PasswordStatePasswords.ps1
@@ -28,10 +28,10 @@ function Get-PasswordStatePasswords {
     }
 
     process {
-        [PasswordResult]$results = Get-PasswordStateResource -uri $("/api/passwords/" + $PasswordlistID + "?QueryAll")
-        Foreach ($result in $results){
+        $results = Get-PasswordStateResource -uri $("/api/passwords/" + $PasswordlistID + "?QueryAll")
+        $output = Foreach ($result in $results){
             $result.Password = [EncryptedPassword]$result.Password
-            $output += $result
+            [PasswordResult]$result
         }
     }
 


### PR DESCRIPTION
Fixes an issue with Get-PasswordstatePassword not casting the password to the [PasswordResult] class type.