### PR TITLE
Change to PasswordResult Type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 1.0.1
+
++ Changed output of default properties for \[PasswordResult\] typed items.
+
 ## 0.0.105
 
 + Allow password generation using PasswordPolicyID's from New-RandomPassword. Thanks [Colombeen](https://github.com/colombeen)

--- a/functions/PasswordStateClass.ps1
+++ b/functions/PasswordStateClass.ps1
@@ -44,24 +44,32 @@ class PasswordResult {
     [String]$Description
     [String]$Domain
     # Hidden Properties
-    hidden [String]$hostname
-    hidden [String]$GenericField1
-    hidden [String]$GenericField2
-    hidden [String]$GenericField3
-    hidden [String]$GenericField4
-    hidden [String]$GenericField5
-    hidden [String]$GenericField6
-    hidden [String]$GenericField7
-    hidden [String]$GenericField8
-    hidden [String]$GenericField9
-    hidden [String]$GenericField10
-    hidden [int]$AccountTypeID
-    hidden [string]$notes
-    hidden [string]$URL
-    hidden [string]$ExpiryDate
-    hidden [string]$allowExport
-    hidden [string]$accounttype
+    [String]$hostname
+    [String]$GenericField1
+    [String]$GenericField2
+    [String]$GenericField3
+    [String]$GenericField4
+    [String]$GenericField5
+    [String]$GenericField6
+    [String]$GenericField7
+    [String]$GenericField8
+    [String]$GenericField9
+    [String]$GenericField10
+    [int]$AccountTypeID
+    [string]$notes
+    [string]$URL
+    [string]$ExpiryDate
+    [string]$allowExport
+    [string]$accounttype
+    # Constructor used to initiate the default property set.
+    PasswordResult() {
+        [string[]]$DefaultProperties = 'PasswordID', 'Title','Username','Password','Description','Domain'
 
+        #Create a propertyset name DefaultDisplayPropertySet, with properties we care about
+    $propertyset = New-Object System.Management.Automation.PSPropertySet DefaultDisplayPropertySet, $DefaultProperties
+    $PSStandardMembers = [System.Management.Automation.PSMemberInfo[]]$propertyset
+    Add-Member -InputObject $this -MemberType MemberSet -Name PSStandardMembers -Value $PSStandardMembers
+    }
 
 }
 class PasswordHistory : PasswordResult {


### PR DESCRIPTION
Display default properties without having the extra properties hidden from the Get-Member cmdlet unless force is specified.