### PR TITLE
Major - PSCredential conversion moved to a method

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 4.0.0
+
++ Removed the function ConvertTo-PScredential and replaced with a method on the Password returned. Use .ToPSCredential() to convert.
+
 ## 3.1.0
 
 + Added new functions for managing hosts within PasswordState Get-PasswordstateHost, New-PassswordStateHost and Remove-PasswordStateHost.Thanks [Colombeen](https://github.com/colombeen)

--- a/functions/New-PasswordStatePassword.ps1
+++ b/functions/New-PasswordStatePassword.ps1
@@ -71,8 +71,8 @@ function New-PasswordStatePassword {
         }
         # Check if hashtable has valid values
         IF($genericfields) {
-            $genericfields.keys | ForEach-Object -process {
-                if(!($($_) -match "GenericField\d" -and $($_ -replace "[^0-9]" , '') -le 10)){
+            $genericfields.keys | ForEach-Object  {
+                if(!($($_) -match "GenericField\d" -and [int]$($_ -replace "[^0-9]" , '') -le 10)){
                     throw "GenericField array is not between boundaries or has invalid key names GenericField[1-10]"
                 }
             }

--- a/functions/PasswordStateClass.ps1
+++ b/functions/PasswordStateClass.ps1
@@ -36,11 +36,21 @@ class PasswordResult {
         }
     }
     DecryptPassword(){
+            $this.Password = $this.GetPassword()
+    }
+    [PSCredential]ToPSCredential(){
         $result = [string]::IsNullOrEmpty($this.Password.Password)
         If ($this.Password.GetType().Name -ne 'String' -and $result -eq $false) {
-            $SecureString = $this.Password.Password
-            $BSTR = [System.Runtime.InteropServices.Marshal]::SecureStringToBSTR($SecureString)
-            $this.Password = [System.Runtime.InteropServices.Marshal]::PtrToStringAuto($BSTR)
+            $output = [pscredential]::new($this.Username,$this.Password.Password)
+            return $output
+        }
+        if ($result -eq $true){
+            return $null
+        }
+        Else {
+            $this.Password = [EncryptedPassword]$this.Password
+            $output = [pscredential]::new($this.Username,$this.Password.Password)
+            return $output
         }
     }
     [String]$Description
@@ -81,28 +91,6 @@ class PasswordHistory : PasswordResult {
     [String]$FirstName
     [String]$Surname
     [int32]$PasswordHistoryID
-    [String]GetPassword() {
-        $result = [string]::IsNullOrEmpty($this.Password.Password)
-        If ($this.Password.GetType().Name -ne 'String' -and $result -eq $false) {
-            $SecureString = $this.Password.Password
-            $BSTR = [System.Runtime.InteropServices.Marshal]::SecureStringToBSTR($SecureString)
-            return [System.Runtime.InteropServices.Marshal]::PtrToStringAuto($BSTR)
-        }
-        if ($result -eq $true){
-            return $null
-        }
-        Else {
-            return $this.Password
-        }
-    }
-    DecryptPassword(){
-        $result = [string]::IsNullOrEmpty($this.Password.Password)
-        If ($this.Password.GetType().Name -ne 'String' -and $result -eq $false) {
-            $SecureString = $this.Password.Password
-            $BSTR = [System.Runtime.InteropServices.Marshal]::SecureStringToBSTR($SecureString)
-            $this.Password = [System.Runtime.InteropServices.Marshal]::PtrToStringAuto($BSTR)
-        }
-    }
     # Constructor used to initiate the default property set.
     PasswordHistory() {
     [string[]]$DefaultProperties = 'PasswordID','PasswordHistoryID','USERID','DateChanged','Title','Username','Password','Description','Domain'

--- a/functions/PasswordStateClass.ps1
+++ b/functions/PasswordStateClass.ps1
@@ -4,14 +4,14 @@
 Class EncryptedPassword {
     EncryptedPassword ($Password) {
         $result = [string]::IsNullOrEmpty($Password)
-        if ($result -eq $false){
+        if ($result -eq $false) {
             $this.Password = ConvertTo-SecureString -String $Password -AsPlainText -Force
         }
         Else {
             $this.Password = $null
         }
     }
-   [SecureString]$Password
+    [SecureString]$Password
 }
 class PasswordResult {
     # Properties
@@ -28,28 +28,28 @@ class PasswordResult {
             $BSTR = [System.Runtime.InteropServices.Marshal]::SecureStringToBSTR($SecureString)
             return [System.Runtime.InteropServices.Marshal]::PtrToStringAuto($BSTR)
         }
-        if ($result -eq $true){
+        if ($result -eq $true) {
             return $null
         }
         Else {
             return $this.Password
         }
     }
-    DecryptPassword(){
-            $this.Password = $this.GetPassword()
+    DecryptPassword() {
+        $this.Password = $this.GetPassword()
     }
-    [PSCredential]ToPSCredential(){
+    [PSCredential]ToPSCredential() {
         $result = [string]::IsNullOrEmpty($this.Password.Password)
         If ($this.Password.GetType().Name -ne 'String' -and $result -eq $false) {
-            $output = [pscredential]::new($this.Username,$this.Password.Password)
+            $output = [pscredential]::new($this.Username, $this.Password.Password)
             return $output
         }
-        if ($result -eq $true){
+        if ($result -eq $true) {
             return $null
         }
         Else {
             $this.Password = [EncryptedPassword]$this.Password
-            $output = [pscredential]::new($this.Username,$this.Password.Password)
+            $output = [pscredential]::new($this.Username, $this.Password.Password)
             return $output
         }
     }
@@ -76,12 +76,12 @@ class PasswordResult {
     [string]$accounttype
     # Constructor used to initiate the default property set.
     PasswordResult() {
-        [string[]]$DefaultProperties = 'PasswordID', 'Title','Username','Password','Description','Domain'
+        [string[]]$DefaultProperties = 'PasswordID', 'Title', 'Username', 'Password', 'Description', 'Domain'
 
         #Create a propertyset name DefaultDisplayPropertySet, with properties we care about
-    $propertyset = New-Object System.Management.Automation.PSPropertySet DefaultDisplayPropertySet, $DefaultProperties
-    $PSStandardMembers = [System.Management.Automation.PSMemberInfo[]]$propertyset
-    Add-Member -InputObject $this -MemberType MemberSet -Name PSStandardMembers -Value $PSStandardMembers
+        $propertyset = New-Object System.Management.Automation.PSPropertySet DefaultDisplayPropertySet, $DefaultProperties
+        $PSStandardMembers = [System.Management.Automation.PSMemberInfo[]]$propertyset
+        Add-Member -InputObject $this -MemberType MemberSet -Name PSStandardMembers -Value $PSStandardMembers
     }
 
 }
@@ -93,11 +93,11 @@ class PasswordHistory : PasswordResult {
     [int32]$PasswordHistoryID
     # Constructor used to initiate the default property set.
     PasswordHistory() {
-    [string[]]$DefaultProperties = 'PasswordID','PasswordHistoryID','USERID','DateChanged','Title','Username','Password','Description','Domain'
+        [string[]]$DefaultProperties = 'PasswordID', 'PasswordHistoryID', 'USERID', 'DateChanged', 'Title', 'Username', 'Password', 'Description', 'Domain'
 
         #Create a propertyset name DefaultDisplayPropertySet, with properties we care about
-    $propertyset = New-Object System.Management.Automation.PSPropertySet DefaultDisplayPropertySet, $DefaultProperties
-    $PSStandardMembers = [System.Management.Automation.PSMemberInfo[]]$propertyset
-    Add-Member -InputObject $this -MemberType MemberSet -Name PSStandardMembers -Value $PSStandardMembers -Force
+        $propertyset = New-Object System.Management.Automation.PSPropertySet DefaultDisplayPropertySet, $DefaultProperties
+        $PSStandardMembers = [System.Management.Automation.PSMemberInfo[]]$propertyset
+        Add-Member -InputObject $this -MemberType MemberSet -Name PSStandardMembers -Value $PSStandardMembers -Force
     }
 }


### PR DESCRIPTION
Moved the functionality to a method on the [PasswordResult] class which allows for converting any returned Password object into a credential including password history results.