### PR TITLE
minor - resolve issue of inadvertantly changing password values

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 ## 4.3.0
 
++ Resolve an issue where when passing a password resource via the pipeline to Update-PasswordStatePassword the password could be inadvently changed to EncryptedPassword, when the intention was only to change another field.
+
+eg:
+
+```powershell
+Get-PasswordStatePassword -PasswordID 1 | Update-PasswordStatePassword -url "https://google.com"
+```
+
+## 4.2.1
+
 + Fix searching for a password with the word api in it being changed to winapi.
 
 ## 4.1.0

--- a/functions/Update-PasswordStatePassword.ps1
+++ b/functions/Update-PasswordStatePassword.ps1
@@ -89,11 +89,8 @@ function Update-PasswordStatePassword {
                 # Replace Result property with that of the bound parameter
                 $notprocess = "reason", "verbose", "erroraction", "debug", "whatif", "confirm"
                 if ($notprocess -notcontains $i) {
-                    if ($i -eq "Password" -and $PSBoundParameters.$($i).Gettype().Name -eq "EncryptedPassword"){
-                        $result.$($i) = $result.GetPassword()
-                    }
-                    Else {
-                        $result.$($i) = $PSBoundParameters.$($i)
+                    if ($i -eq "Password"){
+                        $result.DecryptPassword()
                     }
                 }
             }


### PR DESCRIPTION
Resolve an issue where when passing a password resource via the pipeline to Update-PasswordStatePassword the password could be inadvently changed to EncryptedPassword, when the intention was only to change another field.

fixes #73 