### PR TITLE
Fixing #104

### DIFF
--- a/functions/New-PasswordStateList.ps1
+++ b/functions/New-PasswordStateList.ps1
@@ -107,7 +107,7 @@
         }
         if ($PSCmdlet.ShouldProcess("$Name under folder $folderid")) {
             # Sort the CustomObject and then covert body to json and execute the api query
-            $body = "$($body | Get-PSCustomObject -Sort |ConvertTo-Json)"
+            $body = "$($body |ConvertTo-Json)"
             $output = New-PasswordStateResource -uri "/api/passwordlists" -body $body -Sort:$Sort
         }
     }

--- a/internal/functions/Get-PasswordStateResource.ps1
+++ b/internal/functions/Get-PasswordStateResource.ps1
@@ -101,7 +101,7 @@ function Get-PasswordStateResource {
 
     end {
         if ($result) {
-            return $result | Get-PSCustomObject -Sort:$Sort
+            return $result
         }
     }
 }

--- a/internal/functions/New-PasswordStateResource.ps1
+++ b/internal/functions/New-PasswordStateResource.ps1
@@ -105,7 +105,7 @@ function New-PasswordStateResource {
     end {
         if ($result)
         {
-            return $result | Get-PSCustomObject -Sort:$Sort
+            return $result
         }
         Write-PSFMessage -Level Verbose -Message 'End of New-PasswordStteResource'
     }


### PR DESCRIPTION
Fixing #104 

Removed `Get-PSCustomObject` for now (so, no sort of the output possible for the moment).

Problem: The function only returns the last value of the input object. Needs investigation and better testing.