### PR TITLE
fix for missing timeout

### DIFF
--- a/functions/Get-PasswordStateEnvironment.ps1
+++ b/functions/Get-PasswordStateEnvironment.ps1
@@ -44,6 +44,9 @@
             $pwgen = $cred2.GetNetworkCredential().Password
             $output.PasswordGeneratorAPIKey = $pwgen
         }
+        if ($null -eq $output.TimeoutSeconds){
+            $output | Add-Member -MemberType NoteProperty -Name "TimeoutSeconds" -Value 60
+        }
     }
 
     end {


### PR DESCRIPTION
Adds a default timeout if one wasn't set by set-passwordstateenvironment for backwards compatability.

Fixes #106 