### PR TITLE
Fix issue when profile file already exists before module is imported

### DIFF
--- a/functions/Set-PasswordStateEnvironment.ps1
+++ b/functions/Set-PasswordStateEnvironment.ps1
@@ -45,7 +45,7 @@
         }
         $json = @{
             TimeoutSeconds = 60
-            Baseuri = $Baseuri
+            Baseuri = $Uri -replace '/$',''
             Apikey = $JsonApiKey
             AuthType = $AuthType
         }

--- a/functions/Set-PasswordStateEnvironment.ps1
+++ b/functions/Set-PasswordStateEnvironment.ps1
@@ -47,7 +47,7 @@
             TimeoutSeconds = 60
             Baseuri = $Baseuri
             Apikey = $JsonApiKey
-            "AuthType" = $AuthType
+            AuthType = $AuthType
         }
         if ($SetPlainTextPasswords) {
             if ($PSCmdlet.ShouldProcess('Allow passwords to be returned in plain text')) {

--- a/functions/Set-PasswordStateEnvironment.ps1
+++ b/functions/Set-PasswordStateEnvironment.ps1
@@ -42,15 +42,12 @@
                 ($Apikey | ConvertTo-SecureString -AsPlainText -Force | ConvertFrom-SecureString)
 
             }
-<<<<<<< HEAD
-=======
         }
         $json = @{
             TimeoutSeconds = 60
             Baseuri = $Baseuri
             Apikey = $JsonApiKey
             "AuthType" = $AuthType
->>>>>>> 9b00e0c... Removed pscustomobject
         }
         if ($SetPlainTextPasswords) {
             if ($PSCmdlet.ShouldProcess('Allow passwords to be returned in plain text')) {

--- a/functions/Set-PasswordStateEnvironment.ps1
+++ b/functions/Set-PasswordStateEnvironment.ps1
@@ -30,35 +30,40 @@
 
     process {
         # Build the custom object to be converted to JSON. Set APIKey as WindowsAuth if we are to use windows authentication.
-        $json = [PSCustomObject]@{
-            TimeoutSeconds = 60
-            Baseuri = $Baseuri
-            Apikey = switch ($AuthType) {
-                WindowsIntegrated { "" }
-                WindowsCustom {
-                    [pscustomobject]@{
-                        "username" = $customcredentials.UserName
-                        "Password" = ($customcredentials.Password | ConvertFrom-SecureString)
-                    }
+        $JsonApiKey = switch ($AuthType) {
+            WindowsIntegrated { "" }
+            WindowsCustom {
+                @{
+                    "username" = $customcredentials.UserName
+                    "Password" = ($customcredentials.Password | ConvertFrom-SecureString)
                 }
             }
             APIKey {
                 ($Apikey | ConvertTo-SecureString -AsPlainText -Force | ConvertFrom-SecureString)
 
             }
+<<<<<<< HEAD
+=======
+        }
+        $json = @{
+            TimeoutSeconds = 60
+            Baseuri = $Baseuri
+            Apikey = $JsonApiKey
+            "AuthType" = $AuthType
+>>>>>>> 9b00e0c... Removed pscustomobject
         }
         if ($SetPlainTextPasswords) {
             if ($PSCmdlet.ShouldProcess('Allow passwords to be returned in plain text')) {
-                $json | Add-Member -NotePropertyName 'PasswordsInPlainText' -NotePropertyValue $SetPlainTextPasswords
+                $json['PasswordsInPlainText'] = $SetPlainTextPasswords
             } else {
-                $json | Add-Member -NotePropertyName 'PasswordsInPlainText' -NotePropertyValue $false
+                $json['PasswordsInPlainText'] = $false
             }
         } else {
-            $json | Add-Member -NotePropertyName 'PasswordsInPlainText' -NotePropertyValue $SetPlainTextPasswords
+            $json['PasswordsInPlainText'] = $SetPlainTextPasswords
         }
 
         if ($PasswordGeneratorAPIkey){
-            $json | Add-Member -NotePropertyName 'PasswordGeneratorAPIKey' -NotePropertyValue ($PasswordGeneratorAPIkey | ConvertTo-SecureString -AsPlainText -Force | ConvertFrom-SecureString)
+            $json['PasswordGeneratorAPIKey'] = ($PasswordGeneratorAPIkey | ConvertTo-SecureString -AsPlainText -Force | ConvertFrom-SecureString)
         }
         $json = $json | ConvertTo-Json
     }

--- a/functions/Set-PasswordStateEnvironment.ps1
+++ b/functions/Set-PasswordStateEnvironment.ps1
@@ -45,7 +45,7 @@
         }
         $json = @{
             TimeoutSeconds = 60
-            Baseuri = $Baseuri
+            Baseuri = $Uri -replace '/$',''
             Apikey = $JsonApiKey
             "AuthType" = $AuthType
         }

--- a/functions/Set-PasswordStateEnvironment.ps1
+++ b/functions/Set-PasswordStateEnvironment.ps1
@@ -56,7 +56,7 @@
         if ($SetPlainTextPasswords) {
             if ($PSCmdlet.ShouldProcess('Allow passwords to be returned in plain text')) {
                 $json | Add-Member -NotePropertyName 'PasswordsInPlainText' -NotePropertyValue $SetPlainTextPasswords
-            } else { 
+            } else {
                 $json | Add-Member -NotePropertyName 'PasswordsInPlainText' -NotePropertyValue $false
             }
         } else {

--- a/functions/Set-PasswordStateEnvironment.ps1
+++ b/functions/Set-PasswordStateEnvironment.ps1
@@ -50,7 +50,7 @@
         if ($SetPlainTextPasswords) {
             if ($PSCmdlet.ShouldProcess('Allow passwords to be returned in plain text')) {
                 $json | Add-Member -NotePropertyName 'PasswordsInPlainText' -NotePropertyValue $SetPlainTextPasswords
-            } else { 
+            } else {
                 $json | Add-Member -NotePropertyName 'PasswordsInPlainText' -NotePropertyValue $false
             }
         } else {

--- a/functions/Set-PasswordStateEnvironment.ps1
+++ b/functions/Set-PasswordStateEnvironment.ps1
@@ -30,12 +30,16 @@
 
     process {
         # Build the custom object to be converted to JSON. Set APIKey as WindowsAuth if we are to use windows authentication.
-        $JsonApiKey = switch ($AuthType) {
-            WindowsIntegrated { "" }
-            WindowsCustom {
-                @{
-                    "username" = $customcredentials.UserName
-                    "Password" = ($customcredentials.Password | ConvertFrom-SecureString)
+        $json = [PSCustomObject]@{
+            TimeoutSeconds = 60
+            Baseuri = $Baseuri
+            Apikey = switch ($AuthType) {
+                WindowsIntegrated { "" }
+                WindowsCustom {
+                    [pscustomobject]@{
+                        "username" = $customcredentials.UserName
+                        "Password" = ($customcredentials.Password | ConvertFrom-SecureString)
+                    }
                 }
             }
             APIKey {
@@ -51,16 +55,16 @@
         }
         if ($SetPlainTextPasswords) {
             if ($PSCmdlet.ShouldProcess('Allow passwords to be returned in plain text')) {
-                $json['PasswordsInPlainText'] = $SetPlainTextPasswords
-            } else {
-                $json['PasswordsInPlainText'] = $false
+                $json | Add-Member -NotePropertyName 'PasswordsInPlainText' -NotePropertyValue $SetPlainTextPasswords
+            } else { 
+                $json | Add-Member -NotePropertyName 'PasswordsInPlainText' -NotePropertyValue $false
             }
         } else {
-            $json['PasswordsInPlainText'] = $SetPlainTextPasswords
+            $json | Add-Member -NotePropertyName 'PasswordsInPlainText' -NotePropertyValue $SetPlainTextPasswords
         }
 
         if ($PasswordGeneratorAPIkey){
-            $json['PasswordGeneratorAPIKey'] = ($PasswordGeneratorAPIkey | ConvertTo-SecureString -AsPlainText -Force | ConvertFrom-SecureString)
+            $json | Add-Member -NotePropertyName 'PasswordGeneratorAPIKey' -NotePropertyValue ($PasswordGeneratorAPIkey | ConvertTo-SecureString -AsPlainText -Force | ConvertFrom-SecureString)
         }
         $json = $json | ConvertTo-Json
     }

--- a/functions/Set-PasswordStateEnvironment.ps1
+++ b/functions/Set-PasswordStateEnvironment.ps1
@@ -30,16 +30,12 @@
 
     process {
         # Build the custom object to be converted to JSON. Set APIKey as WindowsAuth if we are to use windows authentication.
-        $json = [PSCustomObject]@{
-            TimeoutSeconds = 60
-            Baseuri = $Baseuri
-            Apikey = switch ($AuthType) {
-                WindowsIntegrated { "" }
-                WindowsCustom {
-                    [pscustomobject]@{
-                        "username" = $customcredentials.UserName
-                        "Password" = ($customcredentials.Password | ConvertFrom-SecureString)
-                    }
+        $JsonApiKey = switch ($AuthType) {
+            WindowsIntegrated { "" }
+            WindowsCustom {
+                @{
+                    "username" = $customcredentials.UserName
+                    "Password" = ($customcredentials.Password | ConvertFrom-SecureString)
                 }
             }
             APIKey {
@@ -49,22 +45,22 @@
         }
         $json = @{
             TimeoutSeconds = 60
-            Baseuri = $Uri -replace '/$',''
+            Baseuri = $Baseuri
             Apikey = $JsonApiKey
             "AuthType" = $AuthType
         }
         if ($SetPlainTextPasswords) {
             if ($PSCmdlet.ShouldProcess('Allow passwords to be returned in plain text')) {
-                $json | Add-Member -NotePropertyName 'PasswordsInPlainText' -NotePropertyValue $SetPlainTextPasswords
+                $json['PasswordsInPlainText'] = $SetPlainTextPasswords
             } else {
-                $json | Add-Member -NotePropertyName 'PasswordsInPlainText' -NotePropertyValue $false
+                $json['PasswordsInPlainText'] = $false
             }
         } else {
-            $json | Add-Member -NotePropertyName 'PasswordsInPlainText' -NotePropertyValue $SetPlainTextPasswords
+            $json['PasswordsInPlainText'] = $SetPlainTextPasswords
         }
 
         if ($PasswordGeneratorAPIkey){
-            $json | Add-Member -NotePropertyName 'PasswordGeneratorAPIKey' -NotePropertyValue ($PasswordGeneratorAPIkey | ConvertTo-SecureString -AsPlainText -Force | ConvertFrom-SecureString)
+            $json['PasswordGeneratorAPIKey'] = ($PasswordGeneratorAPIkey | ConvertTo-SecureString -AsPlainText -Force | ConvertFrom-SecureString)
         }
         $json = $json | ConvertTo-Json
     }

--- a/internal/functions/Get-PasswordStateResource.ps1
+++ b/internal/functions/Get-PasswordStateResource.ps1
@@ -97,7 +97,7 @@ function Get-PasswordStateResource {
                 $result = Invoke-RestMethod @params -UseDefaultCredentials -TimeoutSec 60
             }
         }
-        if ($sort) {
+        if ($sort) { 
             Write-PSFMessage -Level Warning -Message "This feature is not available yet"
         }
     }

--- a/internal/functions/Get-PasswordStateResource.ps1
+++ b/internal/functions/Get-PasswordStateResource.ps1
@@ -97,7 +97,7 @@ function Get-PasswordStateResource {
                 $result = Invoke-RestMethod @params -UseDefaultCredentials -TimeoutSec 60
             }
         }
-        if ($sort) { 
+        if ($sort) {
             Write-PSFMessage -Level Warning -Message "This feature is not available yet"
         }
     }

--- a/tests/functions/Set-PasswordStateEnvironment.Tests.ps1
+++ b/tests/functions/Set-PasswordStateEnvironment.Tests.ps1
@@ -94,19 +94,24 @@ InModuleScope 'PasswordState-Management' {
             }
         }
         Context 'Unit testing with Windows Custom Credential' {
-            It 'should verify if a json file is witten and Baseuri contains <baseuri>' -TestCases $AuthTestCases {
+            It 'should verify if a json file is witten and Uri contains <Uri>' -TestCases $AuthTestCases {
+                param($Uri)
+                Set-PasswordStateEnvironment -Uri $Uri -path $ProfilePath -customcredentials $Credential
+                (Get-Content $ProfileFile | ConvertFrom-Json).BaseUri | should -be $Uri
+            }
+            It 'should verify if a json file is witten and Baseuri contains <Baseuri>' -TestCases $BaseuriAuthTestCases {
                 param($Baseuri)
                 Set-PasswordStateEnvironment -Baseuri $Baseuri -path $ProfilePath -customcredentials $Credential
-                (Get-Content $ProfileFile | ConvertFrom-Json).Baseuri | should -be $Baseuri
+                (Get-Content $ProfileFile | ConvertFrom-Json).BaseUri | should -be $Baseuri
             }
             It 'Should verify if a json file is written and apikey has a credential' -TestCases $AuthTestCases {
-                param($Baseuri)
-                Set-PasswordStateEnvironment -Baseuri $Baseuri -path $ProfilePath -customcredentials $Credential
+                param($Uri)
+                Set-PasswordStateEnvironment -Uri $Uri -path $ProfilePath -customcredentials $Credential
                 (Get-Content $ProfileFile | ConvertFrom-Json).apikey.username | should -BeExactly $UserName
             }
-            It 'Should verify if a json file is written and AuthType is exactly "WindowsIntegrated" for <baseuri>' -TestCases $AuthTestCases {
-                param($Baseuri)
-                Set-PasswordStateEnvironment -Baseuri $Baseuri -path $ProfilePath -customcredentials $Credential
+            It 'Should verify if a json file is written and AuthType is exactly "WindowsIntegrated" for <Uri>' -TestCases $AuthTestCases {
+                param($Uri)
+                Set-PasswordStateEnvironment -Uri $Uri -path $ProfilePath -customcredentials $Credential
                 (Get-Content $ProfileFile | ConvertFrom-Json).AuthType | should -BeExactly "WindowsCustom"
             }
         }

--- a/tests/functions/Set-PasswordStateEnvironment.Tests.ps1
+++ b/tests/functions/Set-PasswordStateEnvironment.Tests.ps1
@@ -94,24 +94,19 @@ InModuleScope 'PasswordState-Management' {
             }
         }
         Context 'Unit testing with Windows Custom Credential' {
-            It 'should verify if a json file is witten and Uri contains <Uri>' -TestCases $AuthTestCases {
-                param($Uri)
-                Set-PasswordStateEnvironment -Uri $Uri -path $ProfilePath -customcredentials $Credential
-                (Get-Content $ProfileFile | ConvertFrom-Json).BaseUri | should -be $Uri
-            }
-            It 'should verify if a json file is witten and Baseuri contains <Baseuri>' -TestCases $BaseuriAuthTestCases {
+            It 'should verify if a json file is witten and Baseuri contains <baseuri>' -TestCases $AuthTestCases {
                 param($Baseuri)
                 Set-PasswordStateEnvironment -Baseuri $Baseuri -path $ProfilePath -customcredentials $Credential
-                (Get-Content $ProfileFile | ConvertFrom-Json).BaseUri | should -be $Baseuri
+                (Get-Content $ProfileFile | ConvertFrom-Json).Baseuri | should -be $Baseuri
             }
             It 'Should verify if a json file is written and apikey has a credential' -TestCases $AuthTestCases {
-                param($Uri)
-                Set-PasswordStateEnvironment -Uri $Uri -path $ProfilePath -customcredentials $Credential
+                param($Baseuri)
+                Set-PasswordStateEnvironment -Baseuri $Baseuri -path $ProfilePath -customcredentials $Credential
                 (Get-Content $ProfileFile | ConvertFrom-Json).apikey.username | should -BeExactly $UserName
             }
-            It 'Should verify if a json file is written and AuthType is exactly "WindowsIntegrated" for <Uri>' -TestCases $AuthTestCases {
-                param($Uri)
-                Set-PasswordStateEnvironment -Uri $Uri -path $ProfilePath -customcredentials $Credential
+            It 'Should verify if a json file is written and AuthType is exactly "WindowsIntegrated" for <baseuri>' -TestCases $AuthTestCases {
+                param($Baseuri)
+                Set-PasswordStateEnvironment -Baseuri $Baseuri -path $ProfilePath -customcredentials $Credential
                 (Get-Content $ProfileFile | ConvertFrom-Json).AuthType | should -BeExactly "WindowsCustom"
             }
         }


### PR DESCRIPTION
To prevent false positives, I ensured the Path attribute in $script:preferences variable already contains a reference to the user profile.
I also removed the fixed reference to the path attribute in Get-PasswordStatePassword to ensure Get-PasswordStateEnvironment behaves the same in all circumstances (with or without profile file presence in default/non-default path.
Finally I updated the Get-PasswordstateEnvironment tests to ensure they pass in all circumstances, even when the user has a passwordstate profile present in the user profile root.

Fixes #110 