### PR TITLE
Fixed problems in Markdown Help Documentation. Updated Get-PasswordStatePassword

### DIFF
--- a/docs/Get-PasswordStateFolder.md
+++ b/docs/Get-PasswordStateFolder.md
@@ -71,7 +71,7 @@ Accept wildcard characters: False
 ```
 
 ### -PreventAuditing
-{{Fill PreventAuditing Description}}
+By default, the creation/modification or retrieval of (all) Passwords records will add one Audit record for every Password record returned. If you wish to prevent audit records from being added, you can add this `-PreventAuditing` parameter.
 
 ```yaml
 Type: SwitchParameter

--- a/docs/Get-PasswordStateList.md
+++ b/docs/Get-PasswordStateList.md
@@ -91,7 +91,7 @@ Accept wildcard characters: False
 ```
 
 ### -PreventAuditing
-{{Fill PreventAuditing Description}}
+By default, the creation/modification or retrieval of (all) Passwords records will add one Audit record for every Password record returned. If you wish to prevent audit records from being added, you can add this `-PreventAuditing` parameter.
 
 ```yaml
 Type: SwitchParameter

--- a/docs/Get-PasswordStatePassword.md
+++ b/docs/Get-PasswordStatePassword.md
@@ -1,14 +1,14 @@
 ---
 external help file: passwordstate-management-help.xml
 Module Name: passwordstate-management
-online version: https://github.com/dnewsholme/PasswordState-Management/blob/master/docs/New-PasswordStatePassword.md
+online version: https://github.com/dnewsholme/PasswordState-Management/blob/master/docs/Get-PasswordStatePassword.md
 schema: 2.0.0
 ---
 
 # Get-PasswordStatePassword
 
 ## SYNOPSIS
-Finds a password state entry and returns the object.
+Finds a PasswordState password entry and returns the object.
 If multiple matches it will return multiple entries.
 
 ## SYNTAX
@@ -27,52 +27,193 @@ Get-PasswordStatePassword [-PasswordID] <Int32> [[-Reason] <String>] [-PreventAu
 ### Specific
 ```
 Get-PasswordStatePassword [[-Title] <String>] [[-UserName] <String>] [[-HostName] <String>]
- [[-Domain] <String>] [[-AccountType] <String>] [[-Description] <String>] [[-Notes] <String>] [[-URL] <String>]
- [[-SiteID] <String>] [[-SiteLocation] <String>] [[-GenericField1] <String>] [[-GenericField2] <String>]
- [[-GenericField3] <String>] [[-GenericField4] <String>] [[-GenericField5] <String>]
- [[-GenericField6] <String>] [[-GenericField7] <String>] [[-GenericField8] <String>]
- [[-GenericField9] <String>] [[-GenericField10] <String>] [[-PasswordListID] <Int32>] [[-Reason] <String>]
- [-PreventAuditing] [<CommonParameters>]
+ [[-ADDomainNetBIOS] <String>] [[-AccountType] <String>] [[-Description] <String>] [[-Notes] <String>]
+ [[-URL] <String>] [[-SiteID] <String>] [[-SiteLocation] <String>] [[-GenericField1] <String>]
+ [[-GenericField2] <String>] [[-GenericField3] <String>] [[-GenericField4] <String>]
+ [[-GenericField5] <String>] [[-GenericField6] <String>] [[-GenericField7] <String>]
+ [[-GenericField8] <String>] [[-GenericField9] <String>] [[-GenericField10] <String>]
+ [[-AccountTypeID] <String>] [-PasswordResetEnabled] [[-ExpiryDate] <String>] [[-ExpiryDateRange] <String>]
+ [[-AndOr] <String>] [[-PasswordListID] <Int32>] [[-Reason] <String>] [-PreventAuditing] [<CommonParameters>]
 ```
 
 ## DESCRIPTION
-Finds a password state entry and returns the object.
+Finds a PasswordState password entry and returns the object.
 If multiple matches it will return multiple entries.
+
+ There are two ways in which you can search for Passwords via the API, and you can search just within a single Password List, or across all Shared Passwords Lists. The two search methods are:
+
+- Via a **General Search** across the majority of fields in the Passwords table
+- Via **Specific Search** criteria, based on fields and values you specify
+
+**General Search**
+
+When performing a **General Search**, it will query the Passwords table for fields which Contain the value you specify for the `-Search` parameter.  
+You do not need to specify another parameter than `Search` (Also Search is the first parameter, so you generally do not need to specify the parameter name (`Get-PasswordStatePassword "test123"`)).  
+All the fields which will be searched are:
+
+- Title
+- ADDomainNetBIOS
+- HostName
+- UserName
+- AccountType
+- Description
+- GenericField1
+- GenericField2
+- GenericField3
+- GenericField4
+- GenericField5
+- GenericField6
+- GenericField7
+- GenericField8
+- GenericField9
+- GenericField10
+- Notes
+- URL
+- SiteID
+- SiteLocation
+
+**Specific Search**
+
+When performing a **Specific Search**, it will query the Passwords table based on one or more of the parameters you specify.  
+Just add one of the following parameter to the script execution.  
+The fields which can be searched are:
+
+- Title
+- HostName
+- ADDomainNetBIOS
+- UserName
+- AccountTypeID
+- AccountType
+- Description
+- GenericField1
+- GenericField2
+- GenericField3
+- GenericField4
+- GenericField5
+- GenericField6
+- GenericField7
+- GenericField8
+- GenericField9
+- GenericField10
+- Notes
+- URL
+- SiteID
+- SiteLocation
+- PasswordResetEnabled
+- ExpiryDate
+- ExpiryDateRange
+- AndOr
+
+**Note 1**: You can perform an exact match search by enclosing your search criteria in double quotes i.e. '"root_admin"'
+
+**Note 2**: By default, the retrieval of (all) Passwords records will add one Audit record for every Password record returned. If you wish to prevent audit records from being added, you can add the `-PreventAuditing` parameter.
 
 ## EXAMPLES
 
 ### EXAMPLE 1
 ```
-Get-PasswordStatePassword "testuser"
+Get-PasswordStatePassword
 ```
 
-Returns the test user object including password.
+Returns all password objects the user or api key has access to.
 
 ### EXAMPLE 2
+```
+Get-PasswordStatePassword -PreventAuditing
+```
+
+Returns all password objects the user or api key has access to without adding one Audit record for every Password record returned to the audit log.
+
+### EXAMPLE 3
+```
+Get-PasswordStatePassword -Search "testuser"
+```
+
+Returns the object that has the string "testuser" in one of his properties. The password will also be returned.
+
+### EXAMPLE 4
+```
+Get-PasswordStatePassword -PasswordListID 21
+```
+
+Returns all password objects (including password) in password list with ID 21.
+
+### EXAMPLE 5
 ```
 Get-PasswordStatePassword -Title '"testuser"'
 ```
 
-Returns the object including password, which is an exact match with the title (Requires double quotes for exact match).
+Returns the objects (including password) that have the string "testuser" in one of his properties. It has to be an exact match with the one of the properties (Requires double quotes for exact match).
 
-### EXAMPLE 3
+### EXAMPLE 6
+```
+Get-PasswordStatePassword -Title "testuser" -PasswordListID 21
+```
+
+Returns the objects (including password) that have the string "testuser" in one of his properties and are located in password list with ID 21.
+
+### EXAMPLE 7
 ```
 Get-PasswordStatePassword -Username "testuser2" -Notes "Test"
 ```
 
-Returns the test user 2 object, where the notes contain "Test", including password.
+Returns the object with UserName = testuser2 AND where the notes contain "Test", including password.
 
-### EXAMPLE 4
+### EXAMPLE 8
+```
+Get-PasswordStatePassword -Username "testuser2" -Notes "Test" -AndOr "OR"
+```
+
+Returns the object with UserName = testuser2 OR any object where the notes contain "Test", including password.
+
+### EXAMPLE 9
 ```
 Get-PasswordStatePassword -PasswordID "3456"
 ```
 
-Returns the object with the PasswordID 3456 including password.
+Returns the object with the PasswordID 3456.
+
+### EXAMPLE 10
+```
+Get-PasswordStatePassword -PasswordResetEnabled
+```
+
+Returns any object where Password resets are enabled.
+
+### EXAMPLE 11
+```
+Get-PasswordStatePassword -ExpiryDateRange "ExpiryDate>=2012-07-06,ExpiryDate<=2020-12-12"
+```
+
+Returns any object where the password will expire between 2012-07-06 and 2020-12-12.
+
+### EXAMPLE 12
+```
+Get-PasswordStatePassword -ExpiryDate "2020-12-12"
+```
+
+Returns any object where the password will expire at 2020-12-12.
+
+### EXAMPLE 13
+```
+Get-PasswordStatePassword -HostName "SecureComputer.local" -UserName "Administrator" -Reason "Ticket #202005151234567"
+```
+
+Returns the password object with UserName "Administrator" and/on HostName "SecureComputer.local". Also specifying the reason "Ticket #202005151234567" why the password object was requested.
+
+### EXAMPLE 14
+```
+Get-PasswordStatePassword -UserName "Administrator" -SiteLocation "Customer1"
+```
+
+Returns all password objects with UserName "Administrator" but only from Site "Customer1".
 
 ## PARAMETERS
 
 ### -AccountType
 An optional parameter to filter the search on account type.
+The name of the Account Type if one has been chosen for the Password record.  
+Account Types and their ID values can be seen on the screen `Administration -> Passwordstate Administration -> Images and Account Types`, and click on the '**Toggle ID Column Visibility**' button to determine the appropriate value. You can also find the AccountType inside the password objects if set.
 
 ```yaml
 Type: String
@@ -86,8 +227,60 @@ Accept pipeline input: True (ByPropertyName)
 Accept wildcard characters: False
 ```
 
+### -AccountTypeID
+An optional parameter to filter the search on account type by ID.
+The ID value representing the Account Type image (derived from the AccountTypes table). An AccountTypeID of 0 (zero) means there is no associated Account Type image for this Password.  
+Account Types and their ID values can be seen on the screen `Administration -> Passwordstate Administration -> Images and Account Types`, and click on the '**Toggle ID Column Visibility**' button to determine the appropriate value or on any password record if set.
+
+```yaml
+Type: String
+Parameter Sets: Specific
+Aliases:
+
+Required: False
+Position: 20
+Default value: None
+Accept pipeline input: True (ByPropertyName)
+Accept wildcard characters: False
+```
+
+### -ADDomainNetBIOS
+If you want to search for a record that relates to an Active Directory account, then you can specify the Active Directory NetBIOS value here, as it is stored on the `Administration -> PasswordState Administration -> Active Directory Domains` screen in PasswordState or found in a password record if set.
+
+```yaml
+Type: String
+Parameter Sets: Specific
+Aliases: Domain
+
+Required: False
+Position: 3
+Default value: None
+Accept pipeline input: True (ByPropertyName)
+Accept wildcard characters: False
+```
+
+### -AndOr
+If parameter is not set, "AND" will be used as default.
+As you can build up your query string based on one or more fields/parameters, you can also specify how these queries are joined in the SQL query - either using `-AndOr "OR"`, or `-AndOr "AND"`.
+
+As you'd expect, using the OR operator will return a greater number of results, while the AND operator will return less results as it is a more specific type of query.
+
+```yaml
+Type: String
+Parameter Sets: Specific
+Aliases:
+Accepted values: AND, OR
+
+Required: False
+Position: 24
+Default value: None
+Accept pipeline input: True (ByPropertyName)
+Accept wildcard characters: False
+```
+
 ### -Description
 An optional parameter to filter the search on description.
+The description is generally used as a longer verbose description of the nature of the Password object.
 
 ```yaml
 Type: String
@@ -101,8 +294,11 @@ Accept pipeline input: True (ByPropertyName)
 Accept wildcard characters: False
 ```
 
-### -Domain
-An optional parameter to filter the search on domain.
+### -ExpiryDate
+When performing a Specific Search by the `ExpiryDate` field, it will perform an exact match on this value. If you wish to query based on a date range, then please use `-ExpiryDateRange`.  
+The `ExpiryDate` is a date in which the password value should be reset for the Password object. The date will be displayed in the format specified for the System Setting option 'Default Locale', through the PasswordState web site interface.
+
+**Note:** Please specify the ExpiryDate in the date format that you have chosen in `'System Settings - miscellaneous - Default Locale'` (Default: '**YYYY-MM-DD**').
 
 ```yaml
 Type: String
@@ -110,14 +306,41 @@ Parameter Sets: Specific
 Aliases:
 
 Required: False
-Position: 3
+Position: 22
+Default value: None
+Accept pipeline input: True (ByPropertyName)
+Accept wildcard characters: False
+```
+
+### -ExpiryDateRange
+Format: `ExpiryDate>=2012-07-14,ExpiryDate<=2020-12-31`
+
+It is possible to specify SQL style query syntax for the ExpiryDateRange parameter, so you can construct a query based on date ranges if needed. Examples of the query syntax you can use is (ensure you separate two dates with a single comma):
+
+- ExpiryDateRange=ExpiryDate>=2012-07-06,ExpiryDate<=2013-01-01
+- ExpiryDateRange=ExpiryDate>2012-01-01,ExpiryDate<=2012-02-28
+- ExpiryDateRange=ExpiryDate>2013-01-01
+- ExpiryDateRange=ExpiryDate<=2012-11-30
+
+**Note**: Dates must be supplied in the `ISO 8601` international standard for date format of **YYYY-MM-DD**.
+
+```yaml
+Type: String
+Parameter Sets: Specific
+Aliases:
+
+Required: False
+Position: 23
 Default value: None
 Accept pipeline input: True (ByPropertyName)
 Accept wildcard characters: False
 ```
 
 ### -GenericField1
-An optional parameter to filter the search on a generic field.
+An optional parameter to filter the search on a generic field.  
+A generic field is a string field which can be renamed to a different value when being displayed in the PasswordState web interface.
+
+**Note**: Generic Fields can be configured as different Field Types, so ensure you pass a valid value for text fields, Select Lists, Radio Buttons or Date Fields.
 
 ```yaml
 Type: String
@@ -132,7 +355,10 @@ Accept wildcard characters: False
 ```
 
 ### -GenericField10
-An optional parameter to filter the search on a generic field.
+An optional parameter to filter the search on a generic field.  
+A generic field is a string field which can be renamed to a different value when being displayed in the PasswordState web interface.
+
+**Note**: Generic Fields can be configured as different Field Types, so ensure you pass a valid value for text fields, Select Lists, Radio Buttons or Date Fields.
 
 ```yaml
 Type: String
@@ -147,7 +373,10 @@ Accept wildcard characters: False
 ```
 
 ### -GenericField2
-An optional parameter to filter the search on a generic field.
+An optional parameter to filter the search on a generic field.  
+A generic field is a string field which can be renamed to a different value when being displayed in the PasswordState web interface.
+
+**Note**: Generic Fields can be configured as different Field Types, so ensure you pass a valid value for text fields, Select Lists, Radio Buttons or Date Fields.
 
 ```yaml
 Type: String
@@ -162,7 +391,10 @@ Accept wildcard characters: False
 ```
 
 ### -GenericField3
-An optional parameter to filter the search on a generic field.
+An optional parameter to filter the search on a generic field.  
+A generic field is a string field which can be renamed to a different value when being displayed in the PasswordState web interface.
+
+**Note**: Generic Fields can be configured as different Field Types, so ensure you pass a valid value for text fields, Select Lists, Radio Buttons or Date Fields.
 
 ```yaml
 Type: String
@@ -177,7 +409,10 @@ Accept wildcard characters: False
 ```
 
 ### -GenericField4
-An optional parameter to filter the search on a generic field.
+An optional parameter to filter the search on a generic field.  
+A generic field is a string field which can be renamed to a different value when being displayed in the PasswordState web interface.
+
+**Note**: Generic Fields can be configured as different Field Types, so ensure you pass a valid value for text fields, Select Lists, Radio Buttons or Date Fields.
 
 ```yaml
 Type: String
@@ -192,7 +427,10 @@ Accept wildcard characters: False
 ```
 
 ### -GenericField5
-An optional parameter to filter the search on a generic field.
+An optional parameter to filter the search on a generic field.  
+A generic field is a string field which can be renamed to a different value when being displayed in the PasswordState web interface.
+
+**Note**: Generic Fields can be configured as different Field Types, so ensure you pass a valid value for text fields, Select Lists, Radio Buttons or Date Fields.
 
 ```yaml
 Type: String
@@ -207,7 +445,10 @@ Accept wildcard characters: False
 ```
 
 ### -GenericField6
-An optional parameter to filter the search on a generic field.
+An optional parameter to filter the search on a generic field.  
+A generic field is a string field which can be renamed to a different value when being displayed in the PasswordState web interface.
+
+**Note**: Generic Fields can be configured as different Field Types, so ensure you pass a valid value for text fields, Select Lists, Radio Buttons or Date Fields.
 
 ```yaml
 Type: String
@@ -222,7 +463,10 @@ Accept wildcard characters: False
 ```
 
 ### -GenericField7
-An optional parameter to filter the search on a generic field.
+An optional parameter to filter the search on a generic field.  
+A generic field is a string field which can be renamed to a different value when being displayed in the PasswordState web interface.
+
+**Note**: Generic Fields can be configured as different Field Types, so ensure you pass a valid value for text fields, Select Lists, Radio Buttons or Date Fields.
 
 ```yaml
 Type: String
@@ -237,7 +481,10 @@ Accept wildcard characters: False
 ```
 
 ### -GenericField8
-An optional parameter to filter the search on a generic field.
+An optional parameter to filter the search on a generic field.  
+A generic field is a string field which can be renamed to a different value when being displayed in the PasswordState web interface.
+
+**Note**: Generic Fields can be configured as different Field Types, so ensure you pass a valid value for text fields, Select Lists, Radio Buttons or Date Fields.
 
 ```yaml
 Type: String
@@ -252,7 +499,10 @@ Accept wildcard characters: False
 ```
 
 ### -GenericField9
-An optional parameter to filter the search on a generic field.
+An optional parameter to filter the search on a generic field.  
+A generic field is a string field which can be renamed to a different value when being displayed in the PasswordState web interface.
+
+**Note**: Generic Fields can be configured as different Field Types, so ensure you pass a valid value for text fields, Select Lists, Radio Buttons or Date Fields.
 
 ```yaml
 Type: String
@@ -267,7 +517,8 @@ Accept wildcard characters: False
 ```
 
 ### -HostName
-An optional parameter to filter the search on hostname.
+An optional parameter to filter the search on hostname.  
+If the record relates to account on a Host, then you can specify the Host Name here to filter for, as it is stored on the Hosts screen in PasswordState.
 
 ```yaml
 Type: String
@@ -282,7 +533,8 @@ Accept wildcard characters: False
 ```
 
 ### -Notes
-An optional parameter to filter the search on notes.
+An optional parameter to filter the search on notes.  
+The Notes field are a generic field where additional descriptive text can be added.
 
 ```yaml
 Type: String
@@ -297,7 +549,7 @@ Accept wildcard characters: False
 ```
 
 ### -PasswordID
-An ID of a specific password resource to return.
+An PasswordID value of the password record in PasswordState to return.
 
 ```yaml
 Type: Int32
@@ -320,14 +572,29 @@ Parameter Sets: General, Specific
 Aliases:
 
 Required: False
-Position: 20
+Position: 25
 Default value: 0
 Accept pipeline input: True (ByPropertyName)
 Accept wildcard characters: False
 ```
 
+### -PasswordResetEnabled
+Search for all password objects where the password reset is enabled.
+
+```yaml
+Type: SwitchParameter
+Parameter Sets: Specific
+Aliases:
+
+Required: False
+Position: 21
+Default value: None
+Accept pipeline input: True (ByPropertyName)
+Accept wildcard characters: False
+```
+
 ### -PreventAuditing
-{{Fill PreventAuditing Description}}
+By default, the retrieval of (all) Passwords records will add one Audit record for every Password record returned. If you wish to prevent audit records from being added, you can add this `-PreventAuditing` parameter.
 
 ```yaml
 Type: SwitchParameter
@@ -335,7 +602,7 @@ Parameter Sets: (All)
 Aliases:
 
 Required: False
-Position: 22
+Position: 27
 Default value: False
 Accept pipeline input: True (ByPropertyName)
 Accept wildcard characters: False
@@ -350,14 +617,14 @@ Parameter Sets: (All)
 Aliases:
 
 Required: False
-Position: 21
+Position: 26
 Default value: None
 Accept pipeline input: True (ByPropertyName)
 Accept wildcard characters: False
 ```
 
 ### -Search
-A string value which will be matched with most fields in the database table.
+A string value which will be matched with most fields in the database table. Check the description section above fore more information which fields will be used for the search.
 
 ```yaml
 Type: String
@@ -372,7 +639,8 @@ Accept wildcard characters: False
 ```
 
 ### -SiteID
-An optional parameter to filter the search on the site ID.
+An optional parameter to filter the search on the site ID.  
+If you do not specify this parameter, it will report data based on all Site Locations. Values are 0 for Internal, and all other SiteID's can be found on the screen `Administration -> Remote Site Administration -> Remote Site Locations`.
 
 ```yaml
 Type: String
@@ -387,7 +655,8 @@ Accept wildcard characters: False
 ```
 
 ### -SiteLocation
-An optional parameter to filter the search on the site location.
+An optional parameter to filter the search on the site location.  
+If you do not specify this parameter, it will report data based on all Site Locations. Values are the name of the Site Location that can be found on the screen `Administration -> Remote Site Administration -> Remote Site Locations`.
 
 ```yaml
 Type: String
@@ -402,7 +671,8 @@ Accept wildcard characters: False
 ```
 
 ### -Title
-A string value which should match the passwordstate entry.
+A string value which should match the PasswordState entry.  
+A title is a name that describes the nature of the Password object.
 
 ```yaml
 Type: String
@@ -417,7 +687,8 @@ Accept wildcard characters: False
 ```
 
 ### -URL
-An optional parameter to filter the search on the URL.
+An optional parameter to filter the search on the URL.  
+URL parameter can be the URL for HTTP, HTTPS, FTP, SFTP, etc. found in the password object.
 
 ```yaml
 Type: String
@@ -432,7 +703,8 @@ Accept wildcard characters: False
 ```
 
 ### -UserName
-An optional parameter to filter searches to those with a certain username as multiple titles may have the same value.
+An optional parameter to filter searches to those with a certain username as multiple titles may have the same value.  
+Some systems require a username and password to authenticate. This field represents the UserName to do so.  
 
 ```yaml
 Type: String
@@ -455,7 +727,5 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 
 ### Returns the Object from the API as a powershell object.
 ## NOTES
-2018 - Daryl Newsholme
-2019 - Jarno Colombeen
 
 ## RELATED LINKS

--- a/docs/Get-PasswordStatePassword.md
+++ b/docs/Get-PasswordStatePassword.md
@@ -27,13 +27,13 @@ Get-PasswordStatePassword [-PasswordID] <Int32> [[-Reason] <String>] [-PreventAu
 ### Specific
 ```
 Get-PasswordStatePassword [[-Title] <String>] [[-UserName] <String>] [[-HostName] <String>]
- [[-ADDomainNetBIOS] <String>] [[-AccountType] <String>] [[-Description] <String>] [[-Notes] <String>]
- [[-URL] <String>] [[-SiteID] <String>] [[-SiteLocation] <String>] [[-GenericField1] <String>]
- [[-GenericField2] <String>] [[-GenericField3] <String>] [[-GenericField4] <String>]
- [[-GenericField5] <String>] [[-GenericField6] <String>] [[-GenericField7] <String>]
- [[-GenericField8] <String>] [[-GenericField9] <String>] [[-GenericField10] <String>]
- [[-AccountTypeID] <String>] [-PasswordResetEnabled] [[-ExpiryDate] <String>] [[-ExpiryDateRange] <String>]
- [[-AndOr] <String>] [[-PasswordListID] <Int32>] [[-Reason] <String>] [-PreventAuditing] [<CommonParameters>]
+ [[-Domain] <String>] [[-AccountType] <String>] [[-Description] <String>] [[-Notes] <String>] [[-URL] <String>]
+ [[-SiteID] <String>] [[-SiteLocation] <String>] [[-GenericField1] <String>] [[-GenericField2] <String>]
+ [[-GenericField3] <String>] [[-GenericField4] <String>] [[-GenericField5] <String>]
+ [[-GenericField6] <String>] [[-GenericField7] <String>] [[-GenericField8] <String>]
+ [[-GenericField9] <String>] [[-GenericField10] <String>] [[-AccountTypeID] <String>] [-PasswordResetEnabled]
+ [[-ExpiryDate] <String>] [[-ExpiryDateRange] <String>] [[-AndOr] <String>] [[-PasswordListID] <Int32>]
+ [[-Reason] <String>] [-PreventAuditing] [[-ADDomainNetBIOS] <String>] [<CommonParameters>]
 ```
 
 ## DESCRIPTION
@@ -250,10 +250,10 @@ If you want to search for a record that relates to an Active Directory account, 
 ```yaml
 Type: String
 Parameter Sets: Specific
-Aliases: Domain
+Aliases:
 
 Required: False
-Position: 3
+Position: 28
 Default value: None
 Accept pipeline input: True (ByPropertyName)
 Accept wildcard characters: False
@@ -289,6 +289,22 @@ Aliases:
 
 Required: False
 Position: 5
+Default value: None
+Accept pipeline input: True (ByPropertyName)
+Accept wildcard characters: False
+```
+
+### -Domain
+Optionally search for a password object that relates to an Active Directory Account.  
+If the password relates to an Active Directory Account, then this record will show the NetBIOS value for the domain.
+
+```yaml
+Type: String
+Parameter Sets: Specific
+Aliases:
+
+Required: False
+Position: 3
 Default value: None
 Accept pipeline input: True (ByPropertyName)
 Accept wildcard characters: False

--- a/docs/Get-PasswordStatePasswordHistory.md
+++ b/docs/Get-PasswordStatePasswordHistory.md
@@ -48,7 +48,7 @@ Accept wildcard characters: False
 ```
 
 ### -PreventAuditing
-{{Fill PreventAuditing Description}}
+By default, the creation/modification or retrieval of (all) Passwords records will add one Audit record for every Password record returned. If you wish to prevent audit records from being added, you can add this `-PreventAuditing` parameter.
 
 ```yaml
 Type: SwitchParameter

--- a/docs/Get-PasswordStatePermission.md
+++ b/docs/Get-PasswordStatePermission.md
@@ -55,21 +55,6 @@ Run report with ID 24 (What permissions exist for a user?) and specify a user id
 
 ## PARAMETERS
 
-### -Confirm
-Prompts you for confirmation before running the cmdlet.
-
-```yaml
-Type: SwitchParameter
-Parameter Sets: (All)
-Aliases: cf
-
-Required: False
-Position: Named
-Default value: None
-Accept pipeline input: False
-Accept wildcard characters: False
-```
-
 ### -DurationInMonth
 The period in which data can be reported against. Possible values are `0 for current month`, `1 for the past 30 days`, and then `any other integer representing the quantity of months`.
 
@@ -161,6 +146,21 @@ Required: False
 Position: 0
 Default value: None
 Accept pipeline input: True (ByPropertyName)
+Accept wildcard characters: False
+```
+
+### -Confirm
+Prompts you for confirmation before running the cmdlet.
+
+```yaml
+Type: SwitchParameter
+Parameter Sets: (All)
+Aliases: cf
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
 Accept wildcard characters: False
 ```
 

--- a/docs/Invoke-PasswordStateReport.md
+++ b/docs/Invoke-PasswordStateReport.md
@@ -67,21 +67,6 @@ Run report with ID 24 (What permissions exist for a user?) and specify a user id
 
 ## PARAMETERS
 
-### -Confirm
-Prompts you for confirmation before running the cmdlet.
-
-```yaml
-Type: SwitchParameter
-Parameter Sets: (All)
-Aliases: cf
-
-Required: False
-Position: Named
-Default value: None
-Accept pipeline input: False
-Accept wildcard characters: False
-```
-
 ### -DurationInMonth
 The period in which data can be reported against. Possible values are `0 for current month`, `1 for the past 30 days`, and then `any other integer representing the quantity of months`.
 
@@ -220,6 +205,21 @@ Required: False
 Position: 0
 Default value: None
 Accept pipeline input: True (ByPropertyName)
+Accept wildcard characters: False
+```
+
+### -Confirm
+Prompts you for confirmation before running the cmdlet.
+
+```yaml
+Type: SwitchParameter
+Parameter Sets: (All)
+Aliases: cf
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
 Accept wildcard characters: False
 ```
 

--- a/docs/New-PasswordStateADSecurityGroup.md
+++ b/docs/New-PasswordStateADSecurityGroup.md
@@ -50,21 +50,6 @@ Accept pipeline input: True (ByPropertyName)
 Accept wildcard characters: False
 ```
 
-### -Confirm
-Prompts you for confirmation before running the cmdlet.
-
-```yaml
-Type: SwitchParameter
-Parameter Sets: (All)
-Aliases: cf
-
-Required: False
-Position: Named
-Default value: None
-Accept pipeline input: False
-Accept wildcard characters: False
-```
-
 ### -Description
 A description for the Security Group. The description of the Active Directory Security Group will not be imported (missing API feature), you need to specify the description.
 
@@ -92,6 +77,21 @@ Required: True
 Position: 0
 Default value: None
 Accept pipeline input: True (ByPropertyName)
+Accept wildcard characters: False
+```
+
+### -Confirm
+Prompts you for confirmation before running the cmdlet.
+
+```yaml
+Type: SwitchParameter
+Parameter Sets: (All)
+Aliases: cf
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
 Accept wildcard characters: False
 ```
 

--- a/docs/New-PasswordStateDependency.md
+++ b/docs/New-PasswordStateDependency.md
@@ -53,21 +53,6 @@ Adding a Password Reset Post Reset script (ScriptID 43) to password resource wit
 
 ## PARAMETERS
 
-### -Confirm
-Prompts you for confirmation before running the cmdlet.
-
-```yaml
-Type: SwitchParameter
-Parameter Sets: (All)
-Aliases: cf
-
-Required: False
-Position: Named
-Default value: None
-Accept pipeline input: False
-Accept wildcard characters: False
-```
-
 ### -DependencyName
 The actual name of the Dependency, as it relates to Windows resources i.e. the name of a Windows Service, or Scheduled Task.
 
@@ -142,6 +127,21 @@ Required: True
 Position: 3
 Default value: None
 Accept pipeline input: True (ByPropertyName)
+Accept wildcard characters: False
+```
+
+### -Confirm
+Prompts you for confirmation before running the cmdlet.
+
+```yaml
+Type: SwitchParameter
+Parameter Sets: (All)
+Aliases: cf
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
 Accept wildcard characters: False
 ```
 

--- a/docs/New-PasswordStateDocument.md
+++ b/docs/New-PasswordStateDocument.md
@@ -34,21 +34,6 @@ Find-PasswordStatePassword test | New-PasswordStateDocument -resourcetype Passwo
 
 ## PARAMETERS
 
-### -Confirm
-Prompts you for confirmation before running the cmdlet.
-
-```yaml
-Type: SwitchParameter
-Parameter Sets: (All)
-Aliases: cf
-
-Required: False
-Position: Named
-Default value: None
-Accept pipeline input: False
-Accept wildcard characters: False
-```
-
 ### -DocumentDescription
 Description to be added to the document.
 
@@ -109,22 +94,6 @@ Accept pipeline input: True (ByPropertyName)
 Accept wildcard characters: False
 ```
 
-### -WhatIf
-Shows what would happen if the cmdlet runs.
-The cmdlet is not run.
-
-```yaml
-Type: SwitchParameter
-Parameter Sets: (All)
-Aliases: wi
-
-Required: False
-Position: Named
-Default value: None
-Accept pipeline input: False
-Accept wildcard characters: False
-```
-
 ### -resourcetype
 The resource type to add the document to.
 
@@ -138,6 +107,37 @@ Required: False
 Position: 1
 Default value: Password
 Accept pipeline input: True (ByPropertyName)
+Accept wildcard characters: False
+```
+
+### -Confirm
+Prompts you for confirmation before running the cmdlet.
+
+```yaml
+Type: SwitchParameter
+Parameter Sets: (All)
+Aliases: cf
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -WhatIf
+Shows what would happen if the cmdlet runs.
+The cmdlet is not run.
+
+```yaml
+Type: SwitchParameter
+Parameter Sets: (All)
+Aliases: wi
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
 Accept wildcard characters: False
 ```
 

--- a/docs/New-PasswordStateFolder.md
+++ b/docs/New-PasswordStateFolder.md
@@ -54,21 +54,6 @@ Creates the folder "TestFolder" under the folder with ID 4 using the Site Locati
 
 ## PARAMETERS
 
-### -Confirm
-Prompts you for confirmation before running the cmdlet.
-
-```yaml
-Type: SwitchParameter
-Parameter Sets: (All)
-Aliases: cf
-
-Required: False
-Position: Named
-Default value: None
-Accept pipeline input: False
-Accept wildcard characters: False
-```
-
 ### -CopyPermissionsFromPasswordListID
 To copy permissions to the Folder from an existing Password List, you can specify the PasswordListID value for this field.  
 
@@ -197,6 +182,21 @@ Required: False
 Position: 7
 Default value: None
 Accept pipeline input: True (ByPropertyName)
+Accept wildcard characters: False
+```
+
+### -Confirm
+Prompts you for confirmation before running the cmdlet.
+
+```yaml
+Type: SwitchParameter
+Parameter Sets: (All)
+Aliases: cf
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
 Accept wildcard characters: False
 ```
 

--- a/docs/New-PasswordStateFolderPermission.md
+++ b/docs/New-PasswordStateFolderPermission.md
@@ -102,21 +102,6 @@ Accept pipeline input: True (ByPropertyName)
 Accept wildcard characters: False
 ```
 
-### -Confirm
-Prompts you for confirmation before running the cmdlet.
-
-```yaml
-Type: SwitchParameter
-Parameter Sets: (All)
-Aliases: cf
-
-Required: False
-Position: Named
-Default value: None
-Accept pipeline input: False
-Accept wildcard characters: False
-```
-
 ### -FolderID
 Unique identifier for the Folder.
 
@@ -161,6 +146,21 @@ Required: False
 Position: 4
 Default value: None
 Accept pipeline input: True (ByPropertyName)
+Accept wildcard characters: False
+```
+
+### -Confirm
+Prompts you for confirmation before running the cmdlet.
+
+```yaml
+Type: SwitchParameter
+Parameter Sets: (All)
+Aliases: cf
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
 Accept wildcard characters: False
 ```
 

--- a/docs/New-PasswordStateHost.md
+++ b/docs/New-PasswordStateHost.md
@@ -47,21 +47,6 @@ Creates a new host with the hostname 'TestServer.domain.local'
 
 ## PARAMETERS
 
-### -Confirm
-Prompts you for confirmation before running the cmdlet.
-
-```yaml
-Type: SwitchParameter
-Parameter Sets: (All)
-Aliases: cf
-
-Required: False
-Position: Named
-Default value: None
-Accept pipeline input: False
-Accept wildcard characters: False
-```
-
 ### -DatabasePortNumber
 Optional parameter that indicates the Port Number the database server is accessible on.
 Leaving the Port Number blank is most cases should work, but you can specify non-standard port numbers if required
@@ -269,21 +254,6 @@ Accept pipeline input: True (ByPropertyName)
 Accept wildcard characters: False
 ```
 
-### -SQLInstanceName
-Optional parameter that provides either the Microsoft SQL Server Instance Name, Oracle Service Name or PostgreSQL Database Name.
-
-```yaml
-Type: String
-Parameter Sets: (All)
-Aliases:
-
-Required: False
-Position: 4
-Default value: None
-Accept pipeline input: True (ByPropertyName)
-Accept wildcard characters: False
-```
-
 ### -SessionRecording
 Optional switch.
 Indicates whether all sessions will be recorded for this host record.
@@ -312,6 +282,21 @@ Aliases:
 Required: False
 Position: 11
 Default value: 0
+Accept pipeline input: True (ByPropertyName)
+Accept wildcard characters: False
+```
+
+### -SQLInstanceName
+Optional parameter that provides either the Microsoft SQL Server Instance Name, Oracle Service Name or PostgreSQL Database Name.
+
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: 4
+Default value: None
 Accept pipeline input: True (ByPropertyName)
 Accept wildcard characters: False
 ```
@@ -375,6 +360,21 @@ Required: True
 Position: 17
 Default value: None
 Accept pipeline input: True (ByPropertyName)
+Accept wildcard characters: False
+```
+
+### -Confirm
+Prompts you for confirmation before running the cmdlet.
+
+```yaml
+Type: SwitchParameter
+Parameter Sets: (All)
+Aliases: cf
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
 Accept wildcard characters: False
 ```
 

--- a/docs/New-PasswordStateList.md
+++ b/docs/New-PasswordStateList.md
@@ -159,21 +159,6 @@ Accept pipeline input: True (ByPropertyName)
 Accept wildcard characters: False
 ```
 
-### -Confirm
-Prompts you for confirmation before running the cmdlet.
-
-```yaml
-Type: SwitchParameter
-Parameter Sets: (All)
-Aliases: cf
-
-Required: False
-Position: Named
-Default value: False
-Accept pipeline input: False
-Accept wildcard characters: False
-```
-
 ### -CopyPermissionsFromPasswordListID
 Optionally copy the permissions from another list.  
 To copy permissions to the Password List from an existing Password List, you can specify the PasswordListID value for this field.  
@@ -425,7 +410,7 @@ When apply permissions to the newly created Password List (for a User or Securit
 Type: String
 Parameter Sets: Permission
 Aliases:
-Accepted values: A, M, V, A, M, V
+Accepted values: A, M, V
 
 Required: True
 Position: 12
@@ -438,7 +423,7 @@ Accept wildcard characters: False
 Type: String
 Parameter Sets: Private
 Aliases:
-Accepted values: A, M, V, A, M, V
+Accepted values: A, M, V
 
 Required: False
 Position: 12
@@ -521,6 +506,21 @@ Required: False
 Position: 20
 Default value: False
 Accept pipeline input: True (ByPropertyName)
+Accept wildcard characters: False
+```
+
+### -Confirm
+Prompts you for confirmation before running the cmdlet.
+
+```yaml
+Type: SwitchParameter
+Parameter Sets: (All)
+Aliases: cf
+
+Required: False
+Position: Named
+Default value: False
+Accept pipeline input: False
 Accept wildcard characters: False
 ```
 

--- a/docs/New-PasswordStateListPermission.md
+++ b/docs/New-PasswordStateListPermission.md
@@ -102,21 +102,6 @@ Accept pipeline input: True (ByPropertyName)
 Accept wildcard characters: False
 ```
 
-### -Confirm
-Prompts you for confirmation before running the cmdlet.
-
-```yaml
-Type: SwitchParameter
-Parameter Sets: (All)
-Aliases: cf
-
-Required: False
-Position: Named
-Default value: None
-Accept pipeline input: False
-Accept wildcard characters: False
-```
-
 ### -PasswordListID
 Unique identifier for the Password List.
 
@@ -161,6 +146,21 @@ Required: False
 Position: 4
 Default value: None
 Accept pipeline input: True (ByPropertyName)
+Accept wildcard characters: False
+```
+
+### -Confirm
+Prompts you for confirmation before running the cmdlet.
+
+```yaml
+Type: SwitchParameter
+Parameter Sets: (All)
+Aliases: cf
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
 Accept wildcard characters: False
 ```
 

--- a/docs/New-PasswordStatePassword.md
+++ b/docs/New-PasswordStatePassword.md
@@ -158,21 +158,6 @@ Creates a new password entry with AccountType 61 (Ubuntu) enabled password reset
 
 ## PARAMETERS
 
-### -ADDomainNetBIOS
-If the record relates to an Active Directory account, then you must specify the Active Directory NetBIOS value here, as it is stored on the `Administration -> PasswordState Administration -> Active Directory Domains` screen in PasswordState.
-
-```yaml
-Type: String
-Parameter Sets: Heartbeat, Reset, ResetSchedule
-Aliases:
-
-Required: False
-Position: 4
-Default value: None
-Accept pipeline input: True (ByPropertyName)
-Accept wildcard characters: False
-```
-
 ### -AccountType
 The name of the Account Type if one has been chosen for the Password record.  
 You can either specify the AccountType or AccountTypeID if needed when adding password records. Account Types and their ID values can be seen on the screen `Administration -> Passwordstate Administration -> Images and Account Types`, and click on the '**Toggle ID Column Visibility**' button to determine the appropriate value.
@@ -220,6 +205,21 @@ Accept pipeline input: True (ByPropertyName)
 Accept wildcard characters: False
 ```
 
+### -ADDomainNetBIOS
+If the record relates to an Active Directory account, then you must specify the Active Directory NetBIOS value here, as it is stored on the `Administration -> PasswordState Administration -> Active Directory Domains` screen in PasswordState.
+
+```yaml
+Type: String
+Parameter Sets: Heartbeat, Reset, ResetSchedule
+Aliases:
+
+Required: False
+Position: 4
+Default value: None
+Accept pipeline input: True (ByPropertyName)
+Accept wildcard characters: False
+```
+
 ### -AllowExport
 Indicates whether this Password object will be exported when the entire Password List contents are exported.  
 Only working if "Allow Password List to be Exported" is set on the password list.
@@ -233,21 +233,6 @@ Required: False
 Position: 25
 Default value: None
 Accept pipeline input: True (ByPropertyName)
-Accept wildcard characters: False
-```
-
-### -Confirm
-Prompts you for confirmation before running the cmdlet.
-
-```yaml
-Type: SwitchParameter
-Parameter Sets: (All)
-Aliases: cf
-
-Required: False
-Position: Named
-Default value: None
-Accept pipeline input: False
 Accept wildcard characters: False
 ```
 
@@ -851,6 +836,21 @@ Required: False
 Position: 25
 Default value: None
 Accept pipeline input: True (ByPropertyName)
+Accept wildcard characters: False
+```
+
+### -Confirm
+Prompts you for confirmation before running the cmdlet.
+
+```yaml
+Type: SwitchParameter
+Parameter Sets: (All)
+Aliases: cf
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
 Accept wildcard characters: False
 ```
 

--- a/docs/New-PasswordStatePasswordPermission.md
+++ b/docs/New-PasswordStatePasswordPermission.md
@@ -100,21 +100,6 @@ Accept pipeline input: True (ByPropertyName)
 Accept wildcard characters: False
 ```
 
-### -Confirm
-Prompts you for confirmation before running the cmdlet.
-
-```yaml
-Type: SwitchParameter
-Parameter Sets: (All)
-Aliases: cf
-
-Required: False
-Position: Named
-Default value: None
-Accept pipeline input: False
-Accept wildcard characters: False
-```
-
 ### -PasswordID
 Unique identifier for the Password.
 
@@ -159,6 +144,21 @@ Required: False
 Position: 4
 Default value: None
 Accept pipeline input: True (ByPropertyName)
+Accept wildcard characters: False
+```
+
+### -Confirm
+Prompts you for confirmation before running the cmdlet.
+
+```yaml
+Type: SwitchParameter
+Parameter Sets: (All)
+Aliases: cf
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
 Accept wildcard characters: False
 ```
 

--- a/docs/New-RandomPassword.md
+++ b/docs/New-RandomPassword.md
@@ -46,67 +46,6 @@ New-RandomPassword -PolicyID 2
 
 ## PARAMETERS
 
-### -Confirm
-Prompts you for confirmation before running the cmdlet.
-
-```yaml
-Type: SwitchParameter
-Parameter Sets: (All)
-Aliases: cf
-
-Required: False
-Position: Named
-Default value: None
-Accept pipeline input: False
-Accept wildcard characters: False
-```
-
-### -PolicyID
-ID for an existing Password Generator ID
-
-```yaml
-Type: Int32
-Parameter Sets: PolicyID
-Aliases:
-
-Required: True
-Position: 0
-Default value: 0
-Accept pipeline input: True (ByPropertyName)
-Accept wildcard characters: False
-```
-
-### -Quantity
-The quantity of passwords to generate.
-
-```yaml
-Type: Int32
-Parameter Sets: (All)
-Aliases:
-
-Required: False
-Position: Named
-Default value: 1
-Accept pipeline input: True (ByPropertyName)
-Accept wildcard characters: False
-```
-
-### -WhatIf
-Shows what would happen if the cmdlet runs.
-The cmdlet is not run.
-
-```yaml
-Type: SwitchParameter
-Parameter Sets: (All)
-Aliases: wi
-
-Required: False
-Position: Named
-Default value: None
-Accept pipeline input: False
-Accept wildcard characters: False
-```
-
 ### -excludedcharacters
 {{Fill excludedcharacters Description}}
 
@@ -209,6 +148,67 @@ Required: False
 Position: 0
 Default value: 12
 Accept pipeline input: True (ByPropertyName)
+Accept wildcard characters: False
+```
+
+### -PolicyID
+ID for an existing Password Generator ID
+
+```yaml
+Type: Int32
+Parameter Sets: PolicyID
+Aliases:
+
+Required: True
+Position: 0
+Default value: 0
+Accept pipeline input: True (ByPropertyName)
+Accept wildcard characters: False
+```
+
+### -Quantity
+The quantity of passwords to generate.
+
+```yaml
+Type: Int32
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: Named
+Default value: 1
+Accept pipeline input: True (ByPropertyName)
+Accept wildcard characters: False
+```
+
+### -Confirm
+Prompts you for confirmation before running the cmdlet.
+
+```yaml
+Type: SwitchParameter
+Parameter Sets: (All)
+Aliases: cf
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -WhatIf
+Shows what would happen if the cmdlet runs.
+The cmdlet is not run.
+
+```yaml
+Type: SwitchParameter
+Parameter Sets: (All)
+Aliases: wi
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
 Accept wildcard characters: False
 ```
 

--- a/docs/New-RandomPassword.md
+++ b/docs/New-RandomPassword.md
@@ -47,7 +47,7 @@ New-RandomPassword -PolicyID 2
 ## PARAMETERS
 
 ### -excludedcharacters
-{{Fill excludedcharacters Description}}
+I characters should be excluded, add them here.
 
 ```yaml
 Type: String

--- a/docs/Remove-PasswordStateHost.md
+++ b/docs/Remove-PasswordStateHost.md
@@ -31,21 +31,6 @@ Deletes the host testhostname.domain.
 
 ## PARAMETERS
 
-### -Confirm
-Prompts you for confirmation before running the cmdlet.
-
-```yaml
-Type: SwitchParameter
-Parameter Sets: (All)
-Aliases: cf
-
-Required: False
-Position: Named
-Default value: None
-Accept pipeline input: False
-Accept wildcard characters: False
-```
-
 ### -HostName
 The exact hostname for the host you want to remove
 
@@ -88,6 +73,21 @@ Required: False
 Position: 1
 Default value: None
 Accept pipeline input: True (ByPropertyName)
+Accept wildcard characters: False
+```
+
+### -Confirm
+Prompts you for confirmation before running the cmdlet.
+
+```yaml
+Type: SwitchParameter
+Parameter Sets: (All)
+Aliases: cf
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
 Accept wildcard characters: False
 ```
 

--- a/docs/Remove-PasswordStatePassword.md
+++ b/docs/Remove-PasswordStatePassword.md
@@ -31,21 +31,6 @@ Returns the test user object including password.
 
 ## PARAMETERS
 
-### -Confirm
-Prompts you for confirmation before running the cmdlet.
-
-```yaml
-Type: SwitchParameter
-Parameter Sets: (All)
-Aliases: cf
-
-Required: False
-Position: Named
-Default value: None
-Accept pipeline input: False
-Accept wildcard characters: False
-```
-
 ### -PasswordID
 ID value of the entry to delete.
 Int32 value
@@ -77,6 +62,21 @@ Accept pipeline input: True (ByPropertyName)
 Accept wildcard characters: False
 ```
 
+### -reason
+A reason which can be logged for auditing of why a password was removed.
+
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: 2
+Default value: None
+Accept pipeline input: True (ByPropertyName)
+Accept wildcard characters: False
+```
+
 ### -SendToRecycleBin
 Send the password to the recyclebin or permenant delete.
 
@@ -89,6 +89,21 @@ Required: False
 Position: 1
 Default value: False
 Accept pipeline input: True (ByValue)
+Accept wildcard characters: False
+```
+
+### -Confirm
+Prompts you for confirmation before running the cmdlet.
+
+```yaml
+Type: SwitchParameter
+Parameter Sets: (All)
+Aliases: cf
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
 Accept wildcard characters: False
 ```
 
@@ -105,21 +120,6 @@ Required: False
 Position: Named
 Default value: None
 Accept pipeline input: False
-Accept wildcard characters: False
-```
-
-### -reason
-A reason which can be logged for auditing of why a password was removed.
-
-```yaml
-Type: String
-Parameter Sets: (All)
-Aliases:
-
-Required: False
-Position: 2
-Default value: None
-Accept pipeline input: True (ByPropertyName)
 Accept wildcard characters: False
 ```
 

--- a/docs/Remove-PasswordStatePassword.md
+++ b/docs/Remove-PasswordStatePassword.md
@@ -48,7 +48,7 @@ Accept wildcard characters: False
 ```
 
 ### -PreventAuditing
-{{Fill PreventAuditing Description}}
+By default, the creation/modification or retrieval of (all) Passwords records will add one Audit record for every Password record returned. If you wish to prevent audit records from being added, you can add this `-PreventAuditing` parameter.
 
 ```yaml
 Type: SwitchParameter

--- a/docs/Save-PasswordStateDocument.md
+++ b/docs/Save-PasswordStateDocument.md
@@ -35,7 +35,7 @@ Find-PasswordStatePassword test | Save-PasswordStateDocument -Path C:\temp\1.csv
 ## PARAMETERS
 
 ### -DocumentID
-{{Fill DocumentID Description}}
+The ID of the document that will be uploaded.
 
 ```yaml
 Type: Int32

--- a/docs/Set-PasswordStateEnvironment.md
+++ b/docs/Set-PasswordStateEnvironment.md
@@ -84,7 +84,7 @@ Accept wildcard characters: False
 ```
 
 ### -PasswordGeneratorAPIkey
-{{Fill PasswordGeneratorAPIkey Description}}
+The API Key for the password generator usage.
 
 ```yaml
 Type: String
@@ -99,7 +99,7 @@ Accept wildcard characters: False
 ```
 
 ### -path
-{{ Fill path Description }}
+The path to the json configuration file for the passwordstate environment.
 
 ```yaml
 Type: String
@@ -114,7 +114,7 @@ Accept wildcard characters: False
 ```
 
 ### -SetPlainTextPasswords
-{{ Fill SetPlainTextPasswords Description }}
+Set to true, if plaintext passwords shall be displayed.
 
 ```yaml
 Type: Boolean
@@ -129,7 +129,7 @@ Accept wildcard characters: False
 ```
 
 ### -Uri
-{{ Fill Uri Description }}
+The url of the passwordstate website.
 
 ```yaml
 Type: Uri

--- a/docs/Set-PasswordStateEnvironment.md
+++ b/docs/Set-PasswordStateEnvironment.md
@@ -14,20 +14,20 @@ Saves your password state environment configuration to be used when calling the 
 
 ### Two (Default)
 ```
-Set-PasswordStateEnvironment -Baseuri <String> [-WindowsAuthOnly] [-path <String>] [-WhatIf] [-Confirm]
- [<CommonParameters>]
+Set-PasswordStateEnvironment -Uri <Uri> [-WindowsAuthOnly] [-path <String>] [-SetPlainTextPasswords <Boolean>]
+ [-WhatIf] [-Confirm] [<CommonParameters>]
 ```
 
 ### One
 ```
-Set-PasswordStateEnvironment -Baseuri <String> [-Apikey <String>] [-PasswordGeneratorAPIkey <String>]
- [-path <String>] [-WhatIf] [-Confirm] [<CommonParameters>]
+Set-PasswordStateEnvironment -Uri <Uri> [-Apikey <String>] [-PasswordGeneratorAPIkey <String>] [-path <String>]
+ [-SetPlainTextPasswords <Boolean>] [-WhatIf] [-Confirm] [<CommonParameters>]
 ```
 
 ### Three
 ```
-Set-PasswordStateEnvironment -Baseuri <String> [-customcredentials <PSCredential>] [-path <String>] [-WhatIf]
- [-Confirm] [<CommonParameters>]
+Set-PasswordStateEnvironment -Uri <Uri> [-customcredentials <PSCredential>] [-path <String>]
+ [-SetPlainTextPasswords <Boolean>] [-WhatIf] [-Confirm] [<CommonParameters>]
 ```
 
 ## DESCRIPTION
@@ -68,34 +68,18 @@ Accept pipeline input: True (ByPropertyName)
 Accept wildcard characters: False
 ```
 
-### -Baseuri
-The base url of the passwordstate server.
-eg https://passwordstate
+### -customcredentials
+For use if windows custom credentials is the preferred authentication method.
 
 ```yaml
-Type: String
-Parameter Sets: (All)
+Type: PSCredential
+Parameter Sets: Three
 Aliases:
-
-Required: True
-Position: Named
-Default value: None
-Accept pipeline input: True (ByPropertyName)
-Accept wildcard characters: False
-```
-
-### -Confirm
-Prompts you for confirmation before running the cmdlet.
-
-```yaml
-Type: SwitchParameter
-Parameter Sets: (All)
-Aliases: cf
 
 Required: False
 Position: Named
 Default value: None
-Accept pipeline input: False
+Accept pipeline input: True (ByPropertyName)
 Accept wildcard characters: False
 ```
 
@@ -105,52 +89,6 @@ Accept wildcard characters: False
 ```yaml
 Type: String
 Parameter Sets: One
-Aliases:
-
-Required: False
-Position: Named
-Default value: None
-Accept pipeline input: True (ByPropertyName)
-Accept wildcard characters: False
-```
-
-### -WhatIf
-Shows what would happen if the cmdlet runs.
-The cmdlet is not run.
-
-```yaml
-Type: SwitchParameter
-Parameter Sets: (All)
-Aliases: wi
-
-Required: False
-Position: Named
-Default value: None
-Accept pipeline input: False
-Accept wildcard characters: False
-```
-
-### -WindowsAuthOnly
-For use if Windows Passthrough is the preferred authentication method.
-
-```yaml
-Type: SwitchParameter
-Parameter Sets: Two
-Aliases:
-
-Required: False
-Position: Named
-Default value: False
-Accept pipeline input: True (ByPropertyName)
-Accept wildcard characters: False
-```
-
-### -customcredentials
-For use if windows custom credentials is the preferred authentication method.
-
-```yaml
-Type: PSCredential
-Parameter Sets: Three
 Aliases:
 
 Required: False
@@ -172,6 +110,82 @@ Required: False
 Position: Named
 Default value: None
 Accept pipeline input: True (ByPropertyName)
+Accept wildcard characters: False
+```
+
+### -SetPlainTextPasswords
+{{ Fill SetPlainTextPasswords Description }}
+
+```yaml
+Type: Boolean
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -Uri
+{{ Fill Uri Description }}
+
+```yaml
+Type: Uri
+Parameter Sets: (All)
+Aliases: Baseuri
+
+Required: True
+Position: Named
+Default value: None
+Accept pipeline input: True (ByPropertyName)
+Accept wildcard characters: False
+```
+
+### -WindowsAuthOnly
+For use if Windows Passthrough is the preferred authentication method.
+
+```yaml
+Type: SwitchParameter
+Parameter Sets: Two
+Aliases:
+
+Required: False
+Position: Named
+Default value: False
+Accept pipeline input: True (ByPropertyName)
+Accept wildcard characters: False
+```
+
+### -Confirm
+Prompts you for confirmation before running the cmdlet.
+
+```yaml
+Type: SwitchParameter
+Parameter Sets: (All)
+Aliases: cf
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -WhatIf
+Shows what would happen if the cmdlet runs.
+The cmdlet is not run.
+
+```yaml
+Type: SwitchParameter
+Parameter Sets: (All)
+Aliases: wi
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
 Accept wildcard characters: False
 ```
 

--- a/docs/Set-PasswordStatePassword.md
+++ b/docs/Set-PasswordStatePassword.md
@@ -36,18 +36,18 @@ Updates the password to "76y288uneeko%%%2A" for the entry named testuser01
 
 ## PARAMETERS
 
-### -Confirm
-Prompts you for confirmation before running the cmdlet.
+### -domain
+Updated domain value
 
 ```yaml
-Type: SwitchParameter
+Type: String
 Parameter Sets: (All)
-Aliases: cf
+Aliases:
 
 Required: False
-Position: Named
+Position: 4
 Default value: None
-Accept pipeline input: False
+Accept pipeline input: True (ByPropertyName)
 Accept wildcard characters: False
 ```
 
@@ -201,52 +201,6 @@ Accept pipeline input: True (ByPropertyName)
 Accept wildcard characters: False
 ```
 
-### -PreventAuditing
-{{Fill PreventAuditing Description}}
-
-```yaml
-Type: SwitchParameter
-Parameter Sets: (All)
-Aliases:
-
-Required: False
-Position: 19
-Default value: False
-Accept pipeline input: True (ByPropertyName)
-Accept wildcard characters: False
-```
-
-### -WhatIf
-Shows what would happen if the cmdlet runs.
-The cmdlet is not run.
-
-```yaml
-Type: SwitchParameter
-Parameter Sets: (All)
-Aliases: wi
-
-Required: False
-Position: Named
-Default value: None
-Accept pipeline input: False
-Accept wildcard characters: False
-```
-
-### -domain
-Updated domain value
-
-```yaml
-Type: String
-Parameter Sets: (All)
-Aliases:
-
-Required: False
-Position: 4
-Default value: None
-Accept pipeline input: True (ByPropertyName)
-Accept wildcard characters: False
-```
-
 ### -hostname
 Updated hostname value
 
@@ -303,6 +257,21 @@ Aliases:
 Required: True
 Position: 0
 Default value: 0
+Accept pipeline input: True (ByPropertyName)
+Accept wildcard characters: False
+```
+
+### -PreventAuditing
+{{Fill PreventAuditing Description}}
+
+```yaml
+Type: SwitchParameter
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: 19
+Default value: False
 Accept pipeline input: True (ByPropertyName)
 Accept wildcard characters: False
 ```
@@ -364,6 +333,37 @@ Required: False
 Position: 3
 Default value: None
 Accept pipeline input: True (ByPropertyName)
+Accept wildcard characters: False
+```
+
+### -Confirm
+Prompts you for confirmation before running the cmdlet.
+
+```yaml
+Type: SwitchParameter
+Parameter Sets: (All)
+Aliases: cf
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -WhatIf
+Shows what would happen if the cmdlet runs.
+The cmdlet is not run.
+
+```yaml
+Type: SwitchParameter
+Parameter Sets: (All)
+Aliases: wi
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
 Accept wildcard characters: False
 ```
 

--- a/docs/Set-PasswordStatePassword.md
+++ b/docs/Set-PasswordStatePassword.md
@@ -262,7 +262,7 @@ Accept wildcard characters: False
 ```
 
 ### -PreventAuditing
-{{Fill PreventAuditing Description}}
+By default, the creation/modification or retrieval of (all) Passwords records will add one Audit record for every Password record returned. If you wish to prevent audit records from being added, you can add this `-PreventAuditing` parameter.
 
 ```yaml
 Type: SwitchParameter

--- a/docs/Set-PasswordStatePassword.md
+++ b/docs/Set-PasswordStatePassword.md
@@ -52,7 +52,10 @@ Accept wildcard characters: False
 ```
 
 ### -GenericField1
-{{Fill GenericField1 Description}}
+An optional parameter to set the generic field value.  
+A generic field is a string field which can be renamed to a different value when being displayed in the PasswordState web interface.
+
+**Note**: Generic Fields can be configured as different Field Types, so ensure you pass a valid value for text fields, Select Lists, Radio Buttons or Date Fields.
 
 ```yaml
 Type: String
@@ -67,7 +70,10 @@ Accept wildcard characters: False
 ```
 
 ### -GenericField10
-{{Fill GenericField10 Description}}
+An optional parameter to set the generic field value.  
+A generic field is a string field which can be renamed to a different value when being displayed in the PasswordState web interface.
+
+**Note**: Generic Fields can be configured as different Field Types, so ensure you pass a valid value for text fields, Select Lists, Radio Buttons or Date Fields.
 
 ```yaml
 Type: String
@@ -82,7 +88,10 @@ Accept wildcard characters: False
 ```
 
 ### -GenericField2
-{{Fill GenericField2 Description}}
+An optional parameter to set the generic field value.  
+A generic field is a string field which can be renamed to a different value when being displayed in the PasswordState web interface.
+
+**Note**: Generic Fields can be configured as different Field Types, so ensure you pass a valid value for text fields, Select Lists, Radio Buttons or Date Fields.
 
 ```yaml
 Type: String
@@ -97,7 +106,10 @@ Accept wildcard characters: False
 ```
 
 ### -GenericField3
-{{Fill GenericField3 Description}}
+An optional parameter to set the generic field value.  
+A generic field is a string field which can be renamed to a different value when being displayed in the PasswordState web interface.
+
+**Note**: Generic Fields can be configured as different Field Types, so ensure you pass a valid value for text fields, Select Lists, Radio Buttons or Date Fields.
 
 ```yaml
 Type: String
@@ -112,7 +124,10 @@ Accept wildcard characters: False
 ```
 
 ### -GenericField4
-{{Fill GenericField4 Description}}
+An optional parameter to set the generic field value.  
+A generic field is a string field which can be renamed to a different value when being displayed in the PasswordState web interface.
+
+**Note**: Generic Fields can be configured as different Field Types, so ensure you pass a valid value for text fields, Select Lists, Radio Buttons or Date Fields.
 
 ```yaml
 Type: String
@@ -127,7 +142,10 @@ Accept wildcard characters: False
 ```
 
 ### -GenericField5
-{{Fill GenericField5 Description}}
+An optional parameter to set the generic field value.  
+A generic field is a string field which can be renamed to a different value when being displayed in the PasswordState web interface.
+
+**Note**: Generic Fields can be configured as different Field Types, so ensure you pass a valid value for text fields, Select Lists, Radio Buttons or Date Fields.
 
 ```yaml
 Type: String
@@ -142,7 +160,10 @@ Accept wildcard characters: False
 ```
 
 ### -GenericField6
-{{Fill GenericField6 Description}}
+An optional parameter to set the generic field value.  
+A generic field is a string field which can be renamed to a different value when being displayed in the PasswordState web interface.
+
+**Note**: Generic Fields can be configured as different Field Types, so ensure you pass a valid value for text fields, Select Lists, Radio Buttons or Date Fields.
 
 ```yaml
 Type: String
@@ -157,7 +178,10 @@ Accept wildcard characters: False
 ```
 
 ### -GenericField7
-{{Fill GenericField7 Description}}
+An optional parameter to set the generic field value.  
+A generic field is a string field which can be renamed to a different value when being displayed in the PasswordState web interface.
+
+**Note**: Generic Fields can be configured as different Field Types, so ensure you pass a valid value for text fields, Select Lists, Radio Buttons or Date Fields.
 
 ```yaml
 Type: String
@@ -172,7 +196,10 @@ Accept wildcard characters: False
 ```
 
 ### -GenericField8
-{{Fill GenericField8 Description}}
+An optional parameter to set the generic field value.  
+A generic field is a string field which can be renamed to a different value when being displayed in the PasswordState web interface.
+
+**Note**: Generic Fields can be configured as different Field Types, so ensure you pass a valid value for text fields, Select Lists, Radio Buttons or Date Fields.
 
 ```yaml
 Type: String
@@ -187,7 +214,10 @@ Accept wildcard characters: False
 ```
 
 ### -GenericField9
-{{Fill GenericField9 Description}}
+An optional parameter to set the generic field value.  
+A generic field is a string field which can be renamed to a different value when being displayed in the PasswordState web interface.
+
+**Note**: Generic Fields can be configured as different Field Types, so ensure you pass a valid value for text fields, Select Lists, Radio Buttons or Date Fields.
 
 ```yaml
 Type: String

--- a/en-us/passwordstate-management-help.xml
+++ b/en-us/passwordstate-management-help.xml
@@ -1103,10 +1103,23 @@ The `ExpiryDate` is a date in which the password value should be reset for the P
           </dev:type>
           <dev:defaultValue>False</dev:defaultValue>
         </command:parameter>
-        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="3" aliases="Domain">
+        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="28" aliases="none">
           <maml:name>ADDomainNetBIOS</maml:name>
           <maml:Description>
             <maml:para>If you want to search for a record that relates to an Active Directory account, then you can specify the Active Directory NetBIOS value here, as it is stored on the `Administration -&gt; PasswordState Administration -&gt; Active Directory Domains` screen in PasswordState or found in a password record if set.</maml:para>
+          </maml:Description>
+          <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+          <dev:type>
+            <maml:name>String</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="3" aliases="none">
+          <maml:name>Domain</maml:name>
+          <maml:Description>
+            <maml:para>Optionally search for a password object that relates to an Active Directory Account.
+If the password relates to an Active Directory Account, then this record will show the NetBIOS value for the domain.</maml:para>
           </maml:Description>
           <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
           <dev:type>
@@ -1309,7 +1322,7 @@ Account Types and their ID values can be seen on the screen `Administration -&gt
         </dev:type>
         <dev:defaultValue>None</dev:defaultValue>
       </command:parameter>
-      <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="3" aliases="Domain">
+      <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="28" aliases="none">
         <maml:name>ADDomainNetBIOS</maml:name>
         <maml:Description>
           <maml:para>If you want to search for a record that relates to an Active Directory account, then you can specify the Active Directory NetBIOS value here, as it is stored on the `Administration -&gt; PasswordState Administration -&gt; Active Directory Domains` screen in PasswordState or found in a password record if set.</maml:para>
@@ -1338,6 +1351,19 @@ Account Types and their ID values can be seen on the screen `Administration -&gt
         <maml:name>Description</maml:name>
         <maml:Description>
           <maml:para>An optional parameter to filter the search on description. The description is generally used as a longer verbose description of the nature of the Password object.</maml:para>
+        </maml:Description>
+        <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+        <dev:type>
+          <maml:name>String</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="3" aliases="none">
+        <maml:name>Domain</maml:name>
+        <maml:Description>
+          <maml:para>Optionally search for a password object that relates to an Active Directory Account.
+If the password relates to an Active Directory Account, then this record will show the NetBIOS value for the domain.</maml:para>
         </maml:Description>
         <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
         <dev:type>

--- a/en-us/passwordstate-management-help.xml
+++ b/en-us/passwordstate-management-help.xml
@@ -767,11 +767,62 @@
       <command:verb>Get</command:verb>
       <command:noun>PasswordStatePassword</command:noun>
       <maml:description>
-        <maml:para>Finds a password state entry and returns the object. If multiple matches it will return multiple entries.</maml:para>
+        <maml:para>Finds a PasswordState password entry and returns the object. If multiple matches it will return multiple entries.</maml:para>
       </maml:description>
     </command:details>
     <maml:description>
-      <maml:para>Finds a password state entry and returns the object. If multiple matches it will return multiple entries.</maml:para>
+      <maml:para>Finds a PasswordState password entry and returns the object. If multiple matches it will return multiple entries.</maml:para>
+      <maml:para> There are two ways in which you can search for Passwords via the API, and you can search just within a single Password List, or across all Shared Passwords Lists. The two search methods are:</maml:para>
+      <maml:para>- Via a General Search across the majority of fields in the Passwords table - Via Specific Search criteria, based on fields and values you specify General Search When performing a General Search , it will query the Passwords table for fields which Contain the value you specify for the `-Search` parameter.
+You do not need to specify another parameter than `Search` (Also Search is the first parameter, so you generally do not need to specify the parameter name (`Get-PasswordStatePassword "test123"`)).
+All the fields which will be searched are:</maml:para>
+      <maml:para>- Title</maml:para>
+      <maml:para>- ADDomainNetBIOS</maml:para>
+      <maml:para>- HostName</maml:para>
+      <maml:para>- UserName</maml:para>
+      <maml:para>- AccountType</maml:para>
+      <maml:para>- Description</maml:para>
+      <maml:para>- GenericField1</maml:para>
+      <maml:para>- GenericField2</maml:para>
+      <maml:para>- GenericField3</maml:para>
+      <maml:para>- GenericField4</maml:para>
+      <maml:para>- GenericField5</maml:para>
+      <maml:para>- GenericField6</maml:para>
+      <maml:para>- GenericField7</maml:para>
+      <maml:para>- GenericField8</maml:para>
+      <maml:para>- GenericField9</maml:para>
+      <maml:para>- GenericField10</maml:para>
+      <maml:para>- Notes</maml:para>
+      <maml:para>- URL</maml:para>
+      <maml:para>- SiteID</maml:para>
+      <maml:para>- SiteLocation Specific Search When performing a Specific Search , it will query the Passwords table based on one or more of the parameters you specify.
+Just add one of the following parameter to the script execution.
+The fields which can be searched are:</maml:para>
+      <maml:para>- Title</maml:para>
+      <maml:para>- HostName</maml:para>
+      <maml:para>- ADDomainNetBIOS</maml:para>
+      <maml:para>- UserName</maml:para>
+      <maml:para>- AccountTypeID</maml:para>
+      <maml:para>- AccountType</maml:para>
+      <maml:para>- Description</maml:para>
+      <maml:para>- GenericField1</maml:para>
+      <maml:para>- GenericField2</maml:para>
+      <maml:para>- GenericField3</maml:para>
+      <maml:para>- GenericField4</maml:para>
+      <maml:para>- GenericField5</maml:para>
+      <maml:para>- GenericField6</maml:para>
+      <maml:para>- GenericField7</maml:para>
+      <maml:para>- GenericField8</maml:para>
+      <maml:para>- GenericField9</maml:para>
+      <maml:para>- GenericField10</maml:para>
+      <maml:para>- Notes</maml:para>
+      <maml:para>- URL</maml:para>
+      <maml:para>- SiteID</maml:para>
+      <maml:para>- SiteLocation</maml:para>
+      <maml:para>- PasswordResetEnabled</maml:para>
+      <maml:para>- ExpiryDate</maml:para>
+      <maml:para>- ExpiryDateRange</maml:para>
+      <maml:para>- AndOr Note 1 : You can perform an exact match search by enclosing your search criteria in double quotes i.e. '"root_admin"' Note 2 : By default, the retrieval of (all) Passwords records will add one Audit record for every Password record returned. If you wish to prevent audit records from being added, you can add the `-PreventAuditing` parameter.</maml:para>
     </maml:description>
     <command:syntax>
       <command:syntaxItem>
@@ -779,7 +830,8 @@
         <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="0" aliases="none">
           <maml:name>Title</maml:name>
           <maml:Description>
-            <maml:para>A string value which should match the passwordstate entry.</maml:para>
+            <maml:para>A string value which should match the PasswordState entry.
+A title is a name that describes the nature of the Password object.</maml:para>
           </maml:Description>
           <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
           <dev:type>
@@ -791,7 +843,9 @@
         <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="1" aliases="none">
           <maml:name>UserName</maml:name>
           <maml:Description>
-            <maml:para>An optional parameter to filter searches to those with a certain username as multiple titles may have the same value.</maml:para>
+            <maml:para>An optional parameter to filter searches to those with a certain username as multiple titles may have the same value.
+Some systems require a username and password to authenticate. This field represents the UserName to do so.
+</maml:para>
           </maml:Description>
           <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
           <dev:type>
@@ -803,7 +857,8 @@
         <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="10" aliases="none">
           <maml:name>GenericField1</maml:name>
           <maml:Description>
-            <maml:para>An optional parameter to filter the search on a generic field.</maml:para>
+            <maml:para>An optional parameter to filter the search on a generic field.
+A generic field is a string field which can be renamed to a different value when being displayed in the PasswordState web interface. Note : Generic Fields can be configured as different Field Types, so ensure you pass a valid value for text fields, Select Lists, Radio Buttons or Date Fields.</maml:para>
           </maml:Description>
           <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
           <dev:type>
@@ -815,7 +870,8 @@
         <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="11" aliases="none">
           <maml:name>GenericField2</maml:name>
           <maml:Description>
-            <maml:para>An optional parameter to filter the search on a generic field.</maml:para>
+            <maml:para>An optional parameter to filter the search on a generic field.
+A generic field is a string field which can be renamed to a different value when being displayed in the PasswordState web interface. Note : Generic Fields can be configured as different Field Types, so ensure you pass a valid value for text fields, Select Lists, Radio Buttons or Date Fields.</maml:para>
           </maml:Description>
           <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
           <dev:type>
@@ -827,7 +883,8 @@
         <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="12" aliases="none">
           <maml:name>GenericField3</maml:name>
           <maml:Description>
-            <maml:para>An optional parameter to filter the search on a generic field.</maml:para>
+            <maml:para>An optional parameter to filter the search on a generic field.
+A generic field is a string field which can be renamed to a different value when being displayed in the PasswordState web interface. Note : Generic Fields can be configured as different Field Types, so ensure you pass a valid value for text fields, Select Lists, Radio Buttons or Date Fields.</maml:para>
           </maml:Description>
           <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
           <dev:type>
@@ -839,7 +896,8 @@
         <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="13" aliases="none">
           <maml:name>GenericField4</maml:name>
           <maml:Description>
-            <maml:para>An optional parameter to filter the search on a generic field.</maml:para>
+            <maml:para>An optional parameter to filter the search on a generic field.
+A generic field is a string field which can be renamed to a different value when being displayed in the PasswordState web interface. Note : Generic Fields can be configured as different Field Types, so ensure you pass a valid value for text fields, Select Lists, Radio Buttons or Date Fields.</maml:para>
           </maml:Description>
           <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
           <dev:type>
@@ -851,7 +909,8 @@
         <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="14" aliases="none">
           <maml:name>GenericField5</maml:name>
           <maml:Description>
-            <maml:para>An optional parameter to filter the search on a generic field.</maml:para>
+            <maml:para>An optional parameter to filter the search on a generic field.
+A generic field is a string field which can be renamed to a different value when being displayed in the PasswordState web interface. Note : Generic Fields can be configured as different Field Types, so ensure you pass a valid value for text fields, Select Lists, Radio Buttons or Date Fields.</maml:para>
           </maml:Description>
           <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
           <dev:type>
@@ -863,7 +922,8 @@
         <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="15" aliases="none">
           <maml:name>GenericField6</maml:name>
           <maml:Description>
-            <maml:para>An optional parameter to filter the search on a generic field.</maml:para>
+            <maml:para>An optional parameter to filter the search on a generic field.
+A generic field is a string field which can be renamed to a different value when being displayed in the PasswordState web interface. Note : Generic Fields can be configured as different Field Types, so ensure you pass a valid value for text fields, Select Lists, Radio Buttons or Date Fields.</maml:para>
           </maml:Description>
           <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
           <dev:type>
@@ -875,7 +935,8 @@
         <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="16" aliases="none">
           <maml:name>GenericField7</maml:name>
           <maml:Description>
-            <maml:para>An optional parameter to filter the search on a generic field.</maml:para>
+            <maml:para>An optional parameter to filter the search on a generic field.
+A generic field is a string field which can be renamed to a different value when being displayed in the PasswordState web interface. Note : Generic Fields can be configured as different Field Types, so ensure you pass a valid value for text fields, Select Lists, Radio Buttons or Date Fields.</maml:para>
           </maml:Description>
           <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
           <dev:type>
@@ -887,7 +948,8 @@
         <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="17" aliases="none">
           <maml:name>GenericField8</maml:name>
           <maml:Description>
-            <maml:para>An optional parameter to filter the search on a generic field.</maml:para>
+            <maml:para>An optional parameter to filter the search on a generic field.
+A generic field is a string field which can be renamed to a different value when being displayed in the PasswordState web interface. Note : Generic Fields can be configured as different Field Types, so ensure you pass a valid value for text fields, Select Lists, Radio Buttons or Date Fields.</maml:para>
           </maml:Description>
           <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
           <dev:type>
@@ -899,7 +961,8 @@
         <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="18" aliases="none">
           <maml:name>GenericField9</maml:name>
           <maml:Description>
-            <maml:para>An optional parameter to filter the search on a generic field.</maml:para>
+            <maml:para>An optional parameter to filter the search on a generic field.
+A generic field is a string field which can be renamed to a different value when being displayed in the PasswordState web interface. Note : Generic Fields can be configured as different Field Types, so ensure you pass a valid value for text fields, Select Lists, Radio Buttons or Date Fields.</maml:para>
           </maml:Description>
           <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
           <dev:type>
@@ -911,7 +974,8 @@
         <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="19" aliases="none">
           <maml:name>GenericField10</maml:name>
           <maml:Description>
-            <maml:para>An optional parameter to filter the search on a generic field.</maml:para>
+            <maml:para>An optional parameter to filter the search on a generic field.
+A generic field is a string field which can be renamed to a different value when being displayed in the PasswordState web interface. Note : Generic Fields can be configured as different Field Types, so ensure you pass a valid value for text fields, Select Lists, Radio Buttons or Date Fields.</maml:para>
           </maml:Description>
           <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
           <dev:type>
@@ -923,7 +987,8 @@
         <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="2" aliases="none">
           <maml:name>HostName</maml:name>
           <maml:Description>
-            <maml:para>An optional parameter to filter the search on hostname.</maml:para>
+            <maml:para>An optional parameter to filter the search on hostname.
+If the record relates to account on a Host, then you can specify the Host Name here to filter for, as it is stored on the Hosts screen in PasswordState.</maml:para>
           </maml:Description>
           <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
           <dev:type>
@@ -933,6 +998,77 @@
           <dev:defaultValue>None</dev:defaultValue>
         </command:parameter>
         <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="20" aliases="none">
+          <maml:name>AccountTypeID</maml:name>
+          <maml:Description>
+            <maml:para>An optional parameter to filter the search on account type by ID. The ID value representing the Account Type image (derived from the AccountTypes table). An AccountTypeID of 0 (zero) means there is no associated Account Type image for this Password.
+Account Types and their ID values can be seen on the screen `Administration -&gt; Passwordstate Administration -&gt; Images and Account Types`, and click on the ' Toggle ID Column Visibility ' button to determine the appropriate value or on any password record if set.</maml:para>
+          </maml:Description>
+          <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+          <dev:type>
+            <maml:name>String</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="21" aliases="none">
+          <maml:name>PasswordResetEnabled</maml:name>
+          <maml:Description>
+            <maml:para>Search for all password objects where the password reset is enabled.</maml:para>
+          </maml:Description>
+          <dev:type>
+            <maml:name>SwitchParameter</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>False</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="22" aliases="none">
+          <maml:name>ExpiryDate</maml:name>
+          <maml:Description>
+            <maml:para>When performing a Specific Search by the `ExpiryDate` field, it will perform an exact match on this value. If you wish to query based on a date range, then please use `-ExpiryDateRange`.
+The `ExpiryDate` is a date in which the password value should be reset for the Password object. The date will be displayed in the format specified for the System Setting option 'Default Locale', through the PasswordState web site interface. Note: Please specify the ExpiryDate in the date format that you have chosen in `'System Settings - miscellaneous - Default Locale'` (Default: ' YYYY-MM-DD ').</maml:para>
+          </maml:Description>
+          <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+          <dev:type>
+            <maml:name>String</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="23" aliases="none">
+          <maml:name>ExpiryDateRange</maml:name>
+          <maml:Description>
+            <maml:para>Format: `ExpiryDate&gt;=2012-07-14,ExpiryDate&lt;=2020-12-31`</maml:para>
+            <maml:para>It is possible to specify SQL style query syntax for the ExpiryDateRange parameter, so you can construct a query based on date ranges if needed. Examples of the query syntax you can use is (ensure you separate two dates with a single comma):</maml:para>
+            <maml:para>- ExpiryDateRange=ExpiryDate&gt;=2012-07-06,ExpiryDate&lt;=2013-01-01</maml:para>
+            <maml:para>- ExpiryDateRange=ExpiryDate&gt;2012-01-01,ExpiryDate&lt;=2012-02-28</maml:para>
+            <maml:para>- ExpiryDateRange=ExpiryDate&gt;2013-01-01</maml:para>
+            <maml:para>- ExpiryDateRange=ExpiryDate&lt;=2012-11-30 Note : Dates must be supplied in the `ISO 8601` international standard for date format of YYYY-MM-DD .</maml:para>
+          </maml:Description>
+          <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+          <dev:type>
+            <maml:name>String</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="24" aliases="none">
+          <maml:name>AndOr</maml:name>
+          <maml:Description>
+            <maml:para>If parameter is not set, "AND" will be used as default. As you can build up your query string based on one or more fields/parameters, you can also specify how these queries are joined in the SQL query - either using `-AndOr "OR"`, or `-AndOr "AND"`.</maml:para>
+            <maml:para>As you'd expect, using the OR operator will return a greater number of results, while the AND operator will return less results as it is a more specific type of query.</maml:para>
+          </maml:Description>
+          <command:parameterValueGroup>
+            <command:parameterValue required="false" command:variableLength="false">AND</command:parameterValue>
+            <command:parameterValue required="false" command:variableLength="false">OR</command:parameterValue>
+          </command:parameterValueGroup>
+          <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+          <dev:type>
+            <maml:name>String</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="25" aliases="none">
           <maml:name>PasswordListID</maml:name>
           <maml:Description>
             <maml:para>An optional parameter to filter the search on a specific password list.</maml:para>
@@ -944,7 +1080,7 @@
           </dev:type>
           <dev:defaultValue>0</dev:defaultValue>
         </command:parameter>
-        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="21" aliases="none">
+        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="26" aliases="none">
           <maml:name>Reason</maml:name>
           <maml:Description>
             <maml:para>A reason which can be logged for auditing of why a password was retrieved.</maml:para>
@@ -956,10 +1092,10 @@
           </dev:type>
           <dev:defaultValue>None</dev:defaultValue>
         </command:parameter>
-        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="22" aliases="none">
+        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="27" aliases="none">
           <maml:name>PreventAuditing</maml:name>
           <maml:Description>
-            <maml:para>{{Fill PreventAuditing Description}}</maml:para>
+            <maml:para>By default, the retrieval of (all) Passwords records will add one Audit record for every Password record returned. If you wish to prevent audit records from being added, you can add this `-PreventAuditing` parameter.</maml:para>
           </maml:Description>
           <dev:type>
             <maml:name>SwitchParameter</maml:name>
@@ -967,10 +1103,10 @@
           </dev:type>
           <dev:defaultValue>False</dev:defaultValue>
         </command:parameter>
-        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="3" aliases="none">
-          <maml:name>Domain</maml:name>
+        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="3" aliases="Domain">
+          <maml:name>ADDomainNetBIOS</maml:name>
           <maml:Description>
-            <maml:para>An optional parameter to filter the search on domain.</maml:para>
+            <maml:para>If you want to search for a record that relates to an Active Directory account, then you can specify the Active Directory NetBIOS value here, as it is stored on the `Administration -&gt; PasswordState Administration -&gt; Active Directory Domains` screen in PasswordState or found in a password record if set.</maml:para>
           </maml:Description>
           <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
           <dev:type>
@@ -982,7 +1118,8 @@
         <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="4" aliases="none">
           <maml:name>AccountType</maml:name>
           <maml:Description>
-            <maml:para>An optional parameter to filter the search on account type.</maml:para>
+            <maml:para>An optional parameter to filter the search on account type. The name of the Account Type if one has been chosen for the Password record.
+Account Types and their ID values can be seen on the screen `Administration -&gt; Passwordstate Administration -&gt; Images and Account Types`, and click on the ' Toggle ID Column Visibility ' button to determine the appropriate value. You can also find the AccountType inside the password objects if set.</maml:para>
           </maml:Description>
           <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
           <dev:type>
@@ -994,7 +1131,7 @@
         <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="5" aliases="none">
           <maml:name>Description</maml:name>
           <maml:Description>
-            <maml:para>An optional parameter to filter the search on description.</maml:para>
+            <maml:para>An optional parameter to filter the search on description. The description is generally used as a longer verbose description of the nature of the Password object.</maml:para>
           </maml:Description>
           <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
           <dev:type>
@@ -1006,7 +1143,8 @@
         <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="6" aliases="none">
           <maml:name>Notes</maml:name>
           <maml:Description>
-            <maml:para>An optional parameter to filter the search on notes.</maml:para>
+            <maml:para>An optional parameter to filter the search on notes.
+The Notes field are a generic field where additional descriptive text can be added.</maml:para>
           </maml:Description>
           <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
           <dev:type>
@@ -1018,7 +1156,8 @@
         <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="7" aliases="none">
           <maml:name>URL</maml:name>
           <maml:Description>
-            <maml:para>An optional parameter to filter the search on the URL.</maml:para>
+            <maml:para>An optional parameter to filter the search on the URL.
+URL parameter can be the URL for HTTP, HTTPS, FTP, SFTP, etc. found in the password object.</maml:para>
           </maml:Description>
           <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
           <dev:type>
@@ -1030,7 +1169,8 @@
         <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="8" aliases="none">
           <maml:name>SiteID</maml:name>
           <maml:Description>
-            <maml:para>An optional parameter to filter the search on the site ID.</maml:para>
+            <maml:para>An optional parameter to filter the search on the site ID.
+If you do not specify this parameter, it will report data based on all Site Locations. Values are 0 for Internal, and all other SiteID's can be found on the screen `Administration -&gt; Remote Site Administration -&gt; Remote Site Locations`.</maml:para>
           </maml:Description>
           <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
           <dev:type>
@@ -1042,7 +1182,8 @@
         <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="9" aliases="none">
           <maml:name>SiteLocation</maml:name>
           <maml:Description>
-            <maml:para>An optional parameter to filter the search on the site location.</maml:para>
+            <maml:para>An optional parameter to filter the search on the site location.
+If you do not specify this parameter, it will report data based on all Site Locations. Values are the name of the Site Location that can be found on the screen `Administration -&gt; Remote Site Administration -&gt; Remote Site Locations`.</maml:para>
           </maml:Description>
           <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
           <dev:type>
@@ -1057,7 +1198,7 @@
         <command:parameter required="true" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="0" aliases="none">
           <maml:name>PasswordID</maml:name>
           <maml:Description>
-            <maml:para>An ID of a specific password resource to return.</maml:para>
+            <maml:para>An PasswordID value of the password record in PasswordState to return.</maml:para>
           </maml:Description>
           <command:parameterValue required="true" variableLength="false">Int32</command:parameterValue>
           <dev:type>
@@ -1066,7 +1207,7 @@
           </dev:type>
           <dev:defaultValue>0</dev:defaultValue>
         </command:parameter>
-        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="21" aliases="none">
+        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="26" aliases="none">
           <maml:name>Reason</maml:name>
           <maml:Description>
             <maml:para>A reason which can be logged for auditing of why a password was retrieved.</maml:para>
@@ -1078,10 +1219,10 @@
           </dev:type>
           <dev:defaultValue>None</dev:defaultValue>
         </command:parameter>
-        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="22" aliases="none">
+        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="27" aliases="none">
           <maml:name>PreventAuditing</maml:name>
           <maml:Description>
-            <maml:para>{{Fill PreventAuditing Description}}</maml:para>
+            <maml:para>By default, the retrieval of (all) Passwords records will add one Audit record for every Password record returned. If you wish to prevent audit records from being added, you can add this `-PreventAuditing` parameter.</maml:para>
           </maml:Description>
           <dev:type>
             <maml:name>SwitchParameter</maml:name>
@@ -1095,7 +1236,7 @@
         <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName, ByValue)" position="0" aliases="none">
           <maml:name>Search</maml:name>
           <maml:Description>
-            <maml:para>A string value which will be matched with most fields in the database table.</maml:para>
+            <maml:para>A string value which will be matched with most fields in the database table. Check the description section above fore more information which fields will be used for the search.</maml:para>
           </maml:Description>
           <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
           <dev:type>
@@ -1104,7 +1245,7 @@
           </dev:type>
           <dev:defaultValue>%</dev:defaultValue>
         </command:parameter>
-        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="20" aliases="none">
+        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="25" aliases="none">
           <maml:name>PasswordListID</maml:name>
           <maml:Description>
             <maml:para>An optional parameter to filter the search on a specific password list.</maml:para>
@@ -1116,7 +1257,7 @@
           </dev:type>
           <dev:defaultValue>0</dev:defaultValue>
         </command:parameter>
-        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="21" aliases="none">
+        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="26" aliases="none">
           <maml:name>Reason</maml:name>
           <maml:Description>
             <maml:para>A reason which can be logged for auditing of why a password was retrieved.</maml:para>
@@ -1128,10 +1269,10 @@
           </dev:type>
           <dev:defaultValue>None</dev:defaultValue>
         </command:parameter>
-        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="22" aliases="none">
+        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="27" aliases="none">
           <maml:name>PreventAuditing</maml:name>
           <maml:Description>
-            <maml:para>{{Fill PreventAuditing Description}}</maml:para>
+            <maml:para>By default, the retrieval of (all) Passwords records will add one Audit record for every Password record returned. If you wish to prevent audit records from being added, you can add this `-PreventAuditing` parameter.</maml:para>
           </maml:Description>
           <dev:type>
             <maml:name>SwitchParameter</maml:name>
@@ -1145,7 +1286,46 @@
       <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="4" aliases="none">
         <maml:name>AccountType</maml:name>
         <maml:Description>
-          <maml:para>An optional parameter to filter the search on account type.</maml:para>
+          <maml:para>An optional parameter to filter the search on account type. The name of the Account Type if one has been chosen for the Password record.
+Account Types and their ID values can be seen on the screen `Administration -&gt; Passwordstate Administration -&gt; Images and Account Types`, and click on the ' Toggle ID Column Visibility ' button to determine the appropriate value. You can also find the AccountType inside the password objects if set.</maml:para>
+        </maml:Description>
+        <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+        <dev:type>
+          <maml:name>String</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="20" aliases="none">
+        <maml:name>AccountTypeID</maml:name>
+        <maml:Description>
+          <maml:para>An optional parameter to filter the search on account type by ID. The ID value representing the Account Type image (derived from the AccountTypes table). An AccountTypeID of 0 (zero) means there is no associated Account Type image for this Password.
+Account Types and their ID values can be seen on the screen `Administration -&gt; Passwordstate Administration -&gt; Images and Account Types`, and click on the ' Toggle ID Column Visibility ' button to determine the appropriate value or on any password record if set.</maml:para>
+        </maml:Description>
+        <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+        <dev:type>
+          <maml:name>String</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="3" aliases="Domain">
+        <maml:name>ADDomainNetBIOS</maml:name>
+        <maml:Description>
+          <maml:para>If you want to search for a record that relates to an Active Directory account, then you can specify the Active Directory NetBIOS value here, as it is stored on the `Administration -&gt; PasswordState Administration -&gt; Active Directory Domains` screen in PasswordState or found in a password record if set.</maml:para>
+        </maml:Description>
+        <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+        <dev:type>
+          <maml:name>String</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="24" aliases="none">
+        <maml:name>AndOr</maml:name>
+        <maml:Description>
+          <maml:para>If parameter is not set, "AND" will be used as default. As you can build up your query string based on one or more fields/parameters, you can also specify how these queries are joined in the SQL query - either using `-AndOr "OR"`, or `-AndOr "AND"`.</maml:para>
+          <maml:para>As you'd expect, using the OR operator will return a greater number of results, while the AND operator will return less results as it is a more specific type of query.</maml:para>
         </maml:Description>
         <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
         <dev:type>
@@ -1157,7 +1337,7 @@
       <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="5" aliases="none">
         <maml:name>Description</maml:name>
         <maml:Description>
-          <maml:para>An optional parameter to filter the search on description.</maml:para>
+          <maml:para>An optional parameter to filter the search on description. The description is generally used as a longer verbose description of the nature of the Password object.</maml:para>
         </maml:Description>
         <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
         <dev:type>
@@ -1166,10 +1346,28 @@
         </dev:type>
         <dev:defaultValue>None</dev:defaultValue>
       </command:parameter>
-      <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="3" aliases="none">
-        <maml:name>Domain</maml:name>
+      <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="22" aliases="none">
+        <maml:name>ExpiryDate</maml:name>
         <maml:Description>
-          <maml:para>An optional parameter to filter the search on domain.</maml:para>
+          <maml:para>When performing a Specific Search by the `ExpiryDate` field, it will perform an exact match on this value. If you wish to query based on a date range, then please use `-ExpiryDateRange`.
+The `ExpiryDate` is a date in which the password value should be reset for the Password object. The date will be displayed in the format specified for the System Setting option 'Default Locale', through the PasswordState web site interface. Note: Please specify the ExpiryDate in the date format that you have chosen in `'System Settings - miscellaneous - Default Locale'` (Default: ' YYYY-MM-DD ').</maml:para>
+        </maml:Description>
+        <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+        <dev:type>
+          <maml:name>String</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="23" aliases="none">
+        <maml:name>ExpiryDateRange</maml:name>
+        <maml:Description>
+          <maml:para>Format: `ExpiryDate&gt;=2012-07-14,ExpiryDate&lt;=2020-12-31`</maml:para>
+          <maml:para>It is possible to specify SQL style query syntax for the ExpiryDateRange parameter, so you can construct a query based on date ranges if needed. Examples of the query syntax you can use is (ensure you separate two dates with a single comma):</maml:para>
+          <maml:para>- ExpiryDateRange=ExpiryDate&gt;=2012-07-06,ExpiryDate&lt;=2013-01-01</maml:para>
+          <maml:para>- ExpiryDateRange=ExpiryDate&gt;2012-01-01,ExpiryDate&lt;=2012-02-28</maml:para>
+          <maml:para>- ExpiryDateRange=ExpiryDate&gt;2013-01-01</maml:para>
+          <maml:para>- ExpiryDateRange=ExpiryDate&lt;=2012-11-30 Note : Dates must be supplied in the `ISO 8601` international standard for date format of YYYY-MM-DD .</maml:para>
         </maml:Description>
         <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
         <dev:type>
@@ -1181,7 +1379,8 @@
       <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="10" aliases="none">
         <maml:name>GenericField1</maml:name>
         <maml:Description>
-          <maml:para>An optional parameter to filter the search on a generic field.</maml:para>
+          <maml:para>An optional parameter to filter the search on a generic field.
+A generic field is a string field which can be renamed to a different value when being displayed in the PasswordState web interface. Note : Generic Fields can be configured as different Field Types, so ensure you pass a valid value for text fields, Select Lists, Radio Buttons or Date Fields.</maml:para>
         </maml:Description>
         <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
         <dev:type>
@@ -1193,7 +1392,8 @@
       <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="19" aliases="none">
         <maml:name>GenericField10</maml:name>
         <maml:Description>
-          <maml:para>An optional parameter to filter the search on a generic field.</maml:para>
+          <maml:para>An optional parameter to filter the search on a generic field.
+A generic field is a string field which can be renamed to a different value when being displayed in the PasswordState web interface. Note : Generic Fields can be configured as different Field Types, so ensure you pass a valid value for text fields, Select Lists, Radio Buttons or Date Fields.</maml:para>
         </maml:Description>
         <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
         <dev:type>
@@ -1205,7 +1405,8 @@
       <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="11" aliases="none">
         <maml:name>GenericField2</maml:name>
         <maml:Description>
-          <maml:para>An optional parameter to filter the search on a generic field.</maml:para>
+          <maml:para>An optional parameter to filter the search on a generic field.
+A generic field is a string field which can be renamed to a different value when being displayed in the PasswordState web interface. Note : Generic Fields can be configured as different Field Types, so ensure you pass a valid value for text fields, Select Lists, Radio Buttons or Date Fields.</maml:para>
         </maml:Description>
         <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
         <dev:type>
@@ -1217,7 +1418,8 @@
       <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="12" aliases="none">
         <maml:name>GenericField3</maml:name>
         <maml:Description>
-          <maml:para>An optional parameter to filter the search on a generic field.</maml:para>
+          <maml:para>An optional parameter to filter the search on a generic field.
+A generic field is a string field which can be renamed to a different value when being displayed in the PasswordState web interface. Note : Generic Fields can be configured as different Field Types, so ensure you pass a valid value for text fields, Select Lists, Radio Buttons or Date Fields.</maml:para>
         </maml:Description>
         <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
         <dev:type>
@@ -1229,7 +1431,8 @@
       <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="13" aliases="none">
         <maml:name>GenericField4</maml:name>
         <maml:Description>
-          <maml:para>An optional parameter to filter the search on a generic field.</maml:para>
+          <maml:para>An optional parameter to filter the search on a generic field.
+A generic field is a string field which can be renamed to a different value when being displayed in the PasswordState web interface. Note : Generic Fields can be configured as different Field Types, so ensure you pass a valid value for text fields, Select Lists, Radio Buttons or Date Fields.</maml:para>
         </maml:Description>
         <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
         <dev:type>
@@ -1241,7 +1444,8 @@
       <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="14" aliases="none">
         <maml:name>GenericField5</maml:name>
         <maml:Description>
-          <maml:para>An optional parameter to filter the search on a generic field.</maml:para>
+          <maml:para>An optional parameter to filter the search on a generic field.
+A generic field is a string field which can be renamed to a different value when being displayed in the PasswordState web interface. Note : Generic Fields can be configured as different Field Types, so ensure you pass a valid value for text fields, Select Lists, Radio Buttons or Date Fields.</maml:para>
         </maml:Description>
         <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
         <dev:type>
@@ -1253,7 +1457,8 @@
       <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="15" aliases="none">
         <maml:name>GenericField6</maml:name>
         <maml:Description>
-          <maml:para>An optional parameter to filter the search on a generic field.</maml:para>
+          <maml:para>An optional parameter to filter the search on a generic field.
+A generic field is a string field which can be renamed to a different value when being displayed in the PasswordState web interface. Note : Generic Fields can be configured as different Field Types, so ensure you pass a valid value for text fields, Select Lists, Radio Buttons or Date Fields.</maml:para>
         </maml:Description>
         <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
         <dev:type>
@@ -1265,7 +1470,8 @@
       <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="16" aliases="none">
         <maml:name>GenericField7</maml:name>
         <maml:Description>
-          <maml:para>An optional parameter to filter the search on a generic field.</maml:para>
+          <maml:para>An optional parameter to filter the search on a generic field.
+A generic field is a string field which can be renamed to a different value when being displayed in the PasswordState web interface. Note : Generic Fields can be configured as different Field Types, so ensure you pass a valid value for text fields, Select Lists, Radio Buttons or Date Fields.</maml:para>
         </maml:Description>
         <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
         <dev:type>
@@ -1277,7 +1483,8 @@
       <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="17" aliases="none">
         <maml:name>GenericField8</maml:name>
         <maml:Description>
-          <maml:para>An optional parameter to filter the search on a generic field.</maml:para>
+          <maml:para>An optional parameter to filter the search on a generic field.
+A generic field is a string field which can be renamed to a different value when being displayed in the PasswordState web interface. Note : Generic Fields can be configured as different Field Types, so ensure you pass a valid value for text fields, Select Lists, Radio Buttons or Date Fields.</maml:para>
         </maml:Description>
         <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
         <dev:type>
@@ -1289,7 +1496,8 @@
       <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="18" aliases="none">
         <maml:name>GenericField9</maml:name>
         <maml:Description>
-          <maml:para>An optional parameter to filter the search on a generic field.</maml:para>
+          <maml:para>An optional parameter to filter the search on a generic field.
+A generic field is a string field which can be renamed to a different value when being displayed in the PasswordState web interface. Note : Generic Fields can be configured as different Field Types, so ensure you pass a valid value for text fields, Select Lists, Radio Buttons or Date Fields.</maml:para>
         </maml:Description>
         <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
         <dev:type>
@@ -1301,7 +1509,8 @@
       <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="2" aliases="none">
         <maml:name>HostName</maml:name>
         <maml:Description>
-          <maml:para>An optional parameter to filter the search on hostname.</maml:para>
+          <maml:para>An optional parameter to filter the search on hostname.
+If the record relates to account on a Host, then you can specify the Host Name here to filter for, as it is stored on the Hosts screen in PasswordState.</maml:para>
         </maml:Description>
         <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
         <dev:type>
@@ -1313,7 +1522,8 @@
       <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="6" aliases="none">
         <maml:name>Notes</maml:name>
         <maml:Description>
-          <maml:para>An optional parameter to filter the search on notes.</maml:para>
+          <maml:para>An optional parameter to filter the search on notes.
+The Notes field are a generic field where additional descriptive text can be added.</maml:para>
         </maml:Description>
         <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
         <dev:type>
@@ -1325,7 +1535,7 @@
       <command:parameter required="true" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="0" aliases="none">
         <maml:name>PasswordID</maml:name>
         <maml:Description>
-          <maml:para>An ID of a specific password resource to return.</maml:para>
+          <maml:para>An PasswordID value of the password record in PasswordState to return.</maml:para>
         </maml:Description>
         <command:parameterValue required="true" variableLength="false">Int32</command:parameterValue>
         <dev:type>
@@ -1334,7 +1544,7 @@
         </dev:type>
         <dev:defaultValue>0</dev:defaultValue>
       </command:parameter>
-      <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="20" aliases="none">
+      <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="25" aliases="none">
         <maml:name>PasswordListID</maml:name>
         <maml:Description>
           <maml:para>An optional parameter to filter the search on a specific password list.</maml:para>
@@ -1346,10 +1556,10 @@
         </dev:type>
         <dev:defaultValue>0</dev:defaultValue>
       </command:parameter>
-      <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="22" aliases="none">
-        <maml:name>PreventAuditing</maml:name>
+      <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="21" aliases="none">
+        <maml:name>PasswordResetEnabled</maml:name>
         <maml:Description>
-          <maml:para>{{Fill PreventAuditing Description}}</maml:para>
+          <maml:para>Search for all password objects where the password reset is enabled.</maml:para>
         </maml:Description>
         <command:parameterValue required="false" variableLength="false">SwitchParameter</command:parameterValue>
         <dev:type>
@@ -1358,7 +1568,19 @@
         </dev:type>
         <dev:defaultValue>False</dev:defaultValue>
       </command:parameter>
-      <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="21" aliases="none">
+      <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="27" aliases="none">
+        <maml:name>PreventAuditing</maml:name>
+        <maml:Description>
+          <maml:para>By default, the retrieval of (all) Passwords records will add one Audit record for every Password record returned. If you wish to prevent audit records from being added, you can add this `-PreventAuditing` parameter.</maml:para>
+        </maml:Description>
+        <command:parameterValue required="false" variableLength="false">SwitchParameter</command:parameterValue>
+        <dev:type>
+          <maml:name>SwitchParameter</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>False</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="26" aliases="none">
         <maml:name>Reason</maml:name>
         <maml:Description>
           <maml:para>A reason which can be logged for auditing of why a password was retrieved.</maml:para>
@@ -1373,7 +1595,7 @@
       <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName, ByValue)" position="0" aliases="none">
         <maml:name>Search</maml:name>
         <maml:Description>
-          <maml:para>A string value which will be matched with most fields in the database table.</maml:para>
+          <maml:para>A string value which will be matched with most fields in the database table. Check the description section above fore more information which fields will be used for the search.</maml:para>
         </maml:Description>
         <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
         <dev:type>
@@ -1385,7 +1607,8 @@
       <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="8" aliases="none">
         <maml:name>SiteID</maml:name>
         <maml:Description>
-          <maml:para>An optional parameter to filter the search on the site ID.</maml:para>
+          <maml:para>An optional parameter to filter the search on the site ID.
+If you do not specify this parameter, it will report data based on all Site Locations. Values are 0 for Internal, and all other SiteID's can be found on the screen `Administration -&gt; Remote Site Administration -&gt; Remote Site Locations`.</maml:para>
         </maml:Description>
         <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
         <dev:type>
@@ -1397,7 +1620,8 @@
       <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="9" aliases="none">
         <maml:name>SiteLocation</maml:name>
         <maml:Description>
-          <maml:para>An optional parameter to filter the search on the site location.</maml:para>
+          <maml:para>An optional parameter to filter the search on the site location.
+If you do not specify this parameter, it will report data based on all Site Locations. Values are the name of the Site Location that can be found on the screen `Administration -&gt; Remote Site Administration -&gt; Remote Site Locations`.</maml:para>
         </maml:Description>
         <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
         <dev:type>
@@ -1409,7 +1633,8 @@
       <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="0" aliases="none">
         <maml:name>Title</maml:name>
         <maml:Description>
-          <maml:para>A string value which should match the passwordstate entry.</maml:para>
+          <maml:para>A string value which should match the PasswordState entry.
+A title is a name that describes the nature of the Password object.</maml:para>
         </maml:Description>
         <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
         <dev:type>
@@ -1421,7 +1646,8 @@
       <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="7" aliases="none">
         <maml:name>URL</maml:name>
         <maml:Description>
-          <maml:para>An optional parameter to filter the search on the URL.</maml:para>
+          <maml:para>An optional parameter to filter the search on the URL.
+URL parameter can be the URL for HTTP, HTTPS, FTP, SFTP, etc. found in the password object.</maml:para>
         </maml:Description>
         <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
         <dev:type>
@@ -1433,7 +1659,9 @@
       <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="1" aliases="none">
         <maml:name>UserName</maml:name>
         <maml:Description>
-          <maml:para>An optional parameter to filter searches to those with a certain username as multiple titles may have the same value.</maml:para>
+          <maml:para>An optional parameter to filter searches to those with a certain username as multiple titles may have the same value.
+Some systems require a username and password to authenticate. This field represents the UserName to do so.
+</maml:para>
         </maml:Description>
         <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
         <dev:type>
@@ -1456,43 +1684,113 @@
     </command:returnValues>
     <maml:alertSet>
       <maml:alert>
-        <maml:para>2018 - Daryl Newsholme 2019 - Jarno Colombeen</maml:para>
+        <maml:para></maml:para>
       </maml:alert>
     </maml:alertSet>
     <command:examples>
       <command:example>
         <maml:title>-------------------------- EXAMPLE 1 --------------------------</maml:title>
-        <dev:code>Get-PasswordStatePassword "testuser"</dev:code>
+        <dev:code>Get-PasswordStatePassword</dev:code>
         <dev:remarks>
-          <maml:para>Returns the test user object including password.</maml:para>
+          <maml:para>Returns all password objects the user or api key has access to.</maml:para>
         </dev:remarks>
       </command:example>
       <command:example>
         <maml:title>-------------------------- EXAMPLE 2 --------------------------</maml:title>
-        <dev:code>Get-PasswordStatePassword -Title '"testuser"'</dev:code>
+        <dev:code>Get-PasswordStatePassword -PreventAuditing</dev:code>
         <dev:remarks>
-          <maml:para>Returns the object including password, which is an exact match with the title (Requires double quotes for exact match).</maml:para>
+          <maml:para>Returns all password objects the user or api key has access to without adding one Audit record for every Password record returned to the audit log.</maml:para>
         </dev:remarks>
       </command:example>
       <command:example>
         <maml:title>-------------------------- EXAMPLE 3 --------------------------</maml:title>
-        <dev:code>Get-PasswordStatePassword -Username "testuser2" -Notes "Test"</dev:code>
+        <dev:code>Get-PasswordStatePassword -Search "testuser"</dev:code>
         <dev:remarks>
-          <maml:para>Returns the test user 2 object, where the notes contain "Test", including password.</maml:para>
+          <maml:para>Returns the object that has the string "testuser" in one of his properties. The password will also be returned.</maml:para>
         </dev:remarks>
       </command:example>
       <command:example>
         <maml:title>-------------------------- EXAMPLE 4 --------------------------</maml:title>
+        <dev:code>Get-PasswordStatePassword -PasswordListID 21</dev:code>
+        <dev:remarks>
+          <maml:para>Returns all password objects (including password) in password list with ID 21.</maml:para>
+        </dev:remarks>
+      </command:example>
+      <command:example>
+        <maml:title>-------------------------- EXAMPLE 5 --------------------------</maml:title>
+        <dev:code>Get-PasswordStatePassword -Title '"testuser"'</dev:code>
+        <dev:remarks>
+          <maml:para>Returns the objects (including password) that have the string "testuser" in one of his properties. It has to be an exact match with the one of the properties (Requires double quotes for exact match).</maml:para>
+        </dev:remarks>
+      </command:example>
+      <command:example>
+        <maml:title>-------------------------- EXAMPLE 6 --------------------------</maml:title>
+        <dev:code>Get-PasswordStatePassword -Title "testuser" -PasswordListID 21</dev:code>
+        <dev:remarks>
+          <maml:para>Returns the objects (including password) that have the string "testuser" in one of his properties and are located in password list with ID 21.</maml:para>
+        </dev:remarks>
+      </command:example>
+      <command:example>
+        <maml:title>-------------------------- EXAMPLE 7 --------------------------</maml:title>
+        <dev:code>Get-PasswordStatePassword -Username "testuser2" -Notes "Test"</dev:code>
+        <dev:remarks>
+          <maml:para>Returns the object with UserName = testuser2 AND where the notes contain "Test", including password.</maml:para>
+        </dev:remarks>
+      </command:example>
+      <command:example>
+        <maml:title>-------------------------- EXAMPLE 8 --------------------------</maml:title>
+        <dev:code>Get-PasswordStatePassword -Username "testuser2" -Notes "Test" -AndOr "OR"</dev:code>
+        <dev:remarks>
+          <maml:para>Returns the object with UserName = testuser2 OR any object where the notes contain "Test", including password.</maml:para>
+        </dev:remarks>
+      </command:example>
+      <command:example>
+        <maml:title>-------------------------- EXAMPLE 9 --------------------------</maml:title>
         <dev:code>Get-PasswordStatePassword -PasswordID "3456"</dev:code>
         <dev:remarks>
-          <maml:para>Returns the object with the PasswordID 3456 including password.</maml:para>
+          <maml:para>Returns the object with the PasswordID 3456.</maml:para>
+        </dev:remarks>
+      </command:example>
+      <command:example>
+        <maml:title>-------------------------- EXAMPLE 10 --------------------------</maml:title>
+        <dev:code>Get-PasswordStatePassword -PasswordResetEnabled</dev:code>
+        <dev:remarks>
+          <maml:para>Returns any object where Password resets are enabled.</maml:para>
+        </dev:remarks>
+      </command:example>
+      <command:example>
+        <maml:title>-------------------------- EXAMPLE 11 --------------------------</maml:title>
+        <dev:code>Get-PasswordStatePassword -ExpiryDateRange "ExpiryDate&gt;=2012-07-06,ExpiryDate&lt;=2020-12-12"</dev:code>
+        <dev:remarks>
+          <maml:para>Returns any object where the password will expire between 2012-07-06 and 2020-12-12.</maml:para>
+        </dev:remarks>
+      </command:example>
+      <command:example>
+        <maml:title>-------------------------- EXAMPLE 12 --------------------------</maml:title>
+        <dev:code>Get-PasswordStatePassword -ExpiryDate "2020-12-12"</dev:code>
+        <dev:remarks>
+          <maml:para>Returns any object where the password will expire at 2020-12-12.</maml:para>
+        </dev:remarks>
+      </command:example>
+      <command:example>
+        <maml:title>-------------------------- EXAMPLE 13 --------------------------</maml:title>
+        <dev:code>Get-PasswordStatePassword -HostName "SecureComputer.local" -UserName "Administrator" -Reason "Ticket #202005151234567"</dev:code>
+        <dev:remarks>
+          <maml:para>Returns the password object with UserName "Administrator" and/on HostName "SecureComputer.local". Also specifying the reason "Ticket #202005151234567" why the password object was requested.</maml:para>
+        </dev:remarks>
+      </command:example>
+      <command:example>
+        <maml:title>-------------------------- EXAMPLE 14 --------------------------</maml:title>
+        <dev:code>Get-PasswordStatePassword -UserName "Administrator" -SiteLocation "Customer1"</dev:code>
+        <dev:remarks>
+          <maml:para>Returns all password objects with UserName "Administrator" but only from Site "Customer1".</maml:para>
         </dev:remarks>
       </command:example>
     </command:examples>
     <command:relatedLinks>
       <maml:navigationLink>
         <maml:linkText>Online Version:</maml:linkText>
-        <maml:uri>https://github.com/dnewsholme/PasswordState-Management/blob/master/docs/New-PasswordStatePassword.md</maml:uri>
+        <maml:uri>https://github.com/dnewsholme/PasswordState-Management/blob/master/docs/Get-PasswordStatePassword.md</maml:uri>
       </maml:navigationLink>
     </command:relatedLinks>
   </command:command>
@@ -1744,18 +2042,6 @@ SiteID 0 = Default site 'Internal'</maml:para>
       </command:syntaxItem>
     </command:syntax>
     <command:parameters>
-      <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="cf">
-        <maml:name>Confirm</maml:name>
-        <maml:Description>
-          <maml:para>Prompts you for confirmation before running the cmdlet.</maml:para>
-        </maml:Description>
-        <command:parameterValue required="false" variableLength="false">SwitchParameter</command:parameterValue>
-        <dev:type>
-          <maml:name>SwitchParameter</maml:name>
-          <maml:uri />
-        </dev:type>
-        <dev:defaultValue>False</dev:defaultValue>
-      </command:parameter>
       <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="2" aliases="Duration">
         <maml:name>DurationInMonth</maml:name>
         <maml:Description>
@@ -1831,6 +2117,18 @@ SiteID 0 = Default site 'Internal'</maml:para>
           <maml:uri />
         </dev:type>
         <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="cf">
+        <maml:name>Confirm</maml:name>
+        <maml:Description>
+          <maml:para>Prompts you for confirmation before running the cmdlet.</maml:para>
+        </maml:Description>
+        <command:parameterValue required="false" variableLength="false">SwitchParameter</command:parameterValue>
+        <dev:type>
+          <maml:name>SwitchParameter</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>False</dev:defaultValue>
       </command:parameter>
       <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="wi">
         <maml:name>WhatIf</maml:name>
@@ -2080,18 +2378,6 @@ Output in list view.</maml:para>
       </command:syntaxItem>
     </command:syntax>
     <command:parameters>
-      <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="cf">
-        <maml:name>Confirm</maml:name>
-        <maml:Description>
-          <maml:para>Prompts you for confirmation before running the cmdlet.</maml:para>
-        </maml:Description>
-        <command:parameterValue required="false" variableLength="false">SwitchParameter</command:parameterValue>
-        <dev:type>
-          <maml:name>SwitchParameter</maml:name>
-          <maml:uri />
-        </dev:type>
-        <dev:defaultValue>False</dev:defaultValue>
-      </command:parameter>
       <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="2" aliases="Duration">
         <maml:name>DurationInMonth</maml:name>
         <maml:Description>
@@ -2205,6 +2491,18 @@ SiteID 0 = Default site 'Internal'</maml:para>
           <maml:uri />
         </dev:type>
         <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="cf">
+        <maml:name>Confirm</maml:name>
+        <maml:Description>
+          <maml:para>Prompts you for confirmation before running the cmdlet.</maml:para>
+        </maml:Description>
+        <command:parameterValue required="false" variableLength="false">SwitchParameter</command:parameterValue>
+        <dev:type>
+          <maml:name>SwitchParameter</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>False</dev:defaultValue>
       </command:parameter>
       <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="wi">
         <maml:name>WhatIf</maml:name>
@@ -2402,18 +2700,6 @@ SiteID 0 = Default site 'Internal'</maml:para>
         </dev:type>
         <dev:defaultValue>None</dev:defaultValue>
       </command:parameter>
-      <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="cf">
-        <maml:name>Confirm</maml:name>
-        <maml:Description>
-          <maml:para>Prompts you for confirmation before running the cmdlet.</maml:para>
-        </maml:Description>
-        <command:parameterValue required="false" variableLength="false">SwitchParameter</command:parameterValue>
-        <dev:type>
-          <maml:name>SwitchParameter</maml:name>
-          <maml:uri />
-        </dev:type>
-        <dev:defaultValue>False</dev:defaultValue>
-      </command:parameter>
       <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="1" aliases="none">
         <maml:name>Description</maml:name>
         <maml:Description>
@@ -2437,6 +2723,18 @@ SiteID 0 = Default site 'Internal'</maml:para>
           <maml:uri />
         </dev:type>
         <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="cf">
+        <maml:name>Confirm</maml:name>
+        <maml:Description>
+          <maml:para>Prompts you for confirmation before running the cmdlet.</maml:para>
+        </maml:Description>
+        <command:parameterValue required="false" variableLength="false">SwitchParameter</command:parameterValue>
+        <dev:type>
+          <maml:name>SwitchParameter</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>False</dev:defaultValue>
       </command:parameter>
       <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="wi">
         <maml:name>WhatIf</maml:name>
@@ -2648,18 +2946,6 @@ SiteID 0 = Default site 'Internal'</maml:para>
       </command:syntaxItem>
     </command:syntax>
     <command:parameters>
-      <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="cf">
-        <maml:name>Confirm</maml:name>
-        <maml:Description>
-          <maml:para>Prompts you for confirmation before running the cmdlet.</maml:para>
-        </maml:Description>
-        <command:parameterValue required="false" variableLength="false">SwitchParameter</command:parameterValue>
-        <dev:type>
-          <maml:name>SwitchParameter</maml:name>
-          <maml:uri />
-        </dev:type>
-        <dev:defaultValue>False</dev:defaultValue>
-      </command:parameter>
       <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="1" aliases="none">
         <maml:name>DependencyName</maml:name>
         <maml:Description>
@@ -2719,6 +3005,18 @@ SiteID 0 = Default site 'Internal'</maml:para>
           <maml:uri />
         </dev:type>
         <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="cf">
+        <maml:name>Confirm</maml:name>
+        <maml:Description>
+          <maml:para>Prompts you for confirmation before running the cmdlet.</maml:para>
+        </maml:Description>
+        <command:parameterValue required="false" variableLength="false">SwitchParameter</command:parameterValue>
+        <dev:type>
+          <maml:name>SwitchParameter</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>False</dev:defaultValue>
       </command:parameter>
       <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="wi">
         <maml:name>WhatIf</maml:name>
@@ -2894,18 +3192,6 @@ SiteID 0 = Default site 'Internal'</maml:para>
       </command:syntaxItem>
     </command:syntax>
     <command:parameters>
-      <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="cf">
-        <maml:name>Confirm</maml:name>
-        <maml:Description>
-          <maml:para>Prompts you for confirmation before running the cmdlet.</maml:para>
-        </maml:Description>
-        <command:parameterValue required="false" variableLength="false">SwitchParameter</command:parameterValue>
-        <dev:type>
-          <maml:name>SwitchParameter</maml:name>
-          <maml:uri />
-        </dev:type>
-        <dev:defaultValue>False</dev:defaultValue>
-      </command:parameter>
       <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="3" aliases="none">
         <maml:name>DocumentDescription</maml:name>
         <maml:Description>
@@ -2954,18 +3240,6 @@ SiteID 0 = Default site 'Internal'</maml:para>
         </dev:type>
         <dev:defaultValue>None</dev:defaultValue>
       </command:parameter>
-      <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="wi">
-        <maml:name>WhatIf</maml:name>
-        <maml:Description>
-          <maml:para>Shows what would happen if the cmdlet runs. The cmdlet is not run.</maml:para>
-        </maml:Description>
-        <command:parameterValue required="false" variableLength="false">SwitchParameter</command:parameterValue>
-        <dev:type>
-          <maml:name>SwitchParameter</maml:name>
-          <maml:uri />
-        </dev:type>
-        <dev:defaultValue>False</dev:defaultValue>
-      </command:parameter>
       <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="1" aliases="none">
         <maml:name>resourcetype</maml:name>
         <maml:Description>
@@ -2977,6 +3251,30 @@ SiteID 0 = Default site 'Internal'</maml:para>
           <maml:uri />
         </dev:type>
         <dev:defaultValue>Password</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="cf">
+        <maml:name>Confirm</maml:name>
+        <maml:Description>
+          <maml:para>Prompts you for confirmation before running the cmdlet.</maml:para>
+        </maml:Description>
+        <command:parameterValue required="false" variableLength="false">SwitchParameter</command:parameterValue>
+        <dev:type>
+          <maml:name>SwitchParameter</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>False</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="wi">
+        <maml:name>WhatIf</maml:name>
+        <maml:Description>
+          <maml:para>Shows what would happen if the cmdlet runs. The cmdlet is not run.</maml:para>
+        </maml:Description>
+        <command:parameterValue required="false" variableLength="false">SwitchParameter</command:parameterValue>
+        <dev:type>
+          <maml:name>SwitchParameter</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>False</dev:defaultValue>
       </command:parameter>
     </command:parameters>
     <command:inputTypes />
@@ -3155,18 +3453,6 @@ Will default to site 'Internal' (ID 0) if left blank.</maml:para>
       </command:syntaxItem>
     </command:syntax>
     <command:parameters>
-      <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="cf">
-        <maml:name>Confirm</maml:name>
-        <maml:Description>
-          <maml:para>Prompts you for confirmation before running the cmdlet.</maml:para>
-        </maml:Description>
-        <command:parameterValue required="false" variableLength="false">SwitchParameter</command:parameterValue>
-        <dev:type>
-          <maml:name>SwitchParameter</maml:name>
-          <maml:uri />
-        </dev:type>
-        <dev:defaultValue>False</dev:defaultValue>
-      </command:parameter>
       <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="3" aliases="none">
         <maml:name>CopyPermissionsFromPasswordListID</maml:name>
         <maml:Description>
@@ -3273,6 +3559,18 @@ Will default to site 'Internal' (ID 0) if left blank.</maml:para>
           <maml:uri />
         </dev:type>
         <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="cf">
+        <maml:name>Confirm</maml:name>
+        <maml:Description>
+          <maml:para>Prompts you for confirmation before running the cmdlet.</maml:para>
+        </maml:Description>
+        <command:parameterValue required="false" variableLength="false">SwitchParameter</command:parameterValue>
+        <dev:type>
+          <maml:name>SwitchParameter</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>False</dev:defaultValue>
       </command:parameter>
       <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="wi">
         <maml:name>WhatIf</maml:name>
@@ -3566,18 +3864,6 @@ You can only specify SecurityGroupID or SecurityGroupName, not both in the same 
         </dev:type>
         <dev:defaultValue>None</dev:defaultValue>
       </command:parameter>
-      <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="cf">
-        <maml:name>Confirm</maml:name>
-        <maml:Description>
-          <maml:para>Prompts you for confirmation before running the cmdlet.</maml:para>
-        </maml:Description>
-        <command:parameterValue required="false" variableLength="false">SwitchParameter</command:parameterValue>
-        <dev:type>
-          <maml:name>SwitchParameter</maml:name>
-          <maml:uri />
-        </dev:type>
-        <dev:defaultValue>False</dev:defaultValue>
-      </command:parameter>
       <command:parameter required="true" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="0" aliases="none">
         <maml:name>FolderID</maml:name>
         <maml:Description>
@@ -3607,6 +3893,18 @@ A for Administrator, M for Modify or V for View permissions.</maml:para>
         <maml:name>Sort</maml:name>
         <maml:Description>
           <maml:para>Sort the response object (not available at the moment</maml:para>
+        </maml:Description>
+        <command:parameterValue required="false" variableLength="false">SwitchParameter</command:parameterValue>
+        <dev:type>
+          <maml:name>SwitchParameter</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>False</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="cf">
+        <maml:name>Confirm</maml:name>
+        <maml:Description>
+          <maml:para>Prompts you for confirmation before running the cmdlet.</maml:para>
         </maml:Description>
         <command:parameterValue required="false" variableLength="false">SwitchParameter</command:parameterValue>
         <dev:type>
@@ -3991,18 +4289,6 @@ A for Administrator, M for Modify or V for View permissions.</maml:para>
       </command:syntaxItem>
     </command:syntax>
     <command:parameters>
-      <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="cf">
-        <maml:name>Confirm</maml:name>
-        <maml:Description>
-          <maml:para>Prompts you for confirmation before running the cmdlet.</maml:para>
-        </maml:Description>
-        <command:parameterValue required="false" variableLength="false">SwitchParameter</command:parameterValue>
-        <dev:type>
-          <maml:name>SwitchParameter</maml:name>
-          <maml:uri />
-        </dev:type>
-        <dev:defaultValue>False</dev:defaultValue>
-      </command:parameter>
       <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="5" aliases="none">
         <maml:name>DatabasePortNumber</maml:name>
         <maml:Description>
@@ -4159,18 +4445,6 @@ A for Administrator, M for Modify or V for View permissions.</maml:para>
         </dev:type>
         <dev:defaultValue>None</dev:defaultValue>
       </command:parameter>
-      <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="4" aliases="none">
-        <maml:name>SQLInstanceName</maml:name>
-        <maml:Description>
-          <maml:para>Optional parameter that provides either the Microsoft SQL Server Instance Name, Oracle Service Name or PostgreSQL Database Name.</maml:para>
-        </maml:Description>
-        <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
-        <dev:type>
-          <maml:name>String</maml:name>
-          <maml:uri />
-        </dev:type>
-        <dev:defaultValue>None</dev:defaultValue>
-      </command:parameter>
       <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="15" aliases="none">
         <maml:name>SessionRecording</maml:name>
         <maml:Description>
@@ -4194,6 +4468,18 @@ A for Administrator, M for Modify or V for View permissions.</maml:para>
           <maml:uri />
         </dev:type>
         <dev:defaultValue>0</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="4" aliases="none">
+        <maml:name>SQLInstanceName</maml:name>
+        <maml:Description>
+          <maml:para>Optional parameter that provides either the Microsoft SQL Server Instance Name, Oracle Service Name or PostgreSQL Database Name.</maml:para>
+        </maml:Description>
+        <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+        <dev:type>
+          <maml:name>String</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
       </command:parameter>
       <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="9" aliases="none">
         <maml:name>Tag</maml:name>
@@ -4242,6 +4528,18 @@ A for Administrator, M for Modify or V for View permissions.</maml:para>
           <maml:uri />
         </dev:type>
         <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="cf">
+        <maml:name>Confirm</maml:name>
+        <maml:Description>
+          <maml:para>Prompts you for confirmation before running the cmdlet.</maml:para>
+        </maml:Description>
+        <command:parameterValue required="false" variableLength="false">SwitchParameter</command:parameterValue>
+        <dev:type>
+          <maml:name>SwitchParameter</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>False</dev:defaultValue>
       </command:parameter>
       <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="wi">
         <maml:name>WhatIf</maml:name>
@@ -4364,12 +4662,6 @@ The following example shows, in PowerShell, how to create a a new Password List,
 </maml:para>
           </maml:Description>
           <command:parameterValueGroup>
-            <command:parameterValue required="false" command:variableLength="false">A</command:parameterValue>
-            <command:parameterValue required="false" command:variableLength="false">M</command:parameterValue>
-            <command:parameterValue required="false" command:variableLength="false">V</command:parameterValue>
-            <command:parameterValue required="false" command:variableLength="false">A</command:parameterValue>
-            <command:parameterValue required="false" command:variableLength="false">M</command:parameterValue>
-            <command:parameterValue required="false" command:variableLength="false">V</command:parameterValue>
             <command:parameterValue required="false" command:variableLength="false">A</command:parameterValue>
             <command:parameterValue required="false" command:variableLength="false">M</command:parameterValue>
             <command:parameterValue required="false" command:variableLength="false">V</command:parameterValue>
@@ -4654,12 +4946,6 @@ To copy permissions to the Password List from an existing Password List Template
 </maml:para>
           </maml:Description>
           <command:parameterValueGroup>
-            <command:parameterValue required="false" command:variableLength="false">A</command:parameterValue>
-            <command:parameterValue required="false" command:variableLength="false">M</command:parameterValue>
-            <command:parameterValue required="false" command:variableLength="false">V</command:parameterValue>
-            <command:parameterValue required="false" command:variableLength="false">A</command:parameterValue>
-            <command:parameterValue required="false" command:variableLength="false">M</command:parameterValue>
-            <command:parameterValue required="false" command:variableLength="false">V</command:parameterValue>
             <command:parameterValue required="false" command:variableLength="false">A</command:parameterValue>
             <command:parameterValue required="false" command:variableLength="false">M</command:parameterValue>
             <command:parameterValue required="false" command:variableLength="false">V</command:parameterValue>
@@ -5532,18 +5818,6 @@ To copy settings and field configurations to the Password List from an existing 
         </dev:type>
         <dev:defaultValue>None</dev:defaultValue>
       </command:parameter>
-      <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="cf">
-        <maml:name>Confirm</maml:name>
-        <maml:Description>
-          <maml:para>Prompts you for confirmation before running the cmdlet.</maml:para>
-        </maml:Description>
-        <command:parameterValue required="false" variableLength="false">SwitchParameter</command:parameterValue>
-        <dev:type>
-          <maml:name>SwitchParameter</maml:name>
-          <maml:uri />
-        </dev:type>
-        <dev:defaultValue>False</dev:defaultValue>
-      </command:parameter>
       <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="4" aliases="none">
         <maml:name>CopyPermissionsFromPasswordListID</maml:name>
         <maml:Description>
@@ -5780,6 +6054,18 @@ SiteID 0 = Default site 'Internal'
         <maml:Description>
           <maml:para>Sort the response (returned object) by name.
 </maml:para>
+        </maml:Description>
+        <command:parameterValue required="false" variableLength="false">SwitchParameter</command:parameterValue>
+        <dev:type>
+          <maml:name>SwitchParameter</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>False</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="cf">
+        <maml:name>Confirm</maml:name>
+        <maml:Description>
+          <maml:para>Prompts you for confirmation before running the cmdlet.</maml:para>
         </maml:Description>
         <command:parameterValue required="false" variableLength="false">SwitchParameter</command:parameterValue>
         <dev:type>
@@ -6073,18 +6359,6 @@ You can only specify SecurityGroupID or SecurityGroupName, not both in the same 
         </dev:type>
         <dev:defaultValue>None</dev:defaultValue>
       </command:parameter>
-      <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="cf">
-        <maml:name>Confirm</maml:name>
-        <maml:Description>
-          <maml:para>Prompts you for confirmation before running the cmdlet.</maml:para>
-        </maml:Description>
-        <command:parameterValue required="false" variableLength="false">SwitchParameter</command:parameterValue>
-        <dev:type>
-          <maml:name>SwitchParameter</maml:name>
-          <maml:uri />
-        </dev:type>
-        <dev:defaultValue>False</dev:defaultValue>
-      </command:parameter>
       <command:parameter required="true" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="0" aliases="none">
         <maml:name>PasswordListID</maml:name>
         <maml:Description>
@@ -6114,6 +6388,18 @@ A for Administrator, M for Modify or V for View permissions.</maml:para>
         <maml:name>Sort</maml:name>
         <maml:Description>
           <maml:para>Sort the response object (not available at the moment)</maml:para>
+        </maml:Description>
+        <command:parameterValue required="false" variableLength="false">SwitchParameter</command:parameterValue>
+        <dev:type>
+          <maml:name>SwitchParameter</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>False</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="cf">
+        <maml:name>Confirm</maml:name>
+        <maml:Description>
+          <maml:para>Prompts you for confirmation before running the cmdlet.</maml:para>
         </maml:Description>
         <command:parameterValue required="false" variableLength="false">SwitchParameter</command:parameterValue>
         <dev:type>
@@ -8739,18 +9025,6 @@ You can either specify the AccountType or AccountTypeID if needed when adding pa
       </command:syntaxItem>
     </command:syntax>
     <command:parameters>
-      <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="4" aliases="none">
-        <maml:name>ADDomainNetBIOS</maml:name>
-        <maml:Description>
-          <maml:para>If the record relates to an Active Directory account, then you must specify the Active Directory NetBIOS value here, as it is stored on the `Administration -&gt; PasswordState Administration -&gt; Active Directory Domains` screen in PasswordState.</maml:para>
-        </maml:Description>
-        <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
-        <dev:type>
-          <maml:name>String</maml:name>
-          <maml:uri />
-        </dev:type>
-        <dev:defaultValue>None</dev:defaultValue>
-      </command:parameter>
       <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="8" aliases="none">
         <maml:name>AccountType</maml:name>
         <maml:Description>
@@ -8789,23 +9063,23 @@ You can either specify the AccountType or AccountTypeID if needed when adding pa
         </dev:type>
         <dev:defaultValue>None</dev:defaultValue>
       </command:parameter>
+      <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="4" aliases="none">
+        <maml:name>ADDomainNetBIOS</maml:name>
+        <maml:Description>
+          <maml:para>If the record relates to an Active Directory account, then you must specify the Active Directory NetBIOS value here, as it is stored on the `Administration -&gt; PasswordState Administration -&gt; Active Directory Domains` screen in PasswordState.</maml:para>
+        </maml:Description>
+        <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+        <dev:type>
+          <maml:name>String</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
       <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="25" aliases="none">
         <maml:name>AllowExport</maml:name>
         <maml:Description>
           <maml:para>Indicates whether this Password object will be exported when the entire Password List contents are exported.
 Only working if "Allow Password List to be Exported" is set on the password list.</maml:para>
-        </maml:Description>
-        <command:parameterValue required="false" variableLength="false">SwitchParameter</command:parameterValue>
-        <dev:type>
-          <maml:name>SwitchParameter</maml:name>
-          <maml:uri />
-        </dev:type>
-        <dev:defaultValue>False</dev:defaultValue>
-      </command:parameter>
-      <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="cf">
-        <maml:name>Confirm</maml:name>
-        <maml:Description>
-          <maml:para>Prompts you for confirmation before running the cmdlet.</maml:para>
         </maml:Description>
         <command:parameterValue required="false" variableLength="false">SwitchParameter</command:parameterValue>
         <dev:type>
@@ -9215,6 +9489,18 @@ Some systems require a username and password to authenticate. This field represe
         </dev:type>
         <dev:defaultValue>None</dev:defaultValue>
       </command:parameter>
+      <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="cf">
+        <maml:name>Confirm</maml:name>
+        <maml:Description>
+          <maml:para>Prompts you for confirmation before running the cmdlet.</maml:para>
+        </maml:Description>
+        <command:parameterValue required="false" variableLength="false">SwitchParameter</command:parameterValue>
+        <dev:type>
+          <maml:name>SwitchParameter</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>False</dev:defaultValue>
+      </command:parameter>
       <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="wi">
         <maml:name>WhatIf</maml:name>
         <maml:Description>
@@ -9553,18 +9839,6 @@ You can only specify SecurityGroupID or SecurityGroupName, not both in the same 
         </dev:type>
         <dev:defaultValue>None</dev:defaultValue>
       </command:parameter>
-      <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="cf">
-        <maml:name>Confirm</maml:name>
-        <maml:Description>
-          <maml:para>Prompts you for confirmation before running the cmdlet.</maml:para>
-        </maml:Description>
-        <command:parameterValue required="false" variableLength="false">SwitchParameter</command:parameterValue>
-        <dev:type>
-          <maml:name>SwitchParameter</maml:name>
-          <maml:uri />
-        </dev:type>
-        <dev:defaultValue>False</dev:defaultValue>
-      </command:parameter>
       <command:parameter required="true" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="0" aliases="none">
         <maml:name>PasswordID</maml:name>
         <maml:Description>
@@ -9594,6 +9868,18 @@ A for Administrator, M for Modify or V for View permissions.</maml:para>
         <maml:name>Sort</maml:name>
         <maml:Description>
           <maml:para>Sort the response object (not available at the moment)</maml:para>
+        </maml:Description>
+        <command:parameterValue required="false" variableLength="false">SwitchParameter</command:parameterValue>
+        <dev:type>
+          <maml:name>SwitchParameter</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>False</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="cf">
+        <maml:name>Confirm</maml:name>
+        <maml:Description>
+          <maml:para>Prompts you for confirmation before running the cmdlet.</maml:para>
         </maml:Description>
         <command:parameterValue required="false" variableLength="false">SwitchParameter</command:parameterValue>
         <dev:type>
@@ -9702,55 +9988,6 @@ A for Administrator, M for Modify or V for View permissions.</maml:para>
     <command:syntax>
       <command:syntaxItem>
         <maml:name>New-RandomPassword</maml:name>
-        <command:parameter required="true" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="0" aliases="none">
-          <maml:name>PolicyID</maml:name>
-          <maml:Description>
-            <maml:para>ID for an existing Password Generator ID</maml:para>
-          </maml:Description>
-          <command:parameterValue required="true" variableLength="false">Int32</command:parameterValue>
-          <dev:type>
-            <maml:name>Int32</maml:name>
-            <maml:uri />
-          </dev:type>
-          <dev:defaultValue>0</dev:defaultValue>
-        </command:parameter>
-        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="cf">
-          <maml:name>Confirm</maml:name>
-          <maml:Description>
-            <maml:para>Prompts you for confirmation before running the cmdlet.</maml:para>
-          </maml:Description>
-          <dev:type>
-            <maml:name>SwitchParameter</maml:name>
-            <maml:uri />
-          </dev:type>
-          <dev:defaultValue>False</dev:defaultValue>
-        </command:parameter>
-        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="named" aliases="none">
-          <maml:name>Quantity</maml:name>
-          <maml:Description>
-            <maml:para>The quantity of passwords to generate.</maml:para>
-          </maml:Description>
-          <command:parameterValue required="true" variableLength="false">Int32</command:parameterValue>
-          <dev:type>
-            <maml:name>Int32</maml:name>
-            <maml:uri />
-          </dev:type>
-          <dev:defaultValue>1</dev:defaultValue>
-        </command:parameter>
-        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="wi">
-          <maml:name>WhatIf</maml:name>
-          <maml:Description>
-            <maml:para>Shows what would happen if the cmdlet runs. The cmdlet is not run.</maml:para>
-          </maml:Description>
-          <dev:type>
-            <maml:name>SwitchParameter</maml:name>
-            <maml:uri />
-          </dev:type>
-          <dev:defaultValue>False</dev:defaultValue>
-        </command:parameter>
-      </command:syntaxItem>
-      <command:syntaxItem>
-        <maml:name>New-RandomPassword</maml:name>
         <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="0" aliases="none">
           <maml:name>length</maml:name>
           <maml:Description>
@@ -9830,6 +10067,18 @@ A for Administrator, M for Modify or V for View permissions.</maml:para>
           </dev:type>
           <dev:defaultValue>None</dev:defaultValue>
         </command:parameter>
+        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="named" aliases="none">
+          <maml:name>Quantity</maml:name>
+          <maml:Description>
+            <maml:para>The quantity of passwords to generate.</maml:para>
+          </maml:Description>
+          <command:parameterValue required="true" variableLength="false">Int32</command:parameterValue>
+          <dev:type>
+            <maml:name>Int32</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>1</dev:defaultValue>
+        </command:parameter>
         <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="cf">
           <maml:name>Confirm</maml:name>
           <maml:Description>
@@ -9840,6 +10089,32 @@ A for Administrator, M for Modify or V for View permissions.</maml:para>
             <maml:uri />
           </dev:type>
           <dev:defaultValue>False</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="wi">
+          <maml:name>WhatIf</maml:name>
+          <maml:Description>
+            <maml:para>Shows what would happen if the cmdlet runs. The cmdlet is not run.</maml:para>
+          </maml:Description>
+          <dev:type>
+            <maml:name>SwitchParameter</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>False</dev:defaultValue>
+        </command:parameter>
+      </command:syntaxItem>
+      <command:syntaxItem>
+        <maml:name>New-RandomPassword</maml:name>
+        <command:parameter required="true" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="0" aliases="none">
+          <maml:name>PolicyID</maml:name>
+          <maml:Description>
+            <maml:para>ID for an existing Password Generator ID</maml:para>
+          </maml:Description>
+          <command:parameterValue required="true" variableLength="false">Int32</command:parameterValue>
+          <dev:type>
+            <maml:name>Int32</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>0</dev:defaultValue>
         </command:parameter>
         <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="named" aliases="none">
           <maml:name>Quantity</maml:name>
@@ -9852,6 +10127,17 @@ A for Administrator, M for Modify or V for View permissions.</maml:para>
             <maml:uri />
           </dev:type>
           <dev:defaultValue>1</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="cf">
+          <maml:name>Confirm</maml:name>
+          <maml:Description>
+            <maml:para>Prompts you for confirmation before running the cmdlet.</maml:para>
+          </maml:Description>
+          <dev:type>
+            <maml:name>SwitchParameter</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>False</dev:defaultValue>
         </command:parameter>
         <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="wi">
           <maml:name>WhatIf</maml:name>
@@ -9867,54 +10153,6 @@ A for Administrator, M for Modify or V for View permissions.</maml:para>
       </command:syntaxItem>
     </command:syntax>
     <command:parameters>
-      <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="cf">
-        <maml:name>Confirm</maml:name>
-        <maml:Description>
-          <maml:para>Prompts you for confirmation before running the cmdlet.</maml:para>
-        </maml:Description>
-        <command:parameterValue required="false" variableLength="false">SwitchParameter</command:parameterValue>
-        <dev:type>
-          <maml:name>SwitchParameter</maml:name>
-          <maml:uri />
-        </dev:type>
-        <dev:defaultValue>False</dev:defaultValue>
-      </command:parameter>
-      <command:parameter required="true" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="0" aliases="none">
-        <maml:name>PolicyID</maml:name>
-        <maml:Description>
-          <maml:para>ID for an existing Password Generator ID</maml:para>
-        </maml:Description>
-        <command:parameterValue required="true" variableLength="false">Int32</command:parameterValue>
-        <dev:type>
-          <maml:name>Int32</maml:name>
-          <maml:uri />
-        </dev:type>
-        <dev:defaultValue>0</dev:defaultValue>
-      </command:parameter>
-      <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="named" aliases="none">
-        <maml:name>Quantity</maml:name>
-        <maml:Description>
-          <maml:para>The quantity of passwords to generate.</maml:para>
-        </maml:Description>
-        <command:parameterValue required="true" variableLength="false">Int32</command:parameterValue>
-        <dev:type>
-          <maml:name>Int32</maml:name>
-          <maml:uri />
-        </dev:type>
-        <dev:defaultValue>1</dev:defaultValue>
-      </command:parameter>
-      <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="wi">
-        <maml:name>WhatIf</maml:name>
-        <maml:Description>
-          <maml:para>Shows what would happen if the cmdlet runs. The cmdlet is not run.</maml:para>
-        </maml:Description>
-        <command:parameterValue required="false" variableLength="false">SwitchParameter</command:parameterValue>
-        <dev:type>
-          <maml:name>SwitchParameter</maml:name>
-          <maml:uri />
-        </dev:type>
-        <dev:defaultValue>False</dev:defaultValue>
-      </command:parameter>
       <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="6" aliases="none">
         <maml:name>excludedcharacters</maml:name>
         <maml:Description>
@@ -9998,6 +10236,54 @@ A for Administrator, M for Modify or V for View permissions.</maml:para>
           <maml:uri />
         </dev:type>
         <dev:defaultValue>12</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="true" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="0" aliases="none">
+        <maml:name>PolicyID</maml:name>
+        <maml:Description>
+          <maml:para>ID for an existing Password Generator ID</maml:para>
+        </maml:Description>
+        <command:parameterValue required="true" variableLength="false">Int32</command:parameterValue>
+        <dev:type>
+          <maml:name>Int32</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>0</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="named" aliases="none">
+        <maml:name>Quantity</maml:name>
+        <maml:Description>
+          <maml:para>The quantity of passwords to generate.</maml:para>
+        </maml:Description>
+        <command:parameterValue required="true" variableLength="false">Int32</command:parameterValue>
+        <dev:type>
+          <maml:name>Int32</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>1</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="cf">
+        <maml:name>Confirm</maml:name>
+        <maml:Description>
+          <maml:para>Prompts you for confirmation before running the cmdlet.</maml:para>
+        </maml:Description>
+        <command:parameterValue required="false" variableLength="false">SwitchParameter</command:parameterValue>
+        <dev:type>
+          <maml:name>SwitchParameter</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>False</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="wi">
+        <maml:name>WhatIf</maml:name>
+        <maml:Description>
+          <maml:para>Shows what would happen if the cmdlet runs. The cmdlet is not run.</maml:para>
+        </maml:Description>
+        <command:parameterValue required="false" variableLength="false">SwitchParameter</command:parameterValue>
+        <dev:type>
+          <maml:name>SwitchParameter</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>False</dev:defaultValue>
       </command:parameter>
     </command:parameters>
     <command:inputTypes>
@@ -10130,18 +10416,6 @@ A for Administrator, M for Modify or V for View permissions.</maml:para>
       </command:syntaxItem>
     </command:syntax>
     <command:parameters>
-      <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="cf">
-        <maml:name>Confirm</maml:name>
-        <maml:Description>
-          <maml:para>Prompts you for confirmation before running the cmdlet.</maml:para>
-        </maml:Description>
-        <command:parameterValue required="false" variableLength="false">SwitchParameter</command:parameterValue>
-        <dev:type>
-          <maml:name>SwitchParameter</maml:name>
-          <maml:uri />
-        </dev:type>
-        <dev:defaultValue>False</dev:defaultValue>
-      </command:parameter>
       <command:parameter required="true" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="0" aliases="none">
         <maml:name>HostName</maml:name>
         <maml:Description>
@@ -10177,6 +10451,18 @@ A for Administrator, M for Modify or V for View permissions.</maml:para>
           <maml:uri />
         </dev:type>
         <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="cf">
+        <maml:name>Confirm</maml:name>
+        <maml:Description>
+          <maml:para>Prompts you for confirmation before running the cmdlet.</maml:para>
+        </maml:Description>
+        <command:parameterValue required="false" variableLength="false">SwitchParameter</command:parameterValue>
+        <dev:type>
+          <maml:name>SwitchParameter</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>False</dev:defaultValue>
       </command:parameter>
       <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="wi">
         <maml:name>WhatIf</maml:name>
@@ -10309,18 +10595,6 @@ A for Administrator, M for Modify or V for View permissions.</maml:para>
       </command:syntaxItem>
     </command:syntax>
     <command:parameters>
-      <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="cf">
-        <maml:name>Confirm</maml:name>
-        <maml:Description>
-          <maml:para>Prompts you for confirmation before running the cmdlet.</maml:para>
-        </maml:Description>
-        <command:parameterValue required="false" variableLength="false">SwitchParameter</command:parameterValue>
-        <dev:type>
-          <maml:name>SwitchParameter</maml:name>
-          <maml:uri />
-        </dev:type>
-        <dev:defaultValue>False</dev:defaultValue>
-      </command:parameter>
       <command:parameter required="true" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="0" aliases="none">
         <maml:name>PasswordID</maml:name>
         <maml:Description>
@@ -10345,10 +10619,34 @@ A for Administrator, M for Modify or V for View permissions.</maml:para>
         </dev:type>
         <dev:defaultValue>False</dev:defaultValue>
       </command:parameter>
+      <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="2" aliases="none">
+        <maml:name>reason</maml:name>
+        <maml:Description>
+          <maml:para>A reason which can be logged for auditing of why a password was removed.</maml:para>
+        </maml:Description>
+        <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+        <dev:type>
+          <maml:name>String</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
       <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="True (ByValue)" position="1" aliases="none">
         <maml:name>SendToRecycleBin</maml:name>
         <maml:Description>
           <maml:para>Send the password to the recyclebin or permenant delete.</maml:para>
+        </maml:Description>
+        <command:parameterValue required="false" variableLength="false">SwitchParameter</command:parameterValue>
+        <dev:type>
+          <maml:name>SwitchParameter</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>False</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="cf">
+        <maml:name>Confirm</maml:name>
+        <maml:Description>
+          <maml:para>Prompts you for confirmation before running the cmdlet.</maml:para>
         </maml:Description>
         <command:parameterValue required="false" variableLength="false">SwitchParameter</command:parameterValue>
         <dev:type>
@@ -10368,18 +10666,6 @@ A for Administrator, M for Modify or V for View permissions.</maml:para>
           <maml:uri />
         </dev:type>
         <dev:defaultValue>False</dev:defaultValue>
-      </command:parameter>
-      <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="2" aliases="none">
-        <maml:name>reason</maml:name>
-        <maml:Description>
-          <maml:para>A reason which can be logged for auditing of why a password was removed.</maml:para>
-        </maml:Description>
-        <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
-        <dev:type>
-          <maml:name>String</maml:name>
-          <maml:uri />
-        </dev:type>
-        <dev:defaultValue>None</dev:defaultValue>
       </command:parameter>
     </command:parameters>
     <command:inputTypes>
@@ -10690,29 +10976,6 @@ A for Administrator, M for Modify or V for View permissions.</maml:para>
           </dev:type>
           <dev:defaultValue>None</dev:defaultValue>
         </command:parameter>
-        <command:parameter required="true" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="named" aliases="none">
-          <maml:name>Baseuri</maml:name>
-          <maml:Description>
-            <maml:para>The base url of the passwordstate server. eg https://passwordstate</maml:para>
-          </maml:Description>
-          <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
-          <dev:type>
-            <maml:name>String</maml:name>
-            <maml:uri />
-          </dev:type>
-          <dev:defaultValue>None</dev:defaultValue>
-        </command:parameter>
-        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="cf">
-          <maml:name>Confirm</maml:name>
-          <maml:Description>
-            <maml:para>Prompts you for confirmation before running the cmdlet.</maml:para>
-          </maml:Description>
-          <dev:type>
-            <maml:name>SwitchParameter</maml:name>
-            <maml:uri />
-          </dev:type>
-          <dev:defaultValue>False</dev:defaultValue>
-        </command:parameter>
         <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="named" aliases="none">
           <maml:name>PasswordGeneratorAPIkey</maml:name>
           <maml:Description>
@@ -10725,17 +10988,6 @@ A for Administrator, M for Modify or V for View permissions.</maml:para>
           </dev:type>
           <dev:defaultValue>None</dev:defaultValue>
         </command:parameter>
-        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="wi">
-          <maml:name>WhatIf</maml:name>
-          <maml:Description>
-            <maml:para>Shows what would happen if the cmdlet runs. The cmdlet is not run.</maml:para>
-          </maml:Description>
-          <dev:type>
-            <maml:name>SwitchParameter</maml:name>
-            <maml:uri />
-          </dev:type>
-          <dev:defaultValue>False</dev:defaultValue>
-        </command:parameter>
         <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="named" aliases="none">
           <maml:name>path</maml:name>
           <maml:Description>
@@ -10748,17 +11000,26 @@ A for Administrator, M for Modify or V for View permissions.</maml:para>
           </dev:type>
           <dev:defaultValue>None</dev:defaultValue>
         </command:parameter>
-      </command:syntaxItem>
-      <command:syntaxItem>
-        <maml:name>Set-PasswordStateEnvironment</maml:name>
-        <command:parameter required="true" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="named" aliases="none">
-          <maml:name>Baseuri</maml:name>
+        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="none">
+          <maml:name>SetPlainTextPasswords</maml:name>
           <maml:Description>
-            <maml:para>The base url of the passwordstate server. eg https://passwordstate</maml:para>
+            <maml:para>{{ Fill SetPlainTextPasswords Description }}</maml:para>
           </maml:Description>
-          <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+          <command:parameterValue required="true" variableLength="false">Boolean</command:parameterValue>
           <dev:type>
-            <maml:name>String</maml:name>
+            <maml:name>Boolean</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="true" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="named" aliases="Baseuri">
+          <maml:name>Uri</maml:name>
+          <maml:Description>
+            <maml:para>{{ Fill Uri Description }}</maml:para>
+          </maml:Description>
+          <command:parameterValue required="true" variableLength="false">Uri</command:parameterValue>
+          <dev:type>
+            <maml:name>Uri</maml:name>
             <maml:uri />
           </dev:type>
           <dev:defaultValue>None</dev:defaultValue>
@@ -10785,66 +11046,9 @@ A for Administrator, M for Modify or V for View permissions.</maml:para>
           </dev:type>
           <dev:defaultValue>False</dev:defaultValue>
         </command:parameter>
-        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="named" aliases="none">
-          <maml:name>WindowsAuthOnly</maml:name>
-          <maml:Description>
-            <maml:para>For use if Windows Passthrough is the preferred authentication method.</maml:para>
-          </maml:Description>
-          <dev:type>
-            <maml:name>SwitchParameter</maml:name>
-            <maml:uri />
-          </dev:type>
-          <dev:defaultValue>False</dev:defaultValue>
-        </command:parameter>
-        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="named" aliases="none">
-          <maml:name>path</maml:name>
-          <maml:Description>
-            <maml:para>{{ Fill path Description }}</maml:para>
-          </maml:Description>
-          <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
-          <dev:type>
-            <maml:name>String</maml:name>
-            <maml:uri />
-          </dev:type>
-          <dev:defaultValue>None</dev:defaultValue>
-        </command:parameter>
       </command:syntaxItem>
       <command:syntaxItem>
         <maml:name>Set-PasswordStateEnvironment</maml:name>
-        <command:parameter required="true" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="named" aliases="none">
-          <maml:name>Baseuri</maml:name>
-          <maml:Description>
-            <maml:para>The base url of the passwordstate server. eg https://passwordstate</maml:para>
-          </maml:Description>
-          <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
-          <dev:type>
-            <maml:name>String</maml:name>
-            <maml:uri />
-          </dev:type>
-          <dev:defaultValue>None</dev:defaultValue>
-        </command:parameter>
-        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="cf">
-          <maml:name>Confirm</maml:name>
-          <maml:Description>
-            <maml:para>Prompts you for confirmation before running the cmdlet.</maml:para>
-          </maml:Description>
-          <dev:type>
-            <maml:name>SwitchParameter</maml:name>
-            <maml:uri />
-          </dev:type>
-          <dev:defaultValue>False</dev:defaultValue>
-        </command:parameter>
-        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="wi">
-          <maml:name>WhatIf</maml:name>
-          <maml:Description>
-            <maml:para>Shows what would happen if the cmdlet runs. The cmdlet is not run.</maml:para>
-          </maml:Description>
-          <dev:type>
-            <maml:name>SwitchParameter</maml:name>
-            <maml:uri />
-          </dev:type>
-          <dev:defaultValue>False</dev:defaultValue>
-        </command:parameter>
         <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="named" aliases="none">
           <maml:name>customcredentials</maml:name>
           <maml:Description>
@@ -10869,6 +11073,124 @@ A for Administrator, M for Modify or V for View permissions.</maml:para>
           </dev:type>
           <dev:defaultValue>None</dev:defaultValue>
         </command:parameter>
+        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="none">
+          <maml:name>SetPlainTextPasswords</maml:name>
+          <maml:Description>
+            <maml:para>{{ Fill SetPlainTextPasswords Description }}</maml:para>
+          </maml:Description>
+          <command:parameterValue required="true" variableLength="false">Boolean</command:parameterValue>
+          <dev:type>
+            <maml:name>Boolean</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="true" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="named" aliases="Baseuri">
+          <maml:name>Uri</maml:name>
+          <maml:Description>
+            <maml:para>{{ Fill Uri Description }}</maml:para>
+          </maml:Description>
+          <command:parameterValue required="true" variableLength="false">Uri</command:parameterValue>
+          <dev:type>
+            <maml:name>Uri</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="cf">
+          <maml:name>Confirm</maml:name>
+          <maml:Description>
+            <maml:para>Prompts you for confirmation before running the cmdlet.</maml:para>
+          </maml:Description>
+          <dev:type>
+            <maml:name>SwitchParameter</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>False</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="wi">
+          <maml:name>WhatIf</maml:name>
+          <maml:Description>
+            <maml:para>Shows what would happen if the cmdlet runs. The cmdlet is not run.</maml:para>
+          </maml:Description>
+          <dev:type>
+            <maml:name>SwitchParameter</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>False</dev:defaultValue>
+        </command:parameter>
+      </command:syntaxItem>
+      <command:syntaxItem>
+        <maml:name>Set-PasswordStateEnvironment</maml:name>
+        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="named" aliases="none">
+          <maml:name>path</maml:name>
+          <maml:Description>
+            <maml:para>{{ Fill path Description }}</maml:para>
+          </maml:Description>
+          <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+          <dev:type>
+            <maml:name>String</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="none">
+          <maml:name>SetPlainTextPasswords</maml:name>
+          <maml:Description>
+            <maml:para>{{ Fill SetPlainTextPasswords Description }}</maml:para>
+          </maml:Description>
+          <command:parameterValue required="true" variableLength="false">Boolean</command:parameterValue>
+          <dev:type>
+            <maml:name>Boolean</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="true" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="named" aliases="Baseuri">
+          <maml:name>Uri</maml:name>
+          <maml:Description>
+            <maml:para>{{ Fill Uri Description }}</maml:para>
+          </maml:Description>
+          <command:parameterValue required="true" variableLength="false">Uri</command:parameterValue>
+          <dev:type>
+            <maml:name>Uri</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="named" aliases="none">
+          <maml:name>WindowsAuthOnly</maml:name>
+          <maml:Description>
+            <maml:para>For use if Windows Passthrough is the preferred authentication method.</maml:para>
+          </maml:Description>
+          <dev:type>
+            <maml:name>SwitchParameter</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>False</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="cf">
+          <maml:name>Confirm</maml:name>
+          <maml:Description>
+            <maml:para>Prompts you for confirmation before running the cmdlet.</maml:para>
+          </maml:Description>
+          <dev:type>
+            <maml:name>SwitchParameter</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>False</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="wi">
+          <maml:name>WhatIf</maml:name>
+          <maml:Description>
+            <maml:para>Shows what would happen if the cmdlet runs. The cmdlet is not run.</maml:para>
+          </maml:Description>
+          <dev:type>
+            <maml:name>SwitchParameter</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>False</dev:defaultValue>
+        </command:parameter>
       </command:syntaxItem>
     </command:syntax>
     <command:parameters>
@@ -10884,29 +11206,17 @@ A for Administrator, M for Modify or V for View permissions.</maml:para>
         </dev:type>
         <dev:defaultValue>None</dev:defaultValue>
       </command:parameter>
-      <command:parameter required="true" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="named" aliases="none">
-        <maml:name>Baseuri</maml:name>
+      <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="named" aliases="none">
+        <maml:name>customcredentials</maml:name>
         <maml:Description>
-          <maml:para>The base url of the passwordstate server. eg https://passwordstate</maml:para>
+          <maml:para>For use if windows custom credentials is the preferred authentication method.</maml:para>
         </maml:Description>
-        <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+        <command:parameterValue required="true" variableLength="false">PSCredential</command:parameterValue>
         <dev:type>
-          <maml:name>String</maml:name>
+          <maml:name>PSCredential</maml:name>
           <maml:uri />
         </dev:type>
         <dev:defaultValue>None</dev:defaultValue>
-      </command:parameter>
-      <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="cf">
-        <maml:name>Confirm</maml:name>
-        <maml:Description>
-          <maml:para>Prompts you for confirmation before running the cmdlet.</maml:para>
-        </maml:Description>
-        <command:parameterValue required="false" variableLength="false">SwitchParameter</command:parameterValue>
-        <dev:type>
-          <maml:name>SwitchParameter</maml:name>
-          <maml:uri />
-        </dev:type>
-        <dev:defaultValue>False</dev:defaultValue>
       </command:parameter>
       <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="named" aliases="none">
         <maml:name>PasswordGeneratorAPIkey</maml:name>
@@ -10916,42 +11226,6 @@ A for Administrator, M for Modify or V for View permissions.</maml:para>
         <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
         <dev:type>
           <maml:name>String</maml:name>
-          <maml:uri />
-        </dev:type>
-        <dev:defaultValue>None</dev:defaultValue>
-      </command:parameter>
-      <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="wi">
-        <maml:name>WhatIf</maml:name>
-        <maml:Description>
-          <maml:para>Shows what would happen if the cmdlet runs. The cmdlet is not run.</maml:para>
-        </maml:Description>
-        <command:parameterValue required="false" variableLength="false">SwitchParameter</command:parameterValue>
-        <dev:type>
-          <maml:name>SwitchParameter</maml:name>
-          <maml:uri />
-        </dev:type>
-        <dev:defaultValue>False</dev:defaultValue>
-      </command:parameter>
-      <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="named" aliases="none">
-        <maml:name>WindowsAuthOnly</maml:name>
-        <maml:Description>
-          <maml:para>For use if Windows Passthrough is the preferred authentication method.</maml:para>
-        </maml:Description>
-        <command:parameterValue required="false" variableLength="false">SwitchParameter</command:parameterValue>
-        <dev:type>
-          <maml:name>SwitchParameter</maml:name>
-          <maml:uri />
-        </dev:type>
-        <dev:defaultValue>False</dev:defaultValue>
-      </command:parameter>
-      <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="named" aliases="none">
-        <maml:name>customcredentials</maml:name>
-        <maml:Description>
-          <maml:para>For use if windows custom credentials is the preferred authentication method.</maml:para>
-        </maml:Description>
-        <command:parameterValue required="true" variableLength="false">PSCredential</command:parameterValue>
-        <dev:type>
-          <maml:name>PSCredential</maml:name>
           <maml:uri />
         </dev:type>
         <dev:defaultValue>None</dev:defaultValue>
@@ -10967,6 +11241,66 @@ A for Administrator, M for Modify or V for View permissions.</maml:para>
           <maml:uri />
         </dev:type>
         <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="none">
+        <maml:name>SetPlainTextPasswords</maml:name>
+        <maml:Description>
+          <maml:para>{{ Fill SetPlainTextPasswords Description }}</maml:para>
+        </maml:Description>
+        <command:parameterValue required="true" variableLength="false">Boolean</command:parameterValue>
+        <dev:type>
+          <maml:name>Boolean</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="true" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="named" aliases="Baseuri">
+        <maml:name>Uri</maml:name>
+        <maml:Description>
+          <maml:para>{{ Fill Uri Description }}</maml:para>
+        </maml:Description>
+        <command:parameterValue required="true" variableLength="false">Uri</command:parameterValue>
+        <dev:type>
+          <maml:name>Uri</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="named" aliases="none">
+        <maml:name>WindowsAuthOnly</maml:name>
+        <maml:Description>
+          <maml:para>For use if Windows Passthrough is the preferred authentication method.</maml:para>
+        </maml:Description>
+        <command:parameterValue required="false" variableLength="false">SwitchParameter</command:parameterValue>
+        <dev:type>
+          <maml:name>SwitchParameter</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>False</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="cf">
+        <maml:name>Confirm</maml:name>
+        <maml:Description>
+          <maml:para>Prompts you for confirmation before running the cmdlet.</maml:para>
+        </maml:Description>
+        <command:parameterValue required="false" variableLength="false">SwitchParameter</command:parameterValue>
+        <dev:type>
+          <maml:name>SwitchParameter</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>False</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="wi">
+        <maml:name>WhatIf</maml:name>
+        <maml:Description>
+          <maml:para>Shows what would happen if the cmdlet runs. The cmdlet is not run.</maml:para>
+        </maml:Description>
+        <command:parameterValue required="false" variableLength="false">SwitchParameter</command:parameterValue>
+        <dev:type>
+          <maml:name>SwitchParameter</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>False</dev:defaultValue>
       </command:parameter>
     </command:parameters>
     <command:inputTypes>
@@ -11312,17 +11646,17 @@ A for Administrator, M for Modify or V for View permissions.</maml:para>
       </command:syntaxItem>
     </command:syntax>
     <command:parameters>
-      <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="cf">
-        <maml:name>Confirm</maml:name>
+      <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="4" aliases="none">
+        <maml:name>domain</maml:name>
         <maml:Description>
-          <maml:para>Prompts you for confirmation before running the cmdlet.</maml:para>
+          <maml:para>Updated domain value</maml:para>
         </maml:Description>
-        <command:parameterValue required="false" variableLength="false">SwitchParameter</command:parameterValue>
+        <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
         <dev:type>
-          <maml:name>SwitchParameter</maml:name>
+          <maml:name>String</maml:name>
           <maml:uri />
         </dev:type>
-        <dev:defaultValue>False</dev:defaultValue>
+        <dev:defaultValue>None</dev:defaultValue>
       </command:parameter>
       <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="9" aliases="none">
         <maml:name>GenericField1</maml:name>
@@ -11444,42 +11778,6 @@ A for Administrator, M for Modify or V for View permissions.</maml:para>
         </dev:type>
         <dev:defaultValue>None</dev:defaultValue>
       </command:parameter>
-      <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="19" aliases="none">
-        <maml:name>PreventAuditing</maml:name>
-        <maml:Description>
-          <maml:para>{{Fill PreventAuditing Description}}</maml:para>
-        </maml:Description>
-        <command:parameterValue required="false" variableLength="false">SwitchParameter</command:parameterValue>
-        <dev:type>
-          <maml:name>SwitchParameter</maml:name>
-          <maml:uri />
-        </dev:type>
-        <dev:defaultValue>False</dev:defaultValue>
-      </command:parameter>
-      <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="wi">
-        <maml:name>WhatIf</maml:name>
-        <maml:Description>
-          <maml:para>Shows what would happen if the cmdlet runs. The cmdlet is not run.</maml:para>
-        </maml:Description>
-        <command:parameterValue required="false" variableLength="false">SwitchParameter</command:parameterValue>
-        <dev:type>
-          <maml:name>SwitchParameter</maml:name>
-          <maml:uri />
-        </dev:type>
-        <dev:defaultValue>False</dev:defaultValue>
-      </command:parameter>
-      <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="4" aliases="none">
-        <maml:name>domain</maml:name>
-        <maml:Description>
-          <maml:para>Updated domain value</maml:para>
-        </maml:Description>
-        <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
-        <dev:type>
-          <maml:name>String</maml:name>
-          <maml:uri />
-        </dev:type>
-        <dev:defaultValue>None</dev:defaultValue>
-      </command:parameter>
       <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="5" aliases="none">
         <maml:name>hostname</maml:name>
         <maml:Description>
@@ -11528,6 +11826,18 @@ A for Administrator, M for Modify or V for View permissions.</maml:para>
         </dev:type>
         <dev:defaultValue>0</dev:defaultValue>
       </command:parameter>
+      <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="19" aliases="none">
+        <maml:name>PreventAuditing</maml:name>
+        <maml:Description>
+          <maml:para>{{Fill PreventAuditing Description}}</maml:para>
+        </maml:Description>
+        <command:parameterValue required="false" variableLength="false">SwitchParameter</command:parameterValue>
+        <dev:type>
+          <maml:name>SwitchParameter</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>False</dev:defaultValue>
+      </command:parameter>
       <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="8" aliases="none">
         <maml:name>reason</maml:name>
         <maml:Description>
@@ -11575,6 +11885,30 @@ A for Administrator, M for Modify or V for View permissions.</maml:para>
           <maml:uri />
         </dev:type>
         <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="cf">
+        <maml:name>Confirm</maml:name>
+        <maml:Description>
+          <maml:para>Prompts you for confirmation before running the cmdlet.</maml:para>
+        </maml:Description>
+        <command:parameterValue required="false" variableLength="false">SwitchParameter</command:parameterValue>
+        <dev:type>
+          <maml:name>SwitchParameter</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>False</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="wi">
+        <maml:name>WhatIf</maml:name>
+        <maml:Description>
+          <maml:para>Shows what would happen if the cmdlet runs. The cmdlet is not run.</maml:para>
+        </maml:Description>
+        <command:parameterValue required="false" variableLength="false">SwitchParameter</command:parameterValue>
+        <dev:type>
+          <maml:name>SwitchParameter</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>False</dev:defaultValue>
       </command:parameter>
     </command:parameters>
     <command:inputTypes>

--- a/en-us/passwordstate-management-help.xml
+++ b/en-us/passwordstate-management-help.xml
@@ -153,7 +153,7 @@
         <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="5" aliases="none">
           <maml:name>PreventAuditing</maml:name>
           <maml:Description>
-            <maml:para>{{Fill PreventAuditing Description}}</maml:para>
+            <maml:para>By default, the creation/modification or retrieval of (all) Passwords records will add one Audit record for every Password record returned. If you wish to prevent audit records from being added, you can add this `-PreventAuditing` parameter.</maml:para>
           </maml:Description>
           <dev:type>
             <maml:name>SwitchParameter</maml:name>
@@ -191,7 +191,7 @@
       <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="5" aliases="none">
         <maml:name>PreventAuditing</maml:name>
         <maml:Description>
-          <maml:para>{{Fill PreventAuditing Description}}</maml:para>
+          <maml:para>By default, the creation/modification or retrieval of (all) Passwords records will add one Audit record for every Password record returned. If you wish to prevent audit records from being added, you can add this `-PreventAuditing` parameter.</maml:para>
         </maml:Description>
         <command:parameterValue required="false" variableLength="false">SwitchParameter</command:parameterValue>
         <dev:type>
@@ -593,7 +593,7 @@
         <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="5" aliases="none">
           <maml:name>PreventAuditing</maml:name>
           <maml:Description>
-            <maml:para>{{Fill PreventAuditing Description}}</maml:para>
+            <maml:para>By default, the creation/modification or retrieval of (all) Passwords records will add one Audit record for every Password record returned. If you wish to prevent audit records from being added, you can add this `-PreventAuditing` parameter.</maml:para>
           </maml:Description>
           <dev:type>
             <maml:name>SwitchParameter</maml:name>
@@ -619,7 +619,7 @@
         <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="5" aliases="none">
           <maml:name>PreventAuditing</maml:name>
           <maml:Description>
-            <maml:para>{{Fill PreventAuditing Description}}</maml:para>
+            <maml:para>By default, the creation/modification or retrieval of (all) Passwords records will add one Audit record for every Password record returned. If you wish to prevent audit records from being added, you can add this `-PreventAuditing` parameter.</maml:para>
           </maml:Description>
           <dev:type>
             <maml:name>SwitchParameter</maml:name>
@@ -669,7 +669,7 @@
       <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="5" aliases="none">
         <maml:name>PreventAuditing</maml:name>
         <maml:Description>
-          <maml:para>{{Fill PreventAuditing Description}}</maml:para>
+          <maml:para>By default, the creation/modification or retrieval of (all) Passwords records will add one Audit record for every Password record returned. If you wish to prevent audit records from being added, you can add this `-PreventAuditing` parameter.</maml:para>
         </maml:Description>
         <command:parameterValue required="false" variableLength="false">SwitchParameter</command:parameterValue>
         <dev:type>
@@ -1836,7 +1836,7 @@ Some systems require a username and password to authenticate. This field represe
         <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="2" aliases="none">
           <maml:name>PreventAuditing</maml:name>
           <maml:Description>
-            <maml:para>{{Fill PreventAuditing Description}}</maml:para>
+            <maml:para>By default, the creation/modification or retrieval of (all) Passwords records will add one Audit record for every Password record returned. If you wish to prevent audit records from being added, you can add this `-PreventAuditing` parameter.</maml:para>
           </maml:Description>
           <dev:type>
             <maml:name>SwitchParameter</maml:name>
@@ -1862,7 +1862,7 @@ Some systems require a username and password to authenticate. This field represe
       <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="2" aliases="none">
         <maml:name>PreventAuditing</maml:name>
         <maml:Description>
-          <maml:para>{{Fill PreventAuditing Description}}</maml:para>
+          <maml:para>By default, the creation/modification or retrieval of (all) Passwords records will add one Audit record for every Password record returned. If you wish to prevent audit records from being added, you can add this `-PreventAuditing` parameter.</maml:para>
         </maml:Description>
         <command:parameterValue required="false" variableLength="false">SwitchParameter</command:parameterValue>
         <dev:type>
@@ -10058,7 +10058,7 @@ A for Administrator, M for Modify or V for View permissions.</maml:para>
         <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="6" aliases="none">
           <maml:name>excludedcharacters</maml:name>
           <maml:Description>
-            <maml:para>{{Fill excludedcharacters Description}}</maml:para>
+            <maml:para>I characters should be excluded, add them here.</maml:para>
           </maml:Description>
           <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
           <dev:type>
@@ -10156,7 +10156,7 @@ A for Administrator, M for Modify or V for View permissions.</maml:para>
       <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="6" aliases="none">
         <maml:name>excludedcharacters</maml:name>
         <maml:Description>
-          <maml:para>{{Fill excludedcharacters Description}}</maml:para>
+          <maml:para>I characters should be excluded, add them here.</maml:para>
         </maml:Description>
         <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
         <dev:type>
@@ -10562,7 +10562,7 @@ A for Administrator, M for Modify or V for View permissions.</maml:para>
         <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="3" aliases="none">
           <maml:name>PreventAuditing</maml:name>
           <maml:Description>
-            <maml:para>{{Fill PreventAuditing Description}}</maml:para>
+            <maml:para>By default, the creation/modification or retrieval of (all) Passwords records will add one Audit record for every Password record returned. If you wish to prevent audit records from being added, you can add this `-PreventAuditing` parameter.</maml:para>
           </maml:Description>
           <dev:type>
             <maml:name>SwitchParameter</maml:name>
@@ -10610,7 +10610,7 @@ A for Administrator, M for Modify or V for View permissions.</maml:para>
       <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="3" aliases="none">
         <maml:name>PreventAuditing</maml:name>
         <maml:Description>
-          <maml:para>{{Fill PreventAuditing Description}}</maml:para>
+          <maml:para>By default, the creation/modification or retrieval of (all) Passwords records will add one Audit record for every Password record returned. If you wish to prevent audit records from being added, you can add this `-PreventAuditing` parameter.</maml:para>
         </maml:Description>
         <command:parameterValue required="false" variableLength="false">SwitchParameter</command:parameterValue>
         <dev:type>
@@ -10858,7 +10858,7 @@ A for Administrator, M for Modify or V for View permissions.</maml:para>
         <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="2" aliases="none">
           <maml:name>DocumentID</maml:name>
           <maml:Description>
-            <maml:para>{{Fill DocumentID Description}}</maml:para>
+            <maml:para>The ID of the document that will be uploaded.</maml:para>
           </maml:Description>
           <command:parameterValue required="true" variableLength="false">Int32</command:parameterValue>
           <dev:type>
@@ -10885,7 +10885,7 @@ A for Administrator, M for Modify or V for View permissions.</maml:para>
       <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="2" aliases="none">
         <maml:name>DocumentID</maml:name>
         <maml:Description>
-          <maml:para>{{Fill DocumentID Description}}</maml:para>
+          <maml:para>The ID of the document that will be uploaded.</maml:para>
         </maml:Description>
         <command:parameterValue required="true" variableLength="false">Int32</command:parameterValue>
         <dev:type>
@@ -10979,7 +10979,7 @@ A for Administrator, M for Modify or V for View permissions.</maml:para>
         <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="named" aliases="none">
           <maml:name>PasswordGeneratorAPIkey</maml:name>
           <maml:Description>
-            <maml:para>{{Fill PasswordGeneratorAPIkey Description}}</maml:para>
+            <maml:para>The API Key for the password generator usage.</maml:para>
           </maml:Description>
           <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
           <dev:type>
@@ -10991,7 +10991,7 @@ A for Administrator, M for Modify or V for View permissions.</maml:para>
         <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="named" aliases="none">
           <maml:name>path</maml:name>
           <maml:Description>
-            <maml:para>{{ Fill path Description }}</maml:para>
+            <maml:para>The path to the json configuration file for the passwordstate environment.</maml:para>
           </maml:Description>
           <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
           <dev:type>
@@ -11003,7 +11003,7 @@ A for Administrator, M for Modify or V for View permissions.</maml:para>
         <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="none">
           <maml:name>SetPlainTextPasswords</maml:name>
           <maml:Description>
-            <maml:para>{{ Fill SetPlainTextPasswords Description }}</maml:para>
+            <maml:para>Set to true, if plaintext passwords shall be displayed.</maml:para>
           </maml:Description>
           <command:parameterValue required="true" variableLength="false">Boolean</command:parameterValue>
           <dev:type>
@@ -11015,7 +11015,7 @@ A for Administrator, M for Modify or V for View permissions.</maml:para>
         <command:parameter required="true" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="named" aliases="Baseuri">
           <maml:name>Uri</maml:name>
           <maml:Description>
-            <maml:para>{{ Fill Uri Description }}</maml:para>
+            <maml:para>The url of the passwordstate website.</maml:para>
           </maml:Description>
           <command:parameterValue required="true" variableLength="false">Uri</command:parameterValue>
           <dev:type>
@@ -11064,7 +11064,7 @@ A for Administrator, M for Modify or V for View permissions.</maml:para>
         <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="named" aliases="none">
           <maml:name>path</maml:name>
           <maml:Description>
-            <maml:para>{{ Fill path Description }}</maml:para>
+            <maml:para>The path to the json configuration file for the passwordstate environment.</maml:para>
           </maml:Description>
           <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
           <dev:type>
@@ -11076,7 +11076,7 @@ A for Administrator, M for Modify or V for View permissions.</maml:para>
         <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="none">
           <maml:name>SetPlainTextPasswords</maml:name>
           <maml:Description>
-            <maml:para>{{ Fill SetPlainTextPasswords Description }}</maml:para>
+            <maml:para>Set to true, if plaintext passwords shall be displayed.</maml:para>
           </maml:Description>
           <command:parameterValue required="true" variableLength="false">Boolean</command:parameterValue>
           <dev:type>
@@ -11088,7 +11088,7 @@ A for Administrator, M for Modify or V for View permissions.</maml:para>
         <command:parameter required="true" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="named" aliases="Baseuri">
           <maml:name>Uri</maml:name>
           <maml:Description>
-            <maml:para>{{ Fill Uri Description }}</maml:para>
+            <maml:para>The url of the passwordstate website.</maml:para>
           </maml:Description>
           <command:parameterValue required="true" variableLength="false">Uri</command:parameterValue>
           <dev:type>
@@ -11125,7 +11125,7 @@ A for Administrator, M for Modify or V for View permissions.</maml:para>
         <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="named" aliases="none">
           <maml:name>path</maml:name>
           <maml:Description>
-            <maml:para>{{ Fill path Description }}</maml:para>
+            <maml:para>The path to the json configuration file for the passwordstate environment.</maml:para>
           </maml:Description>
           <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
           <dev:type>
@@ -11137,7 +11137,7 @@ A for Administrator, M for Modify or V for View permissions.</maml:para>
         <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="none">
           <maml:name>SetPlainTextPasswords</maml:name>
           <maml:Description>
-            <maml:para>{{ Fill SetPlainTextPasswords Description }}</maml:para>
+            <maml:para>Set to true, if plaintext passwords shall be displayed.</maml:para>
           </maml:Description>
           <command:parameterValue required="true" variableLength="false">Boolean</command:parameterValue>
           <dev:type>
@@ -11149,7 +11149,7 @@ A for Administrator, M for Modify or V for View permissions.</maml:para>
         <command:parameter required="true" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="named" aliases="Baseuri">
           <maml:name>Uri</maml:name>
           <maml:Description>
-            <maml:para>{{ Fill Uri Description }}</maml:para>
+            <maml:para>The url of the passwordstate website.</maml:para>
           </maml:Description>
           <command:parameterValue required="true" variableLength="false">Uri</command:parameterValue>
           <dev:type>
@@ -11221,7 +11221,7 @@ A for Administrator, M for Modify or V for View permissions.</maml:para>
       <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="named" aliases="none">
         <maml:name>PasswordGeneratorAPIkey</maml:name>
         <maml:Description>
-          <maml:para>{{Fill PasswordGeneratorAPIkey Description}}</maml:para>
+          <maml:para>The API Key for the password generator usage.</maml:para>
         </maml:Description>
         <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
         <dev:type>
@@ -11233,7 +11233,7 @@ A for Administrator, M for Modify or V for View permissions.</maml:para>
       <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="named" aliases="none">
         <maml:name>path</maml:name>
         <maml:Description>
-          <maml:para>{{ Fill path Description }}</maml:para>
+          <maml:para>The path to the json configuration file for the passwordstate environment.</maml:para>
         </maml:Description>
         <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
         <dev:type>
@@ -11245,7 +11245,7 @@ A for Administrator, M for Modify or V for View permissions.</maml:para>
       <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="none">
         <maml:name>SetPlainTextPasswords</maml:name>
         <maml:Description>
-          <maml:para>{{ Fill SetPlainTextPasswords Description }}</maml:para>
+          <maml:para>Set to true, if plaintext passwords shall be displayed.</maml:para>
         </maml:Description>
         <command:parameterValue required="true" variableLength="false">Boolean</command:parameterValue>
         <dev:type>
@@ -11257,7 +11257,7 @@ A for Administrator, M for Modify or V for View permissions.</maml:para>
       <command:parameter required="true" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="named" aliases="Baseuri">
         <maml:name>Uri</maml:name>
         <maml:Description>
-          <maml:para>{{ Fill Uri Description }}</maml:para>
+          <maml:para>The url of the passwordstate website.</maml:para>
         </maml:Description>
         <command:parameterValue required="true" variableLength="false">Uri</command:parameterValue>
         <dev:type>
@@ -11409,7 +11409,8 @@ A for Administrator, M for Modify or V for View permissions.</maml:para>
         <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="10" aliases="none">
           <maml:name>GenericField2</maml:name>
           <maml:Description>
-            <maml:para>{{Fill GenericField2 Description}}</maml:para>
+            <maml:para>An optional parameter to set the generic field value.
+A generic field is a string field which can be renamed to a different value when being displayed in the PasswordState web interface. Note : Generic Fields can be configured as different Field Types, so ensure you pass a valid value for text fields, Select Lists, Radio Buttons or Date Fields.</maml:para>
           </maml:Description>
           <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
           <dev:type>
@@ -11421,7 +11422,8 @@ A for Administrator, M for Modify or V for View permissions.</maml:para>
         <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="11" aliases="none">
           <maml:name>GenericField3</maml:name>
           <maml:Description>
-            <maml:para>{{Fill GenericField3 Description}}</maml:para>
+            <maml:para>An optional parameter to set the generic field value.
+A generic field is a string field which can be renamed to a different value when being displayed in the PasswordState web interface. Note : Generic Fields can be configured as different Field Types, so ensure you pass a valid value for text fields, Select Lists, Radio Buttons or Date Fields.</maml:para>
           </maml:Description>
           <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
           <dev:type>
@@ -11433,7 +11435,8 @@ A for Administrator, M for Modify or V for View permissions.</maml:para>
         <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="12" aliases="none">
           <maml:name>GenericField4</maml:name>
           <maml:Description>
-            <maml:para>{{Fill GenericField4 Description}}</maml:para>
+            <maml:para>An optional parameter to set the generic field value.
+A generic field is a string field which can be renamed to a different value when being displayed in the PasswordState web interface. Note : Generic Fields can be configured as different Field Types, so ensure you pass a valid value for text fields, Select Lists, Radio Buttons or Date Fields.</maml:para>
           </maml:Description>
           <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
           <dev:type>
@@ -11445,7 +11448,8 @@ A for Administrator, M for Modify or V for View permissions.</maml:para>
         <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="13" aliases="none">
           <maml:name>GenericField5</maml:name>
           <maml:Description>
-            <maml:para>{{Fill GenericField5 Description}}</maml:para>
+            <maml:para>An optional parameter to set the generic field value.
+A generic field is a string field which can be renamed to a different value when being displayed in the PasswordState web interface. Note : Generic Fields can be configured as different Field Types, so ensure you pass a valid value for text fields, Select Lists, Radio Buttons or Date Fields.</maml:para>
           </maml:Description>
           <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
           <dev:type>
@@ -11457,7 +11461,8 @@ A for Administrator, M for Modify or V for View permissions.</maml:para>
         <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="14" aliases="none">
           <maml:name>GenericField6</maml:name>
           <maml:Description>
-            <maml:para>{{Fill GenericField6 Description}}</maml:para>
+            <maml:para>An optional parameter to set the generic field value.
+A generic field is a string field which can be renamed to a different value when being displayed in the PasswordState web interface. Note : Generic Fields can be configured as different Field Types, so ensure you pass a valid value for text fields, Select Lists, Radio Buttons or Date Fields.</maml:para>
           </maml:Description>
           <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
           <dev:type>
@@ -11469,7 +11474,8 @@ A for Administrator, M for Modify or V for View permissions.</maml:para>
         <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="15" aliases="none">
           <maml:name>GenericField7</maml:name>
           <maml:Description>
-            <maml:para>{{Fill GenericField7 Description}}</maml:para>
+            <maml:para>An optional parameter to set the generic field value.
+A generic field is a string field which can be renamed to a different value when being displayed in the PasswordState web interface. Note : Generic Fields can be configured as different Field Types, so ensure you pass a valid value for text fields, Select Lists, Radio Buttons or Date Fields.</maml:para>
           </maml:Description>
           <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
           <dev:type>
@@ -11481,7 +11487,8 @@ A for Administrator, M for Modify or V for View permissions.</maml:para>
         <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="16" aliases="none">
           <maml:name>GenericField8</maml:name>
           <maml:Description>
-            <maml:para>{{Fill GenericField8 Description}}</maml:para>
+            <maml:para>An optional parameter to set the generic field value.
+A generic field is a string field which can be renamed to a different value when being displayed in the PasswordState web interface. Note : Generic Fields can be configured as different Field Types, so ensure you pass a valid value for text fields, Select Lists, Radio Buttons or Date Fields.</maml:para>
           </maml:Description>
           <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
           <dev:type>
@@ -11493,7 +11500,8 @@ A for Administrator, M for Modify or V for View permissions.</maml:para>
         <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="17" aliases="none">
           <maml:name>GenericField9</maml:name>
           <maml:Description>
-            <maml:para>{{Fill GenericField9 Description}}</maml:para>
+            <maml:para>An optional parameter to set the generic field value.
+A generic field is a string field which can be renamed to a different value when being displayed in the PasswordState web interface. Note : Generic Fields can be configured as different Field Types, so ensure you pass a valid value for text fields, Select Lists, Radio Buttons or Date Fields.</maml:para>
           </maml:Description>
           <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
           <dev:type>
@@ -11505,7 +11513,8 @@ A for Administrator, M for Modify or V for View permissions.</maml:para>
         <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="18" aliases="none">
           <maml:name>GenericField10</maml:name>
           <maml:Description>
-            <maml:para>{{Fill GenericField10 Description}}</maml:para>
+            <maml:para>An optional parameter to set the generic field value.
+A generic field is a string field which can be renamed to a different value when being displayed in the PasswordState web interface. Note : Generic Fields can be configured as different Field Types, so ensure you pass a valid value for text fields, Select Lists, Radio Buttons or Date Fields.</maml:para>
           </maml:Description>
           <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
           <dev:type>
@@ -11517,7 +11526,7 @@ A for Administrator, M for Modify or V for View permissions.</maml:para>
         <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="19" aliases="none">
           <maml:name>PreventAuditing</maml:name>
           <maml:Description>
-            <maml:para>{{Fill PreventAuditing Description}}</maml:para>
+            <maml:para>By default, the creation/modification or retrieval of (all) Passwords records will add one Audit record for every Password record returned. If you wish to prevent audit records from being added, you can add this `-PreventAuditing` parameter.</maml:para>
           </maml:Description>
           <dev:type>
             <maml:name>SwitchParameter</maml:name>
@@ -11612,7 +11621,8 @@ A for Administrator, M for Modify or V for View permissions.</maml:para>
         <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="9" aliases="none">
           <maml:name>GenericField1</maml:name>
           <maml:Description>
-            <maml:para>{{Fill GenericField1 Description}}</maml:para>
+            <maml:para>An optional parameter to set the generic field value.
+A generic field is a string field which can be renamed to a different value when being displayed in the PasswordState web interface. Note : Generic Fields can be configured as different Field Types, so ensure you pass a valid value for text fields, Select Lists, Radio Buttons or Date Fields.</maml:para>
           </maml:Description>
           <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
           <dev:type>
@@ -11661,7 +11671,8 @@ A for Administrator, M for Modify or V for View permissions.</maml:para>
       <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="9" aliases="none">
         <maml:name>GenericField1</maml:name>
         <maml:Description>
-          <maml:para>{{Fill GenericField1 Description}}</maml:para>
+          <maml:para>An optional parameter to set the generic field value.
+A generic field is a string field which can be renamed to a different value when being displayed in the PasswordState web interface. Note : Generic Fields can be configured as different Field Types, so ensure you pass a valid value for text fields, Select Lists, Radio Buttons or Date Fields.</maml:para>
         </maml:Description>
         <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
         <dev:type>
@@ -11673,7 +11684,8 @@ A for Administrator, M for Modify or V for View permissions.</maml:para>
       <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="18" aliases="none">
         <maml:name>GenericField10</maml:name>
         <maml:Description>
-          <maml:para>{{Fill GenericField10 Description}}</maml:para>
+          <maml:para>An optional parameter to set the generic field value.
+A generic field is a string field which can be renamed to a different value when being displayed in the PasswordState web interface. Note : Generic Fields can be configured as different Field Types, so ensure you pass a valid value for text fields, Select Lists, Radio Buttons or Date Fields.</maml:para>
         </maml:Description>
         <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
         <dev:type>
@@ -11685,7 +11697,8 @@ A for Administrator, M for Modify or V for View permissions.</maml:para>
       <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="10" aliases="none">
         <maml:name>GenericField2</maml:name>
         <maml:Description>
-          <maml:para>{{Fill GenericField2 Description}}</maml:para>
+          <maml:para>An optional parameter to set the generic field value.
+A generic field is a string field which can be renamed to a different value when being displayed in the PasswordState web interface. Note : Generic Fields can be configured as different Field Types, so ensure you pass a valid value for text fields, Select Lists, Radio Buttons or Date Fields.</maml:para>
         </maml:Description>
         <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
         <dev:type>
@@ -11697,7 +11710,8 @@ A for Administrator, M for Modify or V for View permissions.</maml:para>
       <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="11" aliases="none">
         <maml:name>GenericField3</maml:name>
         <maml:Description>
-          <maml:para>{{Fill GenericField3 Description}}</maml:para>
+          <maml:para>An optional parameter to set the generic field value.
+A generic field is a string field which can be renamed to a different value when being displayed in the PasswordState web interface. Note : Generic Fields can be configured as different Field Types, so ensure you pass a valid value for text fields, Select Lists, Radio Buttons or Date Fields.</maml:para>
         </maml:Description>
         <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
         <dev:type>
@@ -11709,7 +11723,8 @@ A for Administrator, M for Modify or V for View permissions.</maml:para>
       <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="12" aliases="none">
         <maml:name>GenericField4</maml:name>
         <maml:Description>
-          <maml:para>{{Fill GenericField4 Description}}</maml:para>
+          <maml:para>An optional parameter to set the generic field value.
+A generic field is a string field which can be renamed to a different value when being displayed in the PasswordState web interface. Note : Generic Fields can be configured as different Field Types, so ensure you pass a valid value for text fields, Select Lists, Radio Buttons or Date Fields.</maml:para>
         </maml:Description>
         <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
         <dev:type>
@@ -11721,7 +11736,8 @@ A for Administrator, M for Modify or V for View permissions.</maml:para>
       <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="13" aliases="none">
         <maml:name>GenericField5</maml:name>
         <maml:Description>
-          <maml:para>{{Fill GenericField5 Description}}</maml:para>
+          <maml:para>An optional parameter to set the generic field value.
+A generic field is a string field which can be renamed to a different value when being displayed in the PasswordState web interface. Note : Generic Fields can be configured as different Field Types, so ensure you pass a valid value for text fields, Select Lists, Radio Buttons or Date Fields.</maml:para>
         </maml:Description>
         <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
         <dev:type>
@@ -11733,7 +11749,8 @@ A for Administrator, M for Modify or V for View permissions.</maml:para>
       <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="14" aliases="none">
         <maml:name>GenericField6</maml:name>
         <maml:Description>
-          <maml:para>{{Fill GenericField6 Description}}</maml:para>
+          <maml:para>An optional parameter to set the generic field value.
+A generic field is a string field which can be renamed to a different value when being displayed in the PasswordState web interface. Note : Generic Fields can be configured as different Field Types, so ensure you pass a valid value for text fields, Select Lists, Radio Buttons or Date Fields.</maml:para>
         </maml:Description>
         <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
         <dev:type>
@@ -11745,7 +11762,8 @@ A for Administrator, M for Modify or V for View permissions.</maml:para>
       <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="15" aliases="none">
         <maml:name>GenericField7</maml:name>
         <maml:Description>
-          <maml:para>{{Fill GenericField7 Description}}</maml:para>
+          <maml:para>An optional parameter to set the generic field value.
+A generic field is a string field which can be renamed to a different value when being displayed in the PasswordState web interface. Note : Generic Fields can be configured as different Field Types, so ensure you pass a valid value for text fields, Select Lists, Radio Buttons or Date Fields.</maml:para>
         </maml:Description>
         <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
         <dev:type>
@@ -11757,7 +11775,8 @@ A for Administrator, M for Modify or V for View permissions.</maml:para>
       <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="16" aliases="none">
         <maml:name>GenericField8</maml:name>
         <maml:Description>
-          <maml:para>{{Fill GenericField8 Description}}</maml:para>
+          <maml:para>An optional parameter to set the generic field value.
+A generic field is a string field which can be renamed to a different value when being displayed in the PasswordState web interface. Note : Generic Fields can be configured as different Field Types, so ensure you pass a valid value for text fields, Select Lists, Radio Buttons or Date Fields.</maml:para>
         </maml:Description>
         <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
         <dev:type>
@@ -11769,7 +11788,8 @@ A for Administrator, M for Modify or V for View permissions.</maml:para>
       <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="17" aliases="none">
         <maml:name>GenericField9</maml:name>
         <maml:Description>
-          <maml:para>{{Fill GenericField9 Description}}</maml:para>
+          <maml:para>An optional parameter to set the generic field value.
+A generic field is a string field which can be renamed to a different value when being displayed in the PasswordState web interface. Note : Generic Fields can be configured as different Field Types, so ensure you pass a valid value for text fields, Select Lists, Radio Buttons or Date Fields.</maml:para>
         </maml:Description>
         <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
         <dev:type>
@@ -11829,7 +11849,7 @@ A for Administrator, M for Modify or V for View permissions.</maml:para>
       <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="19" aliases="none">
         <maml:name>PreventAuditing</maml:name>
         <maml:Description>
-          <maml:para>{{Fill PreventAuditing Description}}</maml:para>
+          <maml:para>By default, the creation/modification or retrieval of (all) Passwords records will add one Audit record for every Password record returned. If you wish to prevent audit records from being added, you can add this `-PreventAuditing` parameter.</maml:para>
         </maml:Description>
         <command:parameterValue required="false" variableLength="false">SwitchParameter</command:parameterValue>
         <dev:type>

--- a/functions/Get-PasswordStatePassword.ps1
+++ b/functions/Get-PasswordStatePassword.ps1
@@ -10,7 +10,7 @@
         [Parameter(ParameterSetName = 'Specific', ValueFromPipelineByPropertyName, Position = 0)][string]$Title,
         [Parameter(ParameterSetName = 'Specific', ValueFromPipelineByPropertyName, Position = 1)][string]$UserName,
         [Parameter(ParameterSetName = 'Specific', ValueFromPipelineByPropertyName, Position = 2)][string]$HostName,
-        [Parameter(ParameterSetName = 'Specific', ValueFromPipelineByPropertyName, Position = 3)][Alias('Domain')][string]$ADDomainNetBIOS,
+        [Parameter(ParameterSetName = 'Specific', ValueFromPipelineByPropertyName, Position = 3)][string]$Domain,
         [Parameter(ParameterSetName = 'Specific', ValueFromPipelineByPropertyName, Position = 4)][string]$AccountType,
         [Parameter(ParameterSetName = 'Specific', ValueFromPipelineByPropertyName, Position = 5)][string]$Description,
         [Parameter(ParameterSetName = 'Specific', ValueFromPipelineByPropertyName, Position = 6)][string]$Notes,
@@ -58,7 +58,8 @@
         [Parameter(ParameterSetName = 'Specific', ValueFromPipelineByPropertyName, Position = 24)][ValidateSet('AND', 'OR')][string]$AndOr,
         [Parameter(ParameterSetName = 'General', ValueFromPipelineByPropertyName, Position = 1)][Parameter(ParameterSetName = 'Specific', ValueFromPipelineByPropertyName, Position = 25)][int32]$PasswordListID,
         [parameter(ValueFromPipelineByPropertyName, Position = 26)][string]$Reason,
-        [parameter(ValueFromPipelineByPropertyName, Position = 27)][switch]$PreventAuditing
+        [parameter(ValueFromPipelineByPropertyName, Position = 27)][switch]$PreventAuditing,
+        [Parameter(ParameterSetName = 'Specific', ValueFromPipelineByPropertyName, Position = 28)][string]$ADDomainNetBIOS
     )
 
     Begin {
@@ -105,6 +106,7 @@
                 If ($UserName) { $BuildURL += "UserName=$([System.Web.HttpUtility]::UrlEncode($UserName))&" }
                 If ($HostName) { $BuildURL += "HostName=$([System.Web.HttpUtility]::UrlEncode($HostName))&" }
                 If ($ADDomainNetBIOS) { $BuildURL += "ADDomainNetBIOS=$([System.Web.HttpUtility]::UrlEncode($ADDomainNetBIOS))&" }
+                If ($Domain) { $BuildURL += "Domain=$([System.Web.HttpUtility]::UrlEncode($Domain))&" }
                 If ($AccountType) { $BuildURL += "AccountType=$([System.Web.HttpUtility]::UrlEncode($AccountType))&" }
                 If ($Description) { $BuildURL += "Description=$([System.Web.HttpUtility]::UrlEncode($Description))&" }
                 If ($Notes) { $BuildURL += "Notes=$([System.Web.HttpUtility]::UrlEncode($Notes))&" }

--- a/functions/Get-PasswordStatePassword.ps1
+++ b/functions/Get-PasswordStatePassword.ps1
@@ -1,6 +1,6 @@
 ﻿Function Get-PasswordStatePassword {
     [Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSAvoidUsingPlainTextForPassword', '', Justification = 'No Password is used only ID.')]
-    [Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSAvoidUsingUserNameAndPassWordParams', '', Justification = 'PasswordID isnt a password')]
+    [Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSAvoidUsingUserNameAndPassWordParams', '', Justification = 'PasswordID is not a password')]
     [Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSAvoidGlobalVars', '', Justification = 'Needed for backward compatability')]
     [CmdletBinding(DefaultParameterSetName = 'General')]
     Param
@@ -10,7 +10,7 @@
         [Parameter(ParameterSetName = 'Specific', ValueFromPipelineByPropertyName, Position = 0)][string]$Title,
         [Parameter(ParameterSetName = 'Specific', ValueFromPipelineByPropertyName, Position = 1)][string]$UserName,
         [Parameter(ParameterSetName = 'Specific', ValueFromPipelineByPropertyName, Position = 2)][string]$HostName,
-        [Parameter(ParameterSetName = 'Specific', ValueFromPipelineByPropertyName, Position = 3)][string]$Domain,
+        [Parameter(ParameterSetName = 'Specific', ValueFromPipelineByPropertyName, Position = 3)][Alias('Domain')][string]$ADDomainNetBIOS,
         [Parameter(ParameterSetName = 'Specific', ValueFromPipelineByPropertyName, Position = 4)][string]$AccountType,
         [Parameter(ParameterSetName = 'Specific', ValueFromPipelineByPropertyName, Position = 5)][string]$Description,
         [Parameter(ParameterSetName = 'Specific', ValueFromPipelineByPropertyName, Position = 6)][string]$Notes,
@@ -27,9 +27,38 @@
         [Parameter(ParameterSetName = 'Specific', ValueFromPipelineByPropertyName, Position = 17)][string]$GenericField8,
         [Parameter(ParameterSetName = 'Specific', ValueFromPipelineByPropertyName, Position = 18)][string]$GenericField9,
         [Parameter(ParameterSetName = 'Specific', ValueFromPipelineByPropertyName, Position = 19)][string]$GenericField10,
-        [Parameter(ParameterSetName = 'General', ValueFromPipelineByPropertyName, Position = 1)][Parameter(ParameterSetName = 'Specific', ValueFromPipelineByPropertyName, Position = 20)][int32]$PasswordListID,
-        [parameter(ValueFromPipelineByPropertyName, Position = 21)][string]$Reason,
-        [parameter(ValueFromPipelineByPropertyName, Position = 22)][switch]$PreventAuditing
+        [Parameter(ParameterSetName = 'Specific', ValueFromPipelineByPropertyName, Position = 20)][string]$AccountTypeID,
+        [Parameter(ParameterSetName = 'Specific', ValueFromPipelineByPropertyName, Position = 21)][switch]$PasswordResetEnabled,
+        [Parameter(ParameterSetName = 'Specific', ValueFromPipelineByPropertyName, Position = 22)]
+        [ValidateScript( {
+                # The dates for the ExpiryDate needs to be culture aware, so we cannot validate a specific date format.
+                function isDate([string]$StrDate) {
+                    [boolean]($StrDate -as [DateTime])
+                }
+                if (!(isDate $_)) {
+                    throw "Given ExpiryDate '$_' is not a valid Date format. Also, please specify the ExpiryDate in the date format that you have chosen in 'System Settings - miscellaneous - Default Locale' (Default: 'YYYY-MM-DD')."
+                }
+                else {
+                    $true
+                }
+            })]
+        [string]$ExpiryDate,
+        [Parameter(ParameterSetName = 'Specific', ValueFromPipelineByPropertyName, Position = 23, HelpMessage = 'Format: ExpiryDate>=2012-07-14,ExpiryDate<=2020-12-31')]
+        [ValidateScript( {
+                # The dates here for the ExpiryDate(s) do NOT need to be culture aware, so we can validate a specific date format with a regular expression.
+                # So we only need to validate if the format of the entire ExpiryDateRange string is correct.
+                if ($_ -notmatch 'ExpiryDate[\<=\>]{1,2}(19|20)[0-9]{2}[-](0[1-9]|1[012])[-](0[1-9]|[12][0-9]|3[01]),ExpiryDate[\<=\>]{1,2}(19|20)[0-9]{2}[-](0[1-9]|1[012])[-](0[1-9]|[12][0-9]|3[01])') {
+                    throw "Given ExpiryDateRange '$_' is not a valid ExpiryDateRange format. Please use the following format (single comma between ExpiryDates): 'ExpiryDate>=2012-07-14,ExpiryDate<=2020-12-31' (Also, please specify the ExpiryDates in the ISO 8601 international date format 'YYYY-MM-DD')."
+                }
+                else {
+                    $true
+                }
+            })]
+        [string]$ExpiryDateRange,
+        [Parameter(ParameterSetName = 'Specific', ValueFromPipelineByPropertyName, Position = 24)][ValidateSet('AND', 'OR')][string]$AndOr,
+        [Parameter(ParameterSetName = 'General', ValueFromPipelineByPropertyName, Position = 1)][Parameter(ParameterSetName = 'Specific', ValueFromPipelineByPropertyName, Position = 25)][int32]$PasswordListID,
+        [parameter(ValueFromPipelineByPropertyName, Position = 26)][string]$Reason,
+        [parameter(ValueFromPipelineByPropertyName, Position = 27)][switch]$PreventAuditing
     )
 
     Begin {
@@ -39,8 +68,8 @@
     Process {
         # Add a reason to the audit log
         If ($Reason) {
-            $headerreason = @{"Reason" = "$reason"}
-            $parms = @{ExtraParams = @{"Headers" = $headerreason}}
+            $headerreason = @{"Reason" = "$reason" }
+            $parms = @{ExtraParams = @{"Headers" = $headerreason } }
         }
 
         # If PasswordListID wasn't set, make the variable an empty string
@@ -52,8 +81,14 @@
             # General search
             'General' {
                 if ([string]::IsNullOrEmpty($Search)) {
-                    # Return all Passwords
-                    $uri = "/api/passwords/$($PasswordlistID)?QueryAll"
+                    # Return all Passwords for the given PasswordList
+                    if ($PasswordListID) {
+                        $uri = "/api/passwords/$($PasswordListID)?QueryAll"
+                    }
+                    # Return all Passwords that the user/APIKey has access to
+                    else {
+                        $uri = "/api/passwords/?QueryAll"
+                    }
                 }
                 Else {
                     $uri = "/api/searchpasswords/$($PasswordListID)?Search=$([System.Web.HttpUtility]::UrlEncode($Search))"
@@ -66,44 +101,54 @@
             # Search with a variety of filters
             'Specific' {
                 $BuildURL = '?'
-                If ($Title) {          $BuildURL += "Title=$([System.Web.HttpUtility]::UrlEncode($Title))&" }
-                If ($UserName) {       $BuildURL += "UserName=$([System.Web.HttpUtility]::UrlEncode($UserName))&" }
-                If ($HostName) {       $BuildURL += "HostName=$([System.Web.HttpUtility]::UrlEncode($HostName))&" }
-                If ($Domain) {         $BuildURL += "Domain=$([System.Web.HttpUtility]::UrlEncode($Domain))&" }
-                If ($AccountType) {    $BuildURL += "AccountType=$([System.Web.HttpUtility]::UrlEncode($AccountType))&" }
-                If ($Description) {    $BuildURL += "Description=$([System.Web.HttpUtility]::UrlEncode($Description))&" }
-                If ($Notes) {          $BuildURL += "Notes=$([System.Web.HttpUtility]::UrlEncode($Notes))&" }
-                If ($URL) {            $BuildURL += "URL=$([System.Web.HttpUtility]::UrlEncode($URL))&" }
-                If ($SiteID) {         $BuildURL += "SiteID=$([System.Web.HttpUtility]::UrlEncode($SiteID))&" }
-                If ($SiteLocation) {   $BuildURL += "SiteLocation=$([System.Web.HttpUtility]::UrlEncode($SiteLocation))&" }
-                If ($GenericField1) {  $BuildURL += "GenericField1=$([System.Web.HttpUtility]::UrlEncode($GenericField1))&" }
-                If ($GenericField2) {  $BuildURL += "GenericField2=$([System.Web.HttpUtility]::UrlEncode($GenericField2))&" }
-                If ($GenericField3) {  $BuildURL += "GenericField3=$([System.Web.HttpUtility]::UrlEncode($GenericField3))&" }
-                If ($GenericField4) {  $BuildURL += "GenericField4=$([System.Web.HttpUtility]::UrlEncode($GenericField4))&" }
-                If ($GenericField5) {  $BuildURL += "GenericField5=$([System.Web.HttpUtility]::UrlEncode($GenericField5))&" }
-                If ($GenericField6) {  $BuildURL += "GenericField6=$([System.Web.HttpUtility]::UrlEncode($GenericField6))&" }
-                If ($GenericField7) {  $BuildURL += "GenericField7=$([System.Web.HttpUtility]::UrlEncode($GenericField7))&" }
-                If ($GenericField8) {  $BuildURL += "GenericField8=$([System.Web.HttpUtility]::UrlEncode($GenericField8))&" }
-                If ($GenericField9) {  $BuildURL += "GenericField9=$([System.Web.HttpUtility]::UrlEncode($GenericField9))&" }
+                If ($Title) { $BuildURL += "Title=$([System.Web.HttpUtility]::UrlEncode($Title))&" }
+                If ($UserName) { $BuildURL += "UserName=$([System.Web.HttpUtility]::UrlEncode($UserName))&" }
+                If ($HostName) { $BuildURL += "HostName=$([System.Web.HttpUtility]::UrlEncode($HostName))&" }
+                If ($ADDomainNetBIOS) { $BuildURL += "ADDomainNetBIOS=$([System.Web.HttpUtility]::UrlEncode($ADDomainNetBIOS))&" }
+                If ($AccountType) { $BuildURL += "AccountType=$([System.Web.HttpUtility]::UrlEncode($AccountType))&" }
+                If ($Description) { $BuildURL += "Description=$([System.Web.HttpUtility]::UrlEncode($Description))&" }
+                If ($Notes) { $BuildURL += "Notes=$([System.Web.HttpUtility]::UrlEncode($Notes))&" }
+                If ($URL) { $BuildURL += "URL=$([System.Web.HttpUtility]::UrlEncode($URL))&" }
+                If ($SiteID) { $BuildURL += "SiteID=$([System.Web.HttpUtility]::UrlEncode($SiteID))&" }
+                If ($SiteLocation) { $BuildURL += "SiteLocation=$([System.Web.HttpUtility]::UrlEncode($SiteLocation))&" }
+                If ($GenericField1) { $BuildURL += "GenericField1=$([System.Web.HttpUtility]::UrlEncode($GenericField1))&" }
+                If ($GenericField2) { $BuildURL += "GenericField2=$([System.Web.HttpUtility]::UrlEncode($GenericField2))&" }
+                If ($GenericField3) { $BuildURL += "GenericField3=$([System.Web.HttpUtility]::UrlEncode($GenericField3))&" }
+                If ($GenericField4) { $BuildURL += "GenericField4=$([System.Web.HttpUtility]::UrlEncode($GenericField4))&" }
+                If ($GenericField5) { $BuildURL += "GenericField5=$([System.Web.HttpUtility]::UrlEncode($GenericField5))&" }
+                If ($GenericField6) { $BuildURL += "GenericField6=$([System.Web.HttpUtility]::UrlEncode($GenericField6))&" }
+                If ($GenericField7) { $BuildURL += "GenericField7=$([System.Web.HttpUtility]::UrlEncode($GenericField7))&" }
+                If ($GenericField8) { $BuildURL += "GenericField8=$([System.Web.HttpUtility]::UrlEncode($GenericField8))&" }
+                If ($GenericField9) { $BuildURL += "GenericField9=$([System.Web.HttpUtility]::UrlEncode($GenericField9))&" }
                 If ($GenericField10) { $BuildURL += "GenericField10=$([System.Web.HttpUtility]::UrlEncode($GenericField10))&" }
+                If ($AccountTypeID) { $BuildURL += "AccountTypeID=$([System.Web.HttpUtility]::UrlEncode($AccountTypeID))&" }
+                If ($PasswordResetEnabled.IsPresent) { $BuildURL += "PasswordResetEnabled=$([System.Web.HttpUtility]::UrlEncode('true'))&" }
+                If ($ExpiryDateRange) { $BuildURL += "ExpiryDateRange=$([System.Web.HttpUtility]::UrlEncode($ExpiryDateRange))&" }
+                If ($ExpiryDate) { $BuildURL += "ExpiryDate=$([System.Web.HttpUtility]::UrlEncode($ExpiryDate))&" }
+                If ($AndOr) { $BuildURL += "AndOr=$([System.Web.HttpUtility]::UrlEncode($AndOr))&" }
 
                 $BuildURL = $BuildURL -Replace ".$"
 
-                $uri = "/api/searchpasswords/$($PasswordListID)$($BuildURL)"
+                if ($PasswordListID) {
+                    $uri = "/api/searchpasswords/$($PasswordListID)$($BuildURL)"
+                }
+                else {
+                    $uri = "/api/searchpasswords/$($BuildURL)"
+                }
             }
         }
-        Switch ($PreventAuditing){
+        Switch ($PreventAuditing) {
             $True {
-              $uri +=  "&PreventAuditing=true"
+                $uri += "&PreventAuditing=true"
             }
-            Default{
+            Default {
 
             }
         }
         Try {
-            foreach ($PWSEntry in (Get-PasswordStateResource -URI $uri @parms  -Method GET)) {
+            foreach ($PWSEntry in (Get-PasswordStateResource -URI $uri @parms -Method GET)) {
                 [PasswordResult]$PWSEntry = $PWSEntry
-                if(!$PWSProfile.PasswordsInPlainText) {
+                if (!$PWSProfile.PasswordsInPlainText) {
                     $PWSEntry.Password = [EncryptedPassword]$PWSEntry.Password
                 }
                 $PWSEntry
@@ -116,4 +161,4 @@
     }
 }
 
-Set-Alias -Name Find-PasswordstatePassword -Value Get-PasswordStatePassword -Force
+Set-Alias -Name Find-PasswordStatePassword -Value Get-PasswordStatePassword -Force

--- a/tests/functions/Get-PasswordStatePassword.Tests.ps1
+++ b/tests/functions/Get-PasswordStatePassword.Tests.ps1
@@ -14,7 +14,7 @@ InModuleScope 'Passwordstate-Management' {
                 @{parametername = 'Title'; mandatory = 'False'; ParameterSetName = "Specific" }
                 , @{parametername = 'UserName'; mandatory = 'False'; ParameterSetName = "Specific" }
                 , @{parametername = 'HostName'; mandatory = 'False'; ParameterSetName = "Specific" }
-                , @{parametername = 'ADDomainNetBIOS'; mandatory = 'False'; ParameterSetName = "Specific" }
+                , @{parametername = 'Domain'; mandatory = 'False'; ParameterSetName = "Specific" }
                 , @{parametername = 'AccountType'; mandatory = 'False'; ParameterSetName = "Specific" }
                 , @{parametername = 'Description'; mandatory = 'False'; ParameterSetName = "Specific" }
                 , @{parametername = 'Notes'; mandatory = 'False'; ParameterSetName = "Specific" }
@@ -38,7 +38,7 @@ InModuleScope 'Passwordstate-Management' {
                 @{parametername = 'Title'; testvalue = "Demo AD Username"; ListCount = 2; PWLID = 53 }
                 , @{parametername = 'UserName'; testvalue = "username1"; ListCount = 3; PWLID = 53 }
                 , @{parametername = 'HostName'; testvalue = "HostA"; ListCount = 4; PWLID = 53 }
-                , @{parametername = 'ADDomainNetBIOS'; testvalue = "MYDomain"; ListCount = 5; PWLID = 53 }
+                , @{parametername = 'Domain'; testvalue = "MYDomain"; ListCount = 5; PWLID = 53 }
                 , @{parametername = 'AccountType'; testvalue = ""; ListCount = 1; PWLID = 53 } # testvalue must be empty because the actual property is AccountTypeID
                 , @{parametername = 'Description'; testvalue = "Description for "; ListCount = 6; PWLID = 53 }
                 , @{parametername = 'Notes'; testvalue = "Same Notes"; ListCount = 7; PWLID = 53 }
@@ -98,7 +98,7 @@ InModuleScope 'Passwordstate-Management' {
                 @{parametername = 'Title'; mandatory = 'False'; ParameterSetName = "Specific" }
                 , @{parametername = 'UserName'; mandatory = 'False'; ParameterSetName = "Specific" }
                 , @{parametername = 'HostName'; mandatory = 'False'; ParameterSetName = "Specific" }
-                , @{parametername = 'ADDomainNetBIOS'; mandatory = 'False'; ParameterSetName = "Specific" }
+                , @{parametername = 'Domain'; mandatory = 'False'; ParameterSetName = "Specific" }
                 , @{parametername = 'AccountType'; mandatory = 'False'; ParameterSetName = "Specific" }
                 , @{parametername = 'Description'; mandatory = 'False'; ParameterSetName = "Specific" }
                 , @{parametername = 'Notes'; mandatory = 'False'; ParameterSetName = "Specific" }
@@ -122,7 +122,7 @@ InModuleScope 'Passwordstate-Management' {
                 @{parametername = 'Title'; testvalue = "Demo AD Username"; ListCount = 2; PWLID = 53 }
                 , @{parametername = 'UserName'; testvalue = "username1"; ListCount = 3; PWLID = 53 }
                 , @{parametername = 'HostName'; testvalue = "HostA"; ListCount = 4; PWLID = 53 }
-                , @{parametername = 'ADDomainNetBIOS'; testvalue = "MYDomain"; ListCount = 5; PWLID = 53 }
+                , @{parametername = 'Domain'; testvalue = "MYDomain"; ListCount = 5; PWLID = 53 }
                 , @{parametername = 'AccountType'; testvalue = ""; ListCount = 1; PWLID = 53 } # testvalue must be empty because the actual property is AccountTypeID
                 , @{parametername = 'Description'; testvalue = "Description for "; ListCount = 6; PWLID = 53 }
                 , @{parametername = 'Notes'; testvalue = "Same Notes"; ListCount = 7; PWLID = 53 }
@@ -230,7 +230,7 @@ InModuleScope 'Passwordstate-Management' {
                 @{parametername = 'Title'; mandatory = 'False'; ParameterSetName = "Specific" }
                 , @{parametername = 'UserName'; mandatory = 'False'; ParameterSetName = "Specific" }
                 , @{parametername = 'HostName'; mandatory = 'False'; ParameterSetName = "Specific" }
-                , @{parametername = 'ADDomainNetBIOS'; mandatory = 'False'; ParameterSetName = "Specific" }
+                , @{parametername = 'Domain'; mandatory = 'False'; ParameterSetName = "Specific" }
                 , @{parametername = 'AccountType'; mandatory = 'False'; ParameterSetName = "Specific" }
                 , @{parametername = 'Description'; mandatory = 'False'; ParameterSetName = "Specific" }
                 , @{parametername = 'Notes'; mandatory = 'False'; ParameterSetName = "Specific" }
@@ -254,7 +254,7 @@ InModuleScope 'Passwordstate-Management' {
                 @{parametername = 'Title'; testvalue = "Demo AD Username"; ListCount = 2; PWLID = 53 }
                 , @{parametername = 'UserName'; testvalue = "username1"; ListCount = 3; PWLID = 53 }
                 , @{parametername = 'HostName'; testvalue = "HostA"; ListCount = 4; PWLID = 53 }
-                , @{parametername = 'ADDomainNetBIOS'; testvalue = "MYDomain"; ListCount = 5; PWLID = 53 }
+                , @{parametername = 'Domain'; testvalue = "MYDomain"; ListCount = 5; PWLID = 53 }
                 , @{parametername = 'AccountType'; testvalue = ""; ListCount = 1; PWLID = 53 } # testvalue must be empty because the actual property is AccountTypeID
                 , @{parametername = 'Description'; testvalue = "Description for "; ListCount = 6; PWLID = 53 }
                 , @{parametername = 'Notes'; testvalue = "Same Notes"; ListCount = 7; PWLID = 53 }
@@ -362,7 +362,7 @@ InModuleScope 'Passwordstate-Management' {
                 @{parametername = 'Title'; mandatory = 'False'; ParameterSetName = "Specific" }
                 , @{parametername = 'UserName'; mandatory = 'False'; ParameterSetName = "Specific" }
                 , @{parametername = 'HostName'; mandatory = 'False'; ParameterSetName = "Specific" }
-                , @{parametername = 'ADDomainNetBIOS'; mandatory = 'False'; ParameterSetName = "Specific" }
+                , @{parametername = 'Domain'; mandatory = 'False'; ParameterSetName = "Specific" }
                 , @{parametername = 'AccountType'; mandatory = 'False'; ParameterSetName = "Specific" }
                 , @{parametername = 'Description'; mandatory = 'False'; ParameterSetName = "Specific" }
                 , @{parametername = 'Notes'; mandatory = 'False'; ParameterSetName = "Specific" }
@@ -386,7 +386,7 @@ InModuleScope 'Passwordstate-Management' {
                 @{parametername = 'Title'; testvalue = "Demo AD Username"; ListCount = 2; PWLID = 53 }
                 , @{parametername = 'UserName'; testvalue = "username1"; ListCount = 3; PWLID = 53 }
                 , @{parametername = 'HostName'; testvalue = "HostA"; ListCount = 4; PWLID = 53 }
-                , @{parametername = 'ADDomainNetBIOS'; testvalue = "MYDomain"; ListCount = 5; PWLID = 53 }
+                , @{parametername = 'Domain'; testvalue = "MYDomain"; ListCount = 5; PWLID = 53 }
                 , @{parametername = 'AccountType'; testvalue = ""; ListCount = 1; PWLID = 53 } # testvalue must be empty because the actual property is AccountTypeID
                 , @{parametername = 'Description'; testvalue = "Description for "; ListCount = 6; PWLID = 53 }
                 , @{parametername = 'Notes'; testvalue = "Same Notes"; ListCount = 7; PWLID = 53 }
@@ -494,7 +494,7 @@ InModuleScope 'Passwordstate-Management' {
                 @{parametername = 'Title'; mandatory = 'False'; ParameterSetName = "Specific" }
                 , @{parametername = 'UserName'; mandatory = 'False'; ParameterSetName = "Specific" }
                 , @{parametername = 'HostName'; mandatory = 'False'; ParameterSetName = "Specific" }
-                , @{parametername = 'ADDomainNetBIOS'; mandatory = 'False'; ParameterSetName = "Specific" }
+                , @{parametername = 'Domain'; mandatory = 'False'; ParameterSetName = "Specific" }
                 , @{parametername = 'AccountType'; mandatory = 'False'; ParameterSetName = "Specific" }
                 , @{parametername = 'Description'; mandatory = 'False'; ParameterSetName = "Specific" }
                 , @{parametername = 'Notes'; mandatory = 'False'; ParameterSetName = "Specific" }
@@ -518,7 +518,7 @@ InModuleScope 'Passwordstate-Management' {
                 @{parametername = 'Title'; testvalue = "Demo AD Username"; ListCount = 2; PWLID = 53 }
                 , @{parametername = 'UserName'; testvalue = "username1"; ListCount = 3; PWLID = 53 }
                 , @{parametername = 'HostName'; testvalue = "HostA"; ListCount = 4; PWLID = 53 }
-                , @{parametername = 'ADDomainNetBIOS'; testvalue = "MYDomain"; ListCount = 5; PWLID = 53 }
+                , @{parametername = 'Domain'; testvalue = "MYDomain"; ListCount = 5; PWLID = 53 }
                 , @{parametername = 'AccountType'; testvalue = ""; ListCount = 1; PWLID = 53 } # testvalue must be empty because the actual property is AccountTypeID
                 , @{parametername = 'Description'; testvalue = "Description for "; ListCount = 6; PWLID = 53 }
                 , @{parametername = 'Notes'; testvalue = "Same Notes"; ListCount = 7; PWLID = 53 }

--- a/tests/functions/Get-PasswordStatePassword.Tests.ps1
+++ b/tests/functions/Get-PasswordStatePassword.Tests.ps1
@@ -1,5 +1,5 @@
 Remove-Module PasswordState-Management -Force -ErrorAction SilentlyContinue
-Import-module "$($PSScriptRoot)\..\..\Passwordstate-management.psd1" -Force
+Import-Module "$($PSScriptRoot)\..\..\Passwordstate-management.psd1" -Force
 . "$($PSScriptRoot)\json\enum-jsonFiles.ps1"
 InModuleScope 'Passwordstate-Management' {
     Describe "Get-PasswordStatePassword parameter validation" {
@@ -14,7 +14,7 @@ InModuleScope 'Passwordstate-Management' {
                 @{parametername = 'Title'; mandatory = 'False'; ParameterSetName = "Specific" }
                 , @{parametername = 'UserName'; mandatory = 'False'; ParameterSetName = "Specific" }
                 , @{parametername = 'HostName'; mandatory = 'False'; ParameterSetName = "Specific" }
-                , @{parametername = 'Domain'; mandatory = 'False'; ParameterSetName = "Specific" }
+                , @{parametername = 'ADDomainNetBIOS'; mandatory = 'False'; ParameterSetName = "Specific" }
                 , @{parametername = 'AccountType'; mandatory = 'False'; ParameterSetName = "Specific" }
                 , @{parametername = 'Description'; mandatory = 'False'; ParameterSetName = "Specific" }
                 , @{parametername = 'Notes'; mandatory = 'False'; ParameterSetName = "Specific" }
@@ -38,7 +38,7 @@ InModuleScope 'Passwordstate-Management' {
                 @{parametername = 'Title'; testvalue = "Demo AD Username"; ListCount = 2; PWLID = 53 }
                 , @{parametername = 'UserName'; testvalue = "username1"; ListCount = 3; PWLID = 53 }
                 , @{parametername = 'HostName'; testvalue = "HostA"; ListCount = 4; PWLID = 53 }
-                , @{parametername = 'Domain'; testvalue = "MYDomain"; ListCount = 5; PWLID = 53 }
+                , @{parametername = 'ADDomainNetBIOS'; testvalue = "MYDomain"; ListCount = 5; PWLID = 53 }
                 , @{parametername = 'AccountType'; testvalue = ""; ListCount = 1; PWLID = 53 } # testvalue must be empty because the actual property is AccountTypeID
                 , @{parametername = 'Description'; testvalue = "Description for "; ListCount = 6; PWLID = 53 }
                 , @{parametername = 'Notes'; testvalue = "Same Notes"; ListCount = 7; PWLID = 53 }
@@ -83,7 +83,7 @@ InModuleScope 'Passwordstate-Management' {
 }
 
 Remove-Module PasswordState-Management -Force -ErrorAction SilentlyContinue
-Import-module "$($PSScriptRoot)\..\..\Passwordstate-management.psd1" -Force
+Import-Module "$($PSScriptRoot)\..\..\Passwordstate-management.psd1" -Force
 . "$($PSScriptRoot)\json\enum-jsonFiles.ps1"
 InModuleScope 'Passwordstate-Management' {
     Describe "Get-PasswordStatePassword with winapi profile" {
@@ -98,7 +98,7 @@ InModuleScope 'Passwordstate-Management' {
                 @{parametername = 'Title'; mandatory = 'False'; ParameterSetName = "Specific" }
                 , @{parametername = 'UserName'; mandatory = 'False'; ParameterSetName = "Specific" }
                 , @{parametername = 'HostName'; mandatory = 'False'; ParameterSetName = "Specific" }
-                , @{parametername = 'Domain'; mandatory = 'False'; ParameterSetName = "Specific" }
+                , @{parametername = 'ADDomainNetBIOS'; mandatory = 'False'; ParameterSetName = "Specific" }
                 , @{parametername = 'AccountType'; mandatory = 'False'; ParameterSetName = "Specific" }
                 , @{parametername = 'Description'; mandatory = 'False'; ParameterSetName = "Specific" }
                 , @{parametername = 'Notes'; mandatory = 'False'; ParameterSetName = "Specific" }
@@ -122,7 +122,7 @@ InModuleScope 'Passwordstate-Management' {
                 @{parametername = 'Title'; testvalue = "Demo AD Username"; ListCount = 2; PWLID = 53 }
                 , @{parametername = 'UserName'; testvalue = "username1"; ListCount = 3; PWLID = 53 }
                 , @{parametername = 'HostName'; testvalue = "HostA"; ListCount = 4; PWLID = 53 }
-                , @{parametername = 'Domain'; testvalue = "MYDomain"; ListCount = 5; PWLID = 53 }
+                , @{parametername = 'ADDomainNetBIOS'; testvalue = "MYDomain"; ListCount = 5; PWLID = 53 }
                 , @{parametername = 'AccountType'; testvalue = ""; ListCount = 1; PWLID = 53 } # testvalue must be empty because the actual property is AccountTypeID
                 , @{parametername = 'Description'; testvalue = "Description for "; ListCount = 6; PWLID = 53 }
                 , @{parametername = 'Notes'; testvalue = "Same Notes"; ListCount = 7; PWLID = 53 }
@@ -160,7 +160,8 @@ InModuleScope 'Passwordstate-Management' {
                 param($parametername, $testvalue, $ListCount)
                 $Result = if ($parametername -ne '') {
                     ((Invoke-Expression -Command "$($FunctionName) -$($Parametername) '$($testvalue)'" ) | Measure-Object).Count
-                } else {
+                }
+                else {
                     ((Invoke-Expression -Command "$($FunctionName)" ) | Measure-Object).Count
                 }
                 $Result | Should -BeExactly $ListCount
@@ -170,7 +171,8 @@ InModuleScope 'Passwordstate-Management' {
                 param($parametername, $testvalue, $ListCount, $PWLID)
                 $Result = if ($parametername -ne '') {
                     ((Invoke-Expression -Command "$($FunctionName) -$($Parametername) '$($testvalue)'" ) | Measure-Object).Count
-                } else {
+                }
+                else {
                     ((Invoke-Expression -Command "$($FunctionName)" ) | Measure-Object).Count
                 }
                 $Result | Should -BeExactly $ListCount
@@ -180,7 +182,8 @@ InModuleScope 'Passwordstate-Management' {
                 param($parametername, $testvalue, $ListCount)
                 $Result = if ($parametername -ne '') {
                     ((Invoke-Expression -Command "$($FunctionName) -$($Parametername) '$($testvalue)' -PreventAuditing:`$True" ) | Measure-Object).Count
-                } else {
+                }
+                else {
                     ((Invoke-Expression -Command "$($FunctionName)" ) | Measure-Object).Count
                 }
                 $Result | Should -BeExactly $ListCount
@@ -190,7 +193,8 @@ InModuleScope 'Passwordstate-Management' {
                 param($parametername, $testvalue, $ListCount, $PWLID)
                 $Result = if ($parametername -ne '') {
                     ((Invoke-Expression -Command "$($FunctionName) -$($Parametername) '$($testvalue)'" ) | Measure-Object).Count
-                } else {
+                }
+                else {
                     ((Invoke-Expression -Command "$($FunctionName)" ) | Measure-Object).Count
                 }
                 $Result | Should -BeExactly $ListCount
@@ -211,7 +215,7 @@ InModuleScope 'Passwordstate-Management' {
     }
 }
 Remove-Module PasswordState-Management -Force -ErrorAction SilentlyContinue
-Import-module "$($PSScriptRoot)\..\..\Passwordstate-management.psd1" -Force
+Import-Module "$($PSScriptRoot)\..\..\Passwordstate-management.psd1" -Force
 . "$($PSScriptRoot)\json\enum-jsonFiles.ps1"
 InModuleScope 'Passwordstate-Management' {
     Describe "Get-PasswordStatePassword with Custom Credentials in profile" {
@@ -226,7 +230,7 @@ InModuleScope 'Passwordstate-Management' {
                 @{parametername = 'Title'; mandatory = 'False'; ParameterSetName = "Specific" }
                 , @{parametername = 'UserName'; mandatory = 'False'; ParameterSetName = "Specific" }
                 , @{parametername = 'HostName'; mandatory = 'False'; ParameterSetName = "Specific" }
-                , @{parametername = 'Domain'; mandatory = 'False'; ParameterSetName = "Specific" }
+                , @{parametername = 'ADDomainNetBIOS'; mandatory = 'False'; ParameterSetName = "Specific" }
                 , @{parametername = 'AccountType'; mandatory = 'False'; ParameterSetName = "Specific" }
                 , @{parametername = 'Description'; mandatory = 'False'; ParameterSetName = "Specific" }
                 , @{parametername = 'Notes'; mandatory = 'False'; ParameterSetName = "Specific" }
@@ -250,7 +254,7 @@ InModuleScope 'Passwordstate-Management' {
                 @{parametername = 'Title'; testvalue = "Demo AD Username"; ListCount = 2; PWLID = 53 }
                 , @{parametername = 'UserName'; testvalue = "username1"; ListCount = 3; PWLID = 53 }
                 , @{parametername = 'HostName'; testvalue = "HostA"; ListCount = 4; PWLID = 53 }
-                , @{parametername = 'Domain'; testvalue = "MYDomain"; ListCount = 5; PWLID = 53 }
+                , @{parametername = 'ADDomainNetBIOS'; testvalue = "MYDomain"; ListCount = 5; PWLID = 53 }
                 , @{parametername = 'AccountType'; testvalue = ""; ListCount = 1; PWLID = 53 } # testvalue must be empty because the actual property is AccountTypeID
                 , @{parametername = 'Description'; testvalue = "Description for "; ListCount = 6; PWLID = 53 }
                 , @{parametername = 'Notes'; testvalue = "Same Notes"; ListCount = 7; PWLID = 53 }
@@ -288,7 +292,8 @@ InModuleScope 'Passwordstate-Management' {
                 param($parametername, $testvalue, $ListCount)
                 $Result = if ($parametername -ne '') {
                     ((Invoke-Expression -Command "$($FunctionName) -$($Parametername) '$($testvalue)'" ) | Measure-Object).Count
-                } else {
+                }
+                else {
                     ((Invoke-Expression -Command "$($FunctionName)" ) | Measure-Object).Count
                 }
                 $Result | Should -BeExactly $ListCount
@@ -298,7 +303,8 @@ InModuleScope 'Passwordstate-Management' {
                 param($parametername, $testvalue, $ListCount, $PWLID)
                 $Result = if ($parametername -ne '') {
                     ((Invoke-Expression -Command "$($FunctionName) -$($Parametername) '$($testvalue)'" ) | Measure-Object).Count
-                } else {
+                }
+                else {
                     ((Invoke-Expression -Command "$($FunctionName)" ) | Measure-Object).Count
                 }
                 $Result | Should -BeExactly $ListCount
@@ -308,7 +314,8 @@ InModuleScope 'Passwordstate-Management' {
                 param($parametername, $testvalue, $ListCount)
                 $Result = if ($parametername -ne '') {
                     ((Invoke-Expression -Command "$($FunctionName) -$($Parametername) '$($testvalue)' -PreventAuditing:`$True" ) | Measure-Object).Count
-                } else {
+                }
+                else {
                     ((Invoke-Expression -Command "$($FunctionName)" ) | Measure-Object).Count
                 }
                 $Result | Should -BeExactly $ListCount
@@ -318,7 +325,8 @@ InModuleScope 'Passwordstate-Management' {
                 param($parametername, $testvalue, $ListCount, $PWLID)
                 $Result = if ($parametername -ne '') {
                     ((Invoke-Expression -Command "$($FunctionName) -$($Parametername) '$($testvalue)'" ) | Measure-Object).Count
-                } else {
+                }
+                else {
                     ((Invoke-Expression -Command "$($FunctionName)" ) | Measure-Object).Count
                 }
                 $Result | Should -BeExactly $ListCount
@@ -339,7 +347,7 @@ InModuleScope 'Passwordstate-Management' {
     }
 }
 Remove-Module PasswordState-Management -Force -ErrorAction SilentlyContinue
-Import-module "$($PSScriptRoot)\..\..\Passwordstate-management.psd1" -Force
+Import-Module "$($PSScriptRoot)\..\..\Passwordstate-management.psd1" -Force
 . "$($PSScriptRoot)\json\enum-jsonFiles.ps1"
 InModuleScope 'Passwordstate-Management' {
     Describe "Get-PasswordStatePassword with apikey in profile" {
@@ -354,7 +362,7 @@ InModuleScope 'Passwordstate-Management' {
                 @{parametername = 'Title'; mandatory = 'False'; ParameterSetName = "Specific" }
                 , @{parametername = 'UserName'; mandatory = 'False'; ParameterSetName = "Specific" }
                 , @{parametername = 'HostName'; mandatory = 'False'; ParameterSetName = "Specific" }
-                , @{parametername = 'Domain'; mandatory = 'False'; ParameterSetName = "Specific" }
+                , @{parametername = 'ADDomainNetBIOS'; mandatory = 'False'; ParameterSetName = "Specific" }
                 , @{parametername = 'AccountType'; mandatory = 'False'; ParameterSetName = "Specific" }
                 , @{parametername = 'Description'; mandatory = 'False'; ParameterSetName = "Specific" }
                 , @{parametername = 'Notes'; mandatory = 'False'; ParameterSetName = "Specific" }
@@ -378,7 +386,7 @@ InModuleScope 'Passwordstate-Management' {
                 @{parametername = 'Title'; testvalue = "Demo AD Username"; ListCount = 2; PWLID = 53 }
                 , @{parametername = 'UserName'; testvalue = "username1"; ListCount = 3; PWLID = 53 }
                 , @{parametername = 'HostName'; testvalue = "HostA"; ListCount = 4; PWLID = 53 }
-                , @{parametername = 'Domain'; testvalue = "MYDomain"; ListCount = 5; PWLID = 53 }
+                , @{parametername = 'ADDomainNetBIOS'; testvalue = "MYDomain"; ListCount = 5; PWLID = 53 }
                 , @{parametername = 'AccountType'; testvalue = ""; ListCount = 1; PWLID = 53 } # testvalue must be empty because the actual property is AccountTypeID
                 , @{parametername = 'Description'; testvalue = "Description for "; ListCount = 6; PWLID = 53 }
                 , @{parametername = 'Notes'; testvalue = "Same Notes"; ListCount = 7; PWLID = 53 }
@@ -416,7 +424,8 @@ InModuleScope 'Passwordstate-Management' {
                 param($parametername, $testvalue, $ListCount)
                 $Result = if ($parametername -ne '') {
                     ((Invoke-Expression -Command "$($FunctionName) -$($Parametername) '$($testvalue)'" ) | Measure-Object).Count
-                } else {
+                }
+                else {
                     ((Invoke-Expression -Command "$($FunctionName)" ) | Measure-Object).Count
                 }
                 $Result | Should -BeExactly $ListCount
@@ -426,7 +435,8 @@ InModuleScope 'Passwordstate-Management' {
                 param($parametername, $testvalue, $ListCount, $PWLID)
                 $Result = if ($parametername -ne '') {
                     ((Invoke-Expression -Command "$($FunctionName) -$($Parametername) '$($testvalue)'" ) | Measure-Object).Count
-                } else {
+                }
+                else {
                     ((Invoke-Expression -Command "$($FunctionName)" ) | Measure-Object).Count
                 }
                 $Result | Should -BeExactly $ListCount
@@ -436,7 +446,8 @@ InModuleScope 'Passwordstate-Management' {
                 param($parametername, $testvalue, $ListCount)
                 $Result = if ($parametername -ne '') {
                     ((Invoke-Expression -Command "$($FunctionName) -$($Parametername) '$($testvalue)' -PreventAuditing:`$True" ) | Measure-Object).Count
-                } else {
+                }
+                else {
                     ((Invoke-Expression -Command "$($FunctionName)" ) | Measure-Object).Count
                 }
                 $Result | Should -BeExactly $ListCount
@@ -446,7 +457,8 @@ InModuleScope 'Passwordstate-Management' {
                 param($parametername, $testvalue, $ListCount, $PWLID)
                 $Result = if ($parametername -ne '') {
                     ((Invoke-Expression -Command "$($FunctionName) -$($Parametername) '$($testvalue)'" ) | Measure-Object).Count
-                } else {
+                }
+                else {
                     ((Invoke-Expression -Command "$($FunctionName)" ) | Measure-Object).Count
                 }
                 $Result | Should -BeExactly $ListCount
@@ -467,7 +479,7 @@ InModuleScope 'Passwordstate-Management' {
     }
 }
 Remove-Module PasswordState-Management -Force -ErrorAction SilentlyContinue
-Import-module "$($PSScriptRoot)\..\..\Passwordstate-management.psd1" -Force
+Import-Module "$($PSScriptRoot)\..\..\Passwordstate-management.psd1" -Force
 . "$($PSScriptRoot)\json\enum-jsonFiles.ps1"
 InModuleScope 'Passwordstate-Management' {
     Describe "Get-PasswordStatePassword for winapi" {
@@ -482,7 +494,7 @@ InModuleScope 'Passwordstate-Management' {
                 @{parametername = 'Title'; mandatory = 'False'; ParameterSetName = "Specific" }
                 , @{parametername = 'UserName'; mandatory = 'False'; ParameterSetName = "Specific" }
                 , @{parametername = 'HostName'; mandatory = 'False'; ParameterSetName = "Specific" }
-                , @{parametername = 'Domain'; mandatory = 'False'; ParameterSetName = "Specific" }
+                , @{parametername = 'ADDomainNetBIOS'; mandatory = 'False'; ParameterSetName = "Specific" }
                 , @{parametername = 'AccountType'; mandatory = 'False'; ParameterSetName = "Specific" }
                 , @{parametername = 'Description'; mandatory = 'False'; ParameterSetName = "Specific" }
                 , @{parametername = 'Notes'; mandatory = 'False'; ParameterSetName = "Specific" }
@@ -506,7 +518,7 @@ InModuleScope 'Passwordstate-Management' {
                 @{parametername = 'Title'; testvalue = "Demo AD Username"; ListCount = 2; PWLID = 53 }
                 , @{parametername = 'UserName'; testvalue = "username1"; ListCount = 3; PWLID = 53 }
                 , @{parametername = 'HostName'; testvalue = "HostA"; ListCount = 4; PWLID = 53 }
-                , @{parametername = 'Domain'; testvalue = "MYDomain"; ListCount = 5; PWLID = 53 }
+                , @{parametername = 'ADDomainNetBIOS'; testvalue = "MYDomain"; ListCount = 5; PWLID = 53 }
                 , @{parametername = 'AccountType'; testvalue = ""; ListCount = 1; PWLID = 53 } # testvalue must be empty because the actual property is AccountTypeID
                 , @{parametername = 'Description'; testvalue = "Description for "; ListCount = 6; PWLID = 53 }
                 , @{parametername = 'Notes'; testvalue = "Same Notes"; ListCount = 7; PWLID = 53 }
@@ -544,7 +556,8 @@ InModuleScope 'Passwordstate-Management' {
                 param($parametername, $testvalue, $ListCount)
                 $Result = if ($parametername -ne '') {
                     ((Invoke-Expression -Command "$($FunctionName) -$($Parametername) '$($testvalue)'" ) | Measure-Object).Count
-                } else {
+                }
+                else {
                     ((Invoke-Expression -Command "$($FunctionName)" ) | Measure-Object).Count
                 }
                 $Result | Should -BeExactly $ListCount
@@ -554,7 +567,8 @@ InModuleScope 'Passwordstate-Management' {
                 param($parametername, $testvalue, $ListCount, $PWLID)
                 $Result = if ($parametername -ne '') {
                     ((Invoke-Expression -Command "$($FunctionName) -$($Parametername) '$($testvalue)'" ) | Measure-Object).Count
-                } else {
+                }
+                else {
                     ((Invoke-Expression -Command "$($FunctionName)" ) | Measure-Object).Count
                 }
                 $Result | Should -BeExactly $ListCount
@@ -564,7 +578,8 @@ InModuleScope 'Passwordstate-Management' {
                 param($parametername, $testvalue, $ListCount)
                 $Result = if ($parametername -ne '') {
                     ((Invoke-Expression -Command "$($FunctionName) -$($Parametername) '$($testvalue)' -PreventAuditing:`$True" ) | Measure-Object).Count
-                } else {
+                }
+                else {
                     ((Invoke-Expression -Command "$($FunctionName)" ) | Measure-Object).Count
                 }
                 $Result | Should -BeExactly $ListCount
@@ -574,7 +589,8 @@ InModuleScope 'Passwordstate-Management' {
                 param($parametername, $testvalue, $ListCount, $PWLID)
                 $Result = if ($parametername -ne '') {
                     ((Invoke-Expression -Command "$($FunctionName) -$($Parametername) '$($testvalue)'" ) | Measure-Object).Count
-                } else {
+                }
+                else {
                     ((Invoke-Expression -Command "$($FunctionName)" ) | Measure-Object).Count
                 }
                 $Result | Should -BeExactly $ListCount
@@ -603,7 +619,8 @@ InModuleScope 'Passwordstate-Management' {
                 param($parametername, $testvalue, $ListCount)
                 $Result = if ($parametername -ne '') {
                     ((Invoke-Expression -Command "$($FunctionName) -$($Parametername) '$($testvalue)'" ) | Measure-Object).Count
-                } else {
+                }
+                else {
                     ((Invoke-Expression -Command "$($FunctionName)" ) | Measure-Object).Count
                 }
                 $Result | Should -BeExactly $ListCount
@@ -613,7 +630,8 @@ InModuleScope 'Passwordstate-Management' {
                 param($parametername, $testvalue, $ListCount, $PWLID)
                 $Result = if ($parametername -ne '') {
                     ((Invoke-Expression -Command "$($FunctionName) -$($Parametername) '$($testvalue)'" ) | Measure-Object).Count
-                } else {
+                }
+                else {
                     ((Invoke-Expression -Command "$($FunctionName)" ) | Measure-Object).Count
                 }
                 $Result | Should -BeExactly $ListCount
@@ -623,7 +641,8 @@ InModuleScope 'Passwordstate-Management' {
                 param($parametername, $testvalue, $ListCount)
                 $Result = if ($parametername -ne '') {
                     ((Invoke-Expression -Command "$($FunctionName) -$($Parametername) '$($testvalue)' -PreventAuditing:`$True" ) | Measure-Object).Count
-                } else {
+                }
+                else {
                     ((Invoke-Expression -Command "$($FunctionName)" ) | Measure-Object).Count
                 }
                 $Result | Should -BeExactly $ListCount
@@ -633,7 +652,8 @@ InModuleScope 'Passwordstate-Management' {
                 param($parametername, $testvalue, $ListCount, $PWLID)
                 $Result = if ($parametername -ne '') {
                     ((Invoke-Expression -Command "$($FunctionName) -$($Parametername) '$($testvalue)'" ) | Measure-Object).Count
-                } else {
+                }
+                else {
                     ((Invoke-Expression -Command "$($FunctionName)" ) | Measure-Object).Count
                 }
                 $Result | Should -BeExactly $ListCount
@@ -662,7 +682,8 @@ InModuleScope 'Passwordstate-Management' {
                 param($parametername, $testvalue, $ListCount)
                 $Result = if ($parametername -ne '') {
                     ((Invoke-Expression -Command "$($FunctionName) -$($Parametername) '$($testvalue)'" ) | Measure-Object).Count
-                } else {
+                }
+                else {
                     ((Invoke-Expression -Command "$($FunctionName)" ) | Measure-Object).Count
                 }
                 $Result | Should -BeExactly $ListCount
@@ -672,7 +693,8 @@ InModuleScope 'Passwordstate-Management' {
                 param($parametername, $testvalue, $ListCount, $PWLID)
                 $Result = if ($parametername -ne '') {
                     ((Invoke-Expression -Command "$($FunctionName) -$($Parametername) '$($testvalue)'" ) | Measure-Object).Count
-                } else {
+                }
+                else {
                     ((Invoke-Expression -Command "$($FunctionName)" ) | Measure-Object).Count
                 }
                 $Result | Should -BeExactly $ListCount
@@ -682,7 +704,8 @@ InModuleScope 'Passwordstate-Management' {
                 param($parametername, $testvalue, $ListCount)
                 $Result = if ($parametername -ne '') {
                     ((Invoke-Expression -Command "$($FunctionName) -$($Parametername) '$($testvalue)' -PreventAuditing:`$True" ) | Measure-Object).Count
-                } else {
+                }
+                else {
                     ((Invoke-Expression -Command "$($FunctionName)" ) | Measure-Object).Count
                 }
                 $Result | Should -BeExactly $ListCount
@@ -692,7 +715,8 @@ InModuleScope 'Passwordstate-Management' {
                 param($parametername, $testvalue, $ListCount, $PWLID)
                 $Result = if ($parametername -ne '') {
                     ((Invoke-Expression -Command "$($FunctionName) -$($Parametername) '$($testvalue)'" ) | Measure-Object).Count
-                } else {
+                }
+                else {
                     ((Invoke-Expression -Command "$($FunctionName)" ) | Measure-Object).Count
                 }
                 $Result | Should -BeExactly $ListCount


### PR DESCRIPTION
@dnewsholme 

**1.** I have (hopefully) fixed some problems during `Update-MarkdownHelp` runs. I have identified a problem if the ordering of the parameters has changed during development platyPS does not fully recognize these changes. So i deleted the external help xml file and updated all markdown help files with `Update-MarkdownHelp -Path .\docs\ -Verbose -Force -AlphabeticParamsOrder`. After that the syntax at the top of each help file is now correct, the parameter details are correct and the ValidateSets are not correctly identified. Also new parameters were detected after the next `Update-MarkdownHelp` run. They are all documented now.

**2.** I have updated the `Get-PasswordStatePassword` function so that all currently supported parameters (`ExpiryDate, ExpiryDateRange, AndOr, AccountType(ID), PreventAuditing, PasswordResetEnabled`) are now included.
Also added the possibility to search for all passwords the user/apikey has access too AND/OR all passwords in a specific list.
Also added and updated the documentation for this function to fit the changes.