### PR TITLE
Added New-PasswordStateSelfDestructMessage. Updated *-PasswordStatePasswordPermission

### DIFF
--- a/docs/Get-PasswordStateFolder.md
+++ b/docs/Get-PasswordStateFolder.md
@@ -15,7 +15,7 @@ If multiple matches it will return multiple objects.
 
 ```
 Get-PasswordStateFolder [[-FolderName] <String>] [[-Description] <String>] [[-TreePath] <String>]
- [[-SiteID] <Int32>] [[-SiteLocation] <String>] [-FolderID <Int32>] [-PreventAuditing] [-Reason <String>]
+ [[-SiteID] <Int32>] [[-SiteLocation] <String>] [[-FolderID] <Int32>] [-PreventAuditing] [[-Reason] <String>]
  [<CommonParameters>]
 ```
 
@@ -77,7 +77,7 @@ Parameter Sets: (All)
 Aliases:
 
 Required: False
-Position: Named
+Position: 6
 Default value: None
 Accept pipeline input: True (ByPropertyName)
 Accept wildcard characters: False
@@ -107,7 +107,7 @@ Parameter Sets: (All)
 Aliases:
 
 Required: False
-Position: 5
+Position: 7
 Default value: False
 Accept pipeline input: True (ByPropertyName)
 Accept wildcard characters: False
@@ -122,7 +122,7 @@ Parameter Sets: (All)
 Aliases:
 
 Required: False
-Position: Named
+Position: 8
 Default value: None
 Accept pipeline input: True (ByPropertyName)
 Accept wildcard characters: False
@@ -181,8 +181,11 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 ## INPUTS
 
 ### System.String
-### System.Int32
+
+### System.Nullable`1[[System.Int32, System.Private.CoreLib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=7cec85d7bea7798e]]
+
 ### System.Management.Automation.SwitchParameter
+
 ## OUTPUTS
 
 ### System.Object

--- a/docs/Get-PasswordStateFolder.md
+++ b/docs/Get-PasswordStateFolder.md
@@ -8,40 +8,53 @@ schema: 2.0.0
 # Get-PasswordStateFolder
 
 ## SYNOPSIS
-Finds a password state entry and returns the object.
-If multiple matches it will return multiple entries.
+Find a PasswordState folder entry and returns the object.  
+If multiple matches it will return multiple objects.
 
 ## SYNTAX
 
 ```
 Get-PasswordStateFolder [[-FolderName] <String>] [[-Description] <String>] [[-TreePath] <String>]
- [[-SiteID] <Int32>] [[-SiteLocation] <String>] [-PreventAuditing] [<CommonParameters>]
+ [[-SiteID] <Int32>] [[-SiteLocation] <String>] [-FolderID <Int32>] [-PreventAuditing] [-Reason <String>]
+ [<CommonParameters>]
 ```
 
 ## DESCRIPTION
-Finds a password state entry and returns the object.
-If multiple matches it will return multiple entries.
+Find a PasswordState folder entry and returns the object.  
+If multiple matches it will return multiple objects.
+
+**Note 1**: You can perform an exact match search by enclosing your search criteria in double quotes, i.e. `'"MyFolder"'`
+
+**Note 2**: By default, the retrieval of (all) folder records will add one Audit record for every folder record returned. If you wish to prevent audit records from being added, you can add the `-PreventAuditing` parameter.
 
 ## EXAMPLES
 
 ### EXAMPLE 1
 ```
-Find-PasswordStateFolder -FolderName "test"
+Get-PasswordStateFolder -FolderName "test"
 ```
 
-Returns the test folder object.
+Returns the folder object(s) with name "test".
 
 ### EXAMPLE 2
 ```
-Find-PasswordStateFolder -Description "testfolder"
+Get-PasswordStateFolder -Description "testfolder"
 ```
 
-Returns the folder objects that contain testfolder in the description.
+Returns the folder object(s) that contains testfolder in the description.
+
+### EXAMPLE 3
+```
+Get-PasswordStateFolder -FolderID 12
+```
+
+Returns the folder object(s) with FolderID 12 if found.
 
 ## PARAMETERS
 
 ### -Description
-The description for the folder to find
+An optional parameter to filter the search on description.
+The description is generally used as a longer verbose description of the nature of the Password object.
 
 ```yaml
 Type: String
@@ -55,8 +68,23 @@ Accept pipeline input: True (ByPropertyName)
 Accept wildcard characters: False
 ```
 
+### -FolderID
+The unique ID of the folder to filter the search for.
+
+```yaml
+Type: Int32
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: True (ByPropertyName)
+Accept wildcard characters: False
+```
+
 ### -FolderName
-The name for the folder to find
+The name for the folder to search for.
 
 ```yaml
 Type: String
@@ -85,8 +113,24 @@ Accept pipeline input: True (ByPropertyName)
 Accept wildcard characters: False
 ```
 
+### -Reason
+A reason which can be logged for auditing of why a folder was retrieved.
+
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: True (ByPropertyName)
+Accept wildcard characters: False
+```
+
 ### -SiteID
-The siteID for the folder
+An optional parameter to filter the search on the site ID.  
+If you do not specify this parameter, it will report data based on all Site Locations. Values are 0 for Internal, and all other SiteID's can be found on the screen `Administration -> Remote Site Administration -> Remote Site Locations`.
 
 ```yaml
 Type: Int32
@@ -101,7 +145,8 @@ Accept wildcard characters: False
 ```
 
 ### -SiteLocation
-The sitelocation for the folder
+An optional parameter to filter the search on the site location.  
+If you do not specify this parameter, it will report data based on all Site Locations. Values are the name of the Site Location that can be found on the screen `Administration -> Remote Site Administration -> Remote Site Locations`.
 
 ```yaml
 Type: String
@@ -116,7 +161,7 @@ Accept wildcard characters: False
 ```
 
 ### -TreePath
-The treepath where the folder should be found
+The TreePath where the folder should be found.
 
 ```yaml
 Type: String
@@ -136,11 +181,8 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 ## INPUTS
 
 ### System.String
-
 ### System.Int32
-
 ### System.Management.Automation.SwitchParameter
-
 ## OUTPUTS
 
 ### System.Object

--- a/docs/Get-PasswordStateList.md
+++ b/docs/Get-PasswordStateList.md
@@ -26,6 +26,10 @@ Get-PasswordStateList [[-PasswordList] <String>] [[-Description] <String>] [[-Tr
 ## DESCRIPTION
 Gets all password lists from the API (Only those you have permissions to.)
 
+**Note 1**: You can perform an exact match search by enclosing your search criteria in double quotes, i.e. `'"MyList"'`
+
+**Note 2**: By default, the retrieval of (all) PasswordList records will add one Audit record for every PasswordList record returned. If you wish to prevent audit records from being added, you can add the `-PreventAuditing` parameter.
+
 ## EXAMPLES
 
 ### EXAMPLE 1

--- a/docs/Get-PasswordStateList.md
+++ b/docs/Get-PasswordStateList.md
@@ -14,13 +14,13 @@ Gets all password lists from the API (Only those you have permissions to.)
 
 ### ID (Default)
 ```
-Get-PasswordStateList [[-PasswordListID] <Int32>] [-PreventAuditing] [<CommonParameters>]
+Get-PasswordStateList [[-PasswordListID] <Int32>] [-PreventAuditing] [-Reason <String>] [<CommonParameters>]
 ```
 
 ### Specific
 ```
 Get-PasswordStateList [[-PasswordList] <String>] [[-Description] <String>] [[-TreePath] <String>]
- [[-SiteID] <Int32>] [[-SiteLocation] <String>] [-PreventAuditing] [<CommonParameters>]
+ [[-SiteID] <Int32>] [[-SiteLocation] <String>] [-PreventAuditing] [-Reason <String>] [<CommonParameters>]
 ```
 
 ## DESCRIPTION
@@ -33,20 +33,35 @@ Gets all password lists from the API (Only those you have permissions to.)
 Get-PasswordStateList
 ```
 
+Get all available PasswordState Lists the user/api key has access to.
+
 ### EXAMPLE 2
 ```
 Get-PasswordStateList -PasswordListID 3
 ```
+
+Get the PasswordState List with ID 3.
 
 ### EXAMPLE 3
 ```
 Get-PasswordStateList -PasswordList 'Test' -TreePath '\TestPath\Lists' -SiteID 123
 ```
 
+Search for a PasswordState List with Name Test on Path \TestPath\Lists and on Site with ID 123.
+
+### EXAMPLE 4
+```
+Get-PasswordStateList -PasswordList 'Test' -TreePath '\TestPath\Lists' -SiteID 123 -Reason "Ticket #202005151234567"
+```
+
+Search for a PasswordState List with Name Test on Path \TestPath\Lists and on Site with ID 123. Also specifying the reason "Ticket #202005151234567" why the search for the passwordlist object was requested.  
+The Reason will be added as audit entry to every PasswordList object that will be found with these search criteria.
+
 ## PARAMETERS
 
 ### -Description
-The description for the PasswordList to find
+An optional parameter to filter the search on description.
+The description is generally used as a longer verbose description of the nature of the Password object.
 
 ```yaml
 Type: String
@@ -61,7 +76,7 @@ Accept wildcard characters: False
 ```
 
 ### -PasswordList
-The name for the PasswordList to find
+The name for the PasswordList to search for.
 
 ```yaml
 Type: String
@@ -76,7 +91,7 @@ Accept wildcard characters: False
 ```
 
 ### -PasswordListID
-Gets the passwordlist based on ID, when omitted, gets all the passord lists
+Gets the PasswordList based on ID, when omitted, gets all the password lists.
 
 ```yaml
 Type: Int32
@@ -105,8 +120,24 @@ Accept pipeline input: True (ByPropertyName)
 Accept wildcard characters: False
 ```
 
+### -Reason
+A reason which can be logged for auditing of why a password was retrieved.
+
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: True (ByPropertyName)
+Accept wildcard characters: False
+```
+
 ### -SiteID
-The siteID for the PasswordList
+An optional parameter to filter the search on the site ID.  
+If you do not specify this parameter, it will report data based on all Site Locations. Values are 0 for Internal, and all other SiteID's can be found on the screen `Administration -> Remote Site Administration -> Remote Site Locations`.
 
 ```yaml
 Type: Int32
@@ -121,7 +152,8 @@ Accept wildcard characters: False
 ```
 
 ### -SiteLocation
-The sitelocation for the PasswordList
+An optional parameter to filter the search on the site location.  
+If you do not specify this parameter, it will report data based on all Site Locations. Values are the name of the Site Location that can be found on the screen `Administration -> Remote Site Administration -> Remote Site Locations`.
 
 ```yaml
 Type: String
@@ -136,7 +168,7 @@ Accept wildcard characters: False
 ```
 
 ### -TreePath
-The treepath where the PasswordList should be found
+The TreePath where the PasswordList can be found.
 
 ```yaml
 Type: String
@@ -156,11 +188,8 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 ## INPUTS
 
 ### System.Int32
-
 ### System.String
-
 ### System.Management.Automation.SwitchParameter
-
 ## OUTPUTS
 
 ### System.Object

--- a/docs/Get-PasswordStateList.md
+++ b/docs/Get-PasswordStateList.md
@@ -14,13 +14,13 @@ Gets all password lists from the API (Only those you have permissions to.)
 
 ### ID (Default)
 ```
-Get-PasswordStateList [[-PasswordListID] <Int32>] [-PreventAuditing] [-Reason <String>] [<CommonParameters>]
+Get-PasswordStateList [[-PasswordListID] <Int32>] [-PreventAuditing] [[-Reason] <String>] [<CommonParameters>]
 ```
 
 ### Specific
 ```
 Get-PasswordStateList [[-PasswordList] <String>] [[-Description] <String>] [[-TreePath] <String>]
- [[-SiteID] <Int32>] [[-SiteLocation] <String>] [-PreventAuditing] [-Reason <String>] [<CommonParameters>]
+ [[-SiteID] <Int32>] [[-SiteLocation] <String>] [-PreventAuditing] [[-Reason] <String>] [<CommonParameters>]
 ```
 
 ## DESCRIPTION
@@ -133,7 +133,7 @@ Parameter Sets: (All)
 Aliases:
 
 Required: False
-Position: Named
+Position: 6
 Default value: None
 Accept pipeline input: True (ByPropertyName)
 Accept wildcard characters: False
@@ -192,8 +192,11 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 ## INPUTS
 
 ### System.Int32
+
 ### System.String
+
 ### System.Management.Automation.SwitchParameter
+
 ## OUTPUTS
 
 ### System.Object

--- a/docs/Get-PasswordStatePassword.md
+++ b/docs/Get-PasswordStatePassword.md
@@ -199,7 +199,8 @@ Returns any object where the password will expire at 2020-12-12.
 Get-PasswordStatePassword -HostName "SecureComputer.local" -UserName "Administrator" -Reason "Ticket #202005151234567"
 ```
 
-Returns the password object with UserName "Administrator" and/on HostName "SecureComputer.local". Also specifying the reason "Ticket #202005151234567" why the password object was requested.
+Returns the password object with UserName "Administrator" and/on HostName "SecureComputer.local". Also specifying the reason "Ticket #202005151234567" why the password object was requested.  
+The Reason will be added as audit entry to every password object that will be found with these search criteria.
 
 ### EXAMPLE 14
 ```

--- a/docs/Get-PasswordStatePermission.md
+++ b/docs/Get-PasswordStatePermission.md
@@ -14,15 +14,14 @@ Get the permission for a password state object.
 
 ### All (Default)
 ```
-Get-PasswordStatePermission [[-ReportID] <Int32>] [[-SiteID] <Nullable`1[]>] [-ShowReportIDs] [-WhatIf]
- [-Confirm] [<CommonParameters>]
+Get-PasswordStatePermission [[-ReportID] <Int32>] [[-SiteID] <Int32>] [-ShowReportIDs] [-WhatIf] [-Confirm]
+ [<CommonParameters>]
 ```
 
 ### Specific
 ```
 Get-PasswordStatePermission [[-ReportID] <Int32>] [[-UserID] <String>] [[-SecurityGroupName] <String>]
- [[-DurationInMonth] <Nullable`1[]>] [[-SiteID] <Nullable`1[]>] [-ShowReportIDs] [-WhatIf] [-Confirm]
- [<CommonParameters>]
+ [[-DurationInMonth] <Int32>] [[-SiteID] <Int32>] [-ShowReportIDs] [-WhatIf] [-Confirm] [<CommonParameters>]
 ```
 
 ## DESCRIPTION
@@ -61,7 +60,7 @@ The period in which data can be reported against. Possible values are `0 for cur
 For the '**What passwords are expiring soon?**' report however, Duration refers to the **number of days** you wish to look ahead for passwords which are going to expire.
 
 ```yaml
-Type: Nullable`1[]
+Type: Int32
 Parameter Sets: Specific
 Aliases: Duration
 
@@ -123,7 +122,7 @@ If you leave this parameter **blank**, it will report data based on **all** Site
 SiteID 0 = Default site 'Internal'
 
 ```yaml
-Type: Nullable`1[]
+Type: Int32
 Parameter Sets: (All)
 Aliases:
 
@@ -189,7 +188,7 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 
 ### System.String
 
-### System.Nullable`1[[System.Int32, System.Private.CoreLib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=7cec85d7bea7798e]][]
+### System.Nullable`1[[System.Int32, System.Private.CoreLib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=7cec85d7bea7798e]]
 
 ### System.Management.Automation.SwitchParameter
 

--- a/docs/New-PasswordStateADSecurityGroup.md
+++ b/docs/New-PasswordStateADSecurityGroup.md
@@ -14,7 +14,7 @@ Creates an Active Directory Security Group in PasswordState.
 
 ```
 New-PasswordStateADSecurityGroup [-SecurityGroupName] <String> [[-Description] <String>]
- [-ADDomainNetBIOS] <String> [-Reason <String>] [-WhatIf] [-Confirm] [<CommonParameters>]
+ [-ADDomainNetBIOS] <String> [[-Reason] <String>] [-WhatIf] [-Confirm] [<CommonParameters>]
 ```
 
 ## DESCRIPTION
@@ -75,7 +75,7 @@ Parameter Sets: (All)
 Aliases:
 
 Required: False
-Position: Named
+Position: 3
 Default value: None
 Accept pipeline input: True (ByPropertyName)
 Accept wildcard characters: False
@@ -133,6 +133,7 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 ## INPUTS
 
 ### System.String
+
 ## OUTPUTS
 
 ### System.Object

--- a/docs/New-PasswordStateADSecurityGroup.md
+++ b/docs/New-PasswordStateADSecurityGroup.md
@@ -14,7 +14,7 @@ Creates an Active Directory Security Group in PasswordState.
 
 ```
 New-PasswordStateADSecurityGroup [-SecurityGroupName] <String> [[-Description] <String>]
- [-ADDomainNetBIOS] <String> [-WhatIf] [-Confirm] [<CommonParameters>]
+ [-ADDomainNetBIOS] <String> [-Reason <String>] [-WhatIf] [-Confirm] [<CommonParameters>]
 ```
 
 ## DESCRIPTION
@@ -28,10 +28,10 @@ To add a Security Group, the user account executing the script must be given acc
 
 ### Example 1
 ```powershell
-PS C:\> {{ Add example code here }}
+PS C:\> New-PasswordStateADSecurityGroup -SecurityGroupName "Administrators" -ADDomainNetBIOS "domain.local" -Description "Domain Administrators"
 ```
 
-{{ Add example description here }}
+Adding Administrators group from domain "domain.local" with description to PasswordState if found in ActiveDirectory.
 
 ## PARAMETERS
 
@@ -60,6 +60,22 @@ Aliases:
 
 Required: False
 Position: 1
+Default value: None
+Accept pipeline input: True (ByPropertyName)
+Accept wildcard characters: False
+```
+
+### -Reason
+A reason which can be logged for auditing of why a password was retrieved.
+
+
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: Named
 Default value: None
 Accept pipeline input: True (ByPropertyName)
 Accept wildcard characters: False
@@ -117,7 +133,6 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 ## INPUTS
 
 ### System.String
-
 ## OUTPUTS
 
 ### System.Object

--- a/docs/New-PasswordStateListPermission.md
+++ b/docs/New-PasswordStateListPermission.md
@@ -21,8 +21,8 @@ New-PasswordStateListPermission [-PasswordListID] <Int32> [-Permission] <String>
 ### PermissionID
 ```
 New-PasswordStateListPermission [-PasswordListID] <Int32> [-Permission] <String>
- [[-ApplyPermissionsForUserID] <String>] [-ApplyPermissionsForSecurityGroupID] <Nullable`1[]> [-WhatIf]
- [-Confirm] [<CommonParameters>]
+ [[-ApplyPermissionsForUserID] <String>] [-ApplyPermissionsForSecurityGroupID] <Int32> [-WhatIf] [-Confirm]
+ [<CommonParameters>]
 ```
 
 ### PermissionName
@@ -60,7 +60,7 @@ The SecurityGroupID you wish to apply permissions for.
 You can only specify SecurityGroupID or SecurityGroupName, not both in the same call.
 
 ```yaml
-Type: Nullable`1[]
+Type: Int32
 Parameter Sets: PermissionID
 Aliases:
 
@@ -174,7 +174,7 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 
 ### System.String
 
-### System.Nullable`1[[System.Int32, System.Private.CoreLib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=7cec85d7bea7798e]][]
+### System.Nullable`1[[System.Int32, System.Private.CoreLib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=7cec85d7bea7798e]]
 
 ## OUTPUTS
 

--- a/docs/New-PasswordStatePasswordPermission.md
+++ b/docs/New-PasswordStatePasswordPermission.md
@@ -21,8 +21,8 @@ New-PasswordStatePasswordPermission [-PasswordID] <Int32> [-Permission] <String>
 ### PermissionID
 ```
 New-PasswordStatePasswordPermission [-PasswordID] <Int32> [-Permission] <String>
- [[-ApplyPermissionsForUserID] <String>] [-ApplyPermissionsForSecurityGroupID] <Nullable`1[]> [-WhatIf]
- [-Confirm] [<CommonParameters>]
+ [[-ApplyPermissionsForUserID] <String>] [-ApplyPermissionsForSecurityGroupID] <Int32> [-WhatIf] [-Confirm]
+ [<CommonParameters>]
 ```
 
 ### PermissionName
@@ -58,7 +58,7 @@ The SecurityGroupID you wish to apply permissions for.
 You can only specify SecurityGroupID or SecurityGroupName, not both in the same call.
 
 ```yaml
-Type: Nullable`1[]
+Type: Int32
 Parameter Sets: PermissionID
 Aliases:
 
@@ -172,7 +172,7 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 
 ### System.String
 
-### System.Nullable`1[[System.Int32, System.Private.CoreLib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=7cec85d7bea7798e]][]
+### System.Nullable`1[[System.Int32, System.Private.CoreLib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=7cec85d7bea7798e]]
 
 ## OUTPUTS
 

--- a/docs/New-PasswordStateSelfDestructMessage.md
+++ b/docs/New-PasswordStateSelfDestructMessage.md
@@ -1,0 +1,329 @@
+---
+external help file: passwordstate-management-help.xml
+Module Name: passwordstate-management
+online version: https://github.com/dnewsholme/PasswordState-Management/blob/master/docs/New-PasswordStateSelfDestructMessage.md
+schema: 2.0.0
+---
+
+# New-PasswordStateSelfDestructMessage
+
+## SYNOPSIS
+Sending Self Destruct Messages via the API.
+
+## SYNTAX
+
+```
+New-PasswordStateSelfDestructMessage [[-PasswordID] <Int32>] [[-Message] <String>]
+ [[-PrefixMessageContent] <String>] [[-AppendMessageContent] <String>] [[-ExpiresAt] <String>]
+ [[-NoViews] <Int32>] [-ToEmailAddress] <String> [[-ToFirstName] <String>] [[-EmailSubject] <String>]
+ [[-EmailBody] <String>] [[-Passphrase] <String>] [[-Reason] <String>] [-WhatIf] [-Confirm]
+ [<CommonParameters>]
+```
+
+## DESCRIPTION
+Sending Self Destruct Messages via the API.
+
+To send Self Destruct Messages, you must have access to the following features within PasswordState:
+
+- When sending messages based on a Password record - your account must have access this Password record.
+- When sending a message that is not related to a Password record i.e. free-form message body - you must have access to the '`Self Destruct Message`' **menu** in PasswordState.
+
+With the email the recipient receives for the Self Destruct message, you can either use the supplied **Email Template** '`Self Destruct Message Email`' found on the screen `Administration -> Email Templates`, or you can specify the entire body of the message yourself.
+
+**Note 1**: **Never** send the passphrase + url in the same self destruct message!
+
+## EXAMPLES
+
+### Example 1
+```powershell
+PS C:\> New-PasswordStateSelfDestructMessage -ToEmailAddress "surname.lastname@example.com" -PasswordID 114
+```
+
+Sending a self destruct message for PasswordID 114 to the desired recipient. The url is not restricted and can be accessed by anyone that has the url/email. The default values for `ExpiresAt` and `NoViews` will be used.
+
+### Example 2
+```powershell
+PS C:\> New-PasswordStateSelfDestructMessage -ToEmailAddress "surname.lastname@example.com" -PasswordID 114 -Passphrase "API=Cool" -Reason "This is a cool reason" -EmailSubject "Highly Secure" -PrefixMessageContent "<br>Only for your eyes</br>"
+```
+
+Sending a self destruct message for PasswordID 114 to the desired recipient. The url is restricted and can be accessed with the defined Passphrase. A audit log entry with the Reason will be created. The Email will be send with the given Subject and the default Self Destruct Email Template will be used. The default values for `ExpiresAt` and `NoViews` will be used.  
+After opening the url, a PrefixMessage will be displayed above the Password Details.
+
+### Example 3
+```powershell
+PS C:\> New-PasswordStateSelfDestructMessage -ToEmailAddress "surname.lastname@example.com" -PasswordID 114 -Passphrase "API=Cool" -Reason "This is a cool reason" -EmailSubject "Highly Secure" -ToFirstName "surname.lastname" -PrefixMessageContent "<br>Only for your eyes</br>" -EmailBody "Hello [ToFirstName],
+         <p> A secure message was sent to you from <a href=""https://passwordstate.local/"">PasswordState Passwordmanager</a><br>
+         <p> These message was triggered by [UserName]. <br> Please check the following link: [URL].<br>
+         <p> You have [ExpirePeriod] until the message will be expire.<br>
+         <p> Please enter the Passphrase you got from [UserName] after opening the website.<br>
+         <br>
+         </p>"
+```
+
+Sending a self destruct message for PasswordID 114 to the desired recipient. The url is restricted and can be accessed with the defined Passphrase. A audit log entry with the Reason will be created.  
+The Email will be send with the given Subject and the HTML email body specified will be used as email text. ToFirstName is needed for the email body variable `[ToFirstName]`.  
+After opening the url, a PrefixMessage will be displayed above the Password Details.  
+ The default values for `ExpiresAt` and `NoViews` will be used.
+
+## PARAMETERS
+
+### -AppendMessageContent
+If you are sending a message based of a password record, you can append information after the password record details with content from this field - HTML tags can be used if required.
+
+**Note 1:** All diacritics, german umlauts and other invalid characters that the api does not understand will be converted from the given string.
+
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: 3
+Default value: None
+Accept pipeline input: True (ByPropertyName)
+Accept wildcard characters: False
+```
+
+### -EmailBody
+If left blank, the Email Template '`Self Destruct Message Email`' will be used, but you can use this field to specify the entire Email Body if you wish - HTML tags can be used if required.
+
+There are also certain variables in the EmailBody that will be replaced as appropriate, when the email is sent - and they are:
+
+- `[ToFirstName]`
+  - the First Name of the recipient who will receive the email
+  - You need to specify the `-ToFirstName` parameter
+- `[UserName]`
+  - this is the FirstName and Surname of the user sending the Self Destruct Message
+- `[ExpirePeriod]`
+  - How long the message will be alive until it is automatically deleted
+  - You need to specify the `-ExpiresAt` parameter
+- `[URL]`
+  - This is the URL for the recipient to click on to view the Self Destruct Message
+- `[Version]`
+  - The Version Number for your PasswordState instance
+- `[SiteURL]`
+  - The URL of your PasswordState instance
+
+**Note 1:** All diacritics, german umlauts and other invalid characters that the api does not understand will be converted from the given string.
+
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: 9
+Default value: None
+Accept pipeline input: True (ByPropertyName)
+Accept wildcard characters: False
+```
+
+### -EmailSubject
+The Subject Line of the email sent to the recipient - if not specified, the Subject will be used from the Email Template '`Self Destruct Message Email`'
+
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: 8
+Default value: None
+Accept pipeline input: True (ByPropertyName)
+Accept wildcard characters: False
+```
+
+### -ExpiresAt
+This is the duration for how long the self destruct message exists before it is deleted due to not being viewed.  
+You specify the duration and time period for this field, as per the following examples `30m (30 minutes), 3h (3 hours), or 2d (2 days)`.
+
+Defaults to `1d`.
+
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: 4
+Default value: None
+Accept pipeline input: True (ByPropertyName)
+Accept wildcard characters: False
+```
+
+### -Message
+Use this field is you are wanting to specify the entire Self Destruct Message yourself, instead of it being based off of a password record - HTML tags can be used if required.
+
+**Note 1:** All diacritics, german umlauts and other invalid characters that the api does not understand will be converted from the given string.
+
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: 1
+Default value: None
+Accept pipeline input: True (ByPropertyName)
+Accept wildcard characters: False
+```
+
+### -NoViews
+How many times the Self Destruct Message can be viewed, before it is removed.
+
+Defaults to `1`.
+
+```yaml
+Type: Int32
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: 5
+Default value: None
+Accept pipeline input: True (ByPropertyName)
+Accept wildcard characters: False
+```
+
+### -Passphrase
+If you would like to Passphrase protect the Self Destruct Message, you can use this field to do that - the recipient must know the Passphrase in order to read the message.
+
+**Note 1**: **Never** send the passphrase + url in the same self destruct message!
+
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: 10
+Default value: None
+Accept pipeline input: True (ByPropertyName)
+Accept wildcard characters: False
+```
+
+### -PasswordID
+The PasswordID value of the password record you are sending a Self Destruct Message for.
+
+```yaml
+Type: Int32
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: 0
+Default value: None
+Accept pipeline input: True (ByPropertyName)
+Accept wildcard characters: False
+```
+
+### -PrefixMessageContent
+If you are sending a message based off of a password record, you can prefix information before the password record details with content from this field - HTML tags can be used if required.
+
+**Note 1:** All diacritics, german umlauts and other invalid characters that the api does not understand will be converted from the given string.
+
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: 2
+Default value: None
+Accept pipeline input: True (ByPropertyName)
+Accept wildcard characters: False
+```
+
+### -Reason
+You can specify a Reason for sending this Self Destruct Message, and it will be added to the appropriate auditing data.
+
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: 11
+Default value: None
+Accept pipeline input: True (ByPropertyName)
+Accept wildcard characters: False
+```
+
+### -ToEmailAddress
+The Email Address of the recipient who is to receive the Self Destruct Message.
+
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases:
+
+Required: True
+Position: 6
+Default value: None
+Accept pipeline input: True (ByPropertyName)
+Accept wildcard characters: False
+```
+
+### -ToFirstName
+The First Name of the recipient who is to receive the Self Destruct Message - this is used in the email which is sent to the recipient}
+
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: 7
+Default value: None
+Accept pipeline input: True (ByPropertyName)
+Accept wildcard characters: False
+```
+
+### -Confirm
+Prompts you for confirmation before running the cmdlet.
+
+```yaml
+Type: SwitchParameter
+Parameter Sets: (All)
+Aliases: cf
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -WhatIf
+Shows what would happen if the cmdlet runs.
+The cmdlet is not run.
+
+```yaml
+Type: SwitchParameter
+Parameter Sets: (All)
+Aliases: wi
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### CommonParameters
+This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable. For more information, see [about_CommonParameters](http://go.microsoft.com/fwlink/?LinkID=113216).
+
+## INPUTS
+
+### System.Nullable`1[[System.Int32, System.Private.CoreLib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=7cec85d7bea7798e]]
+
+### System.String
+
+### System.Int32
+
+## OUTPUTS
+
+### System.Object
+## NOTES
+
+## RELATED LINKS

--- a/docs/Remove-PasswordStateListPermission.md
+++ b/docs/Remove-PasswordStateListPermission.md
@@ -21,8 +21,8 @@ Remove-PasswordStateListPermission [-PasswordListID] <Int32> [[-Permission] <Str
 ### PermissionID
 ```
 Remove-PasswordStateListPermission [-PasswordListID] <Int32> [[-Permission] <String>]
- [[-ApplyPermissionsForUserID] <String>] [-ApplyPermissionsForSecurityGroupID] <Nullable`1[]> [-WhatIf]
- [-Confirm] [<CommonParameters>]
+ [[-ApplyPermissionsForUserID] <String>] [-ApplyPermissionsForSecurityGroupID] <Int32> [-WhatIf] [-Confirm]
+ [<CommonParameters>]
 ```
 
 ### PermissionName
@@ -67,7 +67,7 @@ The SecurityGroupID you wish to remove permissions for.
 You can only specify SecurityGroupID or SecurityGroupName, not both in the same call.
 
 ```yaml
-Type: Nullable`1[]
+Type: Int32
 Parameter Sets: PermissionID
 Aliases:
 
@@ -183,7 +183,7 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 
 ### System.String
 
-### System.Nullable`1[[System.Int32, System.Private.CoreLib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=7cec85d7bea7798e]][]
+### System.Nullable`1[[System.Int32, System.Private.CoreLib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=7cec85d7bea7798e]]
 
 ## OUTPUTS
 

--- a/docs/Remove-PasswordStatePasswordPermission.md
+++ b/docs/Remove-PasswordStatePasswordPermission.md
@@ -21,8 +21,8 @@ Remove-PasswordStatePasswordPermission [-PasswordID] <Int32> [[-Permission] <Str
 ### PermissionID
 ```
 Remove-PasswordStatePasswordPermission [-PasswordID] <Int32> [[-Permission] <String>]
- [[-ApplyPermissionsForUserID] <String>] [-ApplyPermissionsForSecurityGroupID] <Nullable`1[]> [-WhatIf]
- [-Confirm] [<CommonParameters>]
+ [[-ApplyPermissionsForUserID] <String>] [-ApplyPermissionsForSecurityGroupID] <Int32> [-WhatIf] [-Confirm]
+ [<CommonParameters>]
 ```
 
 ### PermissionName
@@ -58,7 +58,7 @@ The SecurityGroupID you wish to remove permissions for.
 You can only specify SecurityGroupID or SecurityGroupName, not both in the same call.
 
 ```yaml
-Type: Nullable`1[]
+Type: Int32
 Parameter Sets: PermissionID
 Aliases:
 
@@ -174,7 +174,7 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 
 ### System.String
 
-### System.Nullable`1[[System.Int32, System.Private.CoreLib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=7cec85d7bea7798e]][]
+### System.Nullable`1[[System.Int32, System.Private.CoreLib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=7cec85d7bea7798e]]
 
 ## OUTPUTS
 

--- a/docs/Set-PasswordStateListPermission.md
+++ b/docs/Set-PasswordStateListPermission.md
@@ -21,8 +21,8 @@ Set-PasswordStateListPermission [-PasswordListID] <Int32> [-Permission] <String>
 ### PermissionID
 ```
 Set-PasswordStateListPermission [-PasswordListID] <Int32> [-Permission] <String>
- [[-ApplyPermissionsForUserID] <String>] [-ApplyPermissionsForSecurityGroupID] <Nullable`1[]> [-WhatIf]
- [-Confirm] [<CommonParameters>]
+ [[-ApplyPermissionsForUserID] <String>] [-ApplyPermissionsForSecurityGroupID] <Int32> [-WhatIf] [-Confirm]
+ [<CommonParameters>]
 ```
 
 ### PermissionName
@@ -60,7 +60,7 @@ The SecurityGroupID you wish to apply permissions for.
 You can only specify SecurityGroupID or SecurityGroupName, not both in the same call.
 
 ```yaml
-Type: Nullable`1[]
+Type: Int32
 Parameter Sets: PermissionID
 Aliases:
 
@@ -174,7 +174,7 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 
 ### System.String
 
-### System.Nullable`1[[System.Int32, System.Private.CoreLib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=7cec85d7bea7798e]][]
+### System.Nullable`1[[System.Int32, System.Private.CoreLib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=7cec85d7bea7798e]]
 
 ## OUTPUTS
 

--- a/docs/Set-PasswordStatePassword.md
+++ b/docs/Set-PasswordStatePassword.md
@@ -14,102 +14,99 @@ Updates the password of an existing password state entry.
 
 ### All (Default)
 ```
-Set-PasswordStatePassword [-PasswordID] <Nullable`1[]> [[-Title] <String>] [[-Username] <String>]
+Set-PasswordStatePassword [-PasswordID] <Int32> [[-Title] <String>] [[-Username] <String>]
  [[-Description] <String>] [[-Notes] <String>] [[-Url] <String>] [[-AccountType] <String>]
- [[-AccountTypeID] <Nullable`1[]>] [[-GenericField1] <String>] [[-GenericField2] <String>]
- [[-GenericField3] <String>] [[-GenericField4] <String>] [[-GenericField5] <String>]
- [[-GenericField6] <String>] [[-GenericField7] <String>] [[-GenericField8] <String>]
- [[-GenericField9] <String>] [[-GenericField10] <String>] [-GenerateGenFieldPassword]
- [[-AddDaysToExpiryDate] <Nullable`1[]>] [[-ScriptID] <Nullable`1[]>] [[-PrivilegedAccountID] <Nullable`1[]>]
- [[-ExpiryDate] <String>] [-AllowExport] [[-WebUser_ID] <String>] [[-WebPassword_ID] <String>]
- [[-Reason] <String>] [-WhatIf] [-Confirm] [<CommonParameters>]
+ [[-AccountTypeID] <Int32>] [[-GenericField1] <String>] [[-GenericField2] <String>] [[-GenericField3] <String>]
+ [[-GenericField4] <String>] [[-GenericField5] <String>] [[-GenericField6] <String>]
+ [[-GenericField7] <String>] [[-GenericField8] <String>] [[-GenericField9] <String>]
+ [[-GenericField10] <String>] [-GenerateGenFieldPassword] [[-AddDaysToExpiryDate] <Int32>]
+ [[-ScriptID] <Int32>] [[-PrivilegedAccountID] <Int32>] [[-ExpiryDate] <String>] [-AllowExport]
+ [[-WebUser_ID] <String>] [[-WebPassword_ID] <String>] [[-Reason] <String>] [-WhatIf] [-Confirm]
+ [<CommonParameters>]
 ```
 
 ### HeartbeatSchedule
 ```
-Set-PasswordStatePassword [-PasswordID] <Nullable`1[]> [[-Title] <String>] [[-Username] <String>]
+Set-PasswordStatePassword [-PasswordID] <Int32> [[-Title] <String>] [[-Username] <String>]
  [[-Password] <String>] [[-Description] <String>] [-GeneratePassword] [[-Notes] <String>] [[-Url] <String>]
- [[-AccountType] <String>] [[-AccountTypeID] <Nullable`1[]>] [[-GenericField1] <String>]
- [[-GenericField2] <String>] [[-GenericField3] <String>] [[-GenericField4] <String>]
- [[-GenericField5] <String>] [[-GenericField6] <String>] [[-GenericField7] <String>]
- [[-GenericField8] <String>] [[-GenericField9] <String>] [[-GenericField10] <String>]
- [-GenerateGenFieldPassword] [[-AddDaysToExpiryDate] <Nullable`1[]>] [[-ScriptID] <Nullable`1[]>]
- [[-PrivilegedAccountID] <Nullable`1[]>] [[-HeartbeatSchedule] <String>] [[-ExpiryDate] <String>]
- [-AllowExport] [[-WebUser_ID] <String>] [[-WebPassword_ID] <String>] [[-Reason] <String>] [-WhatIf] [-Confirm]
- [<CommonParameters>]
+ [[-AccountType] <String>] [[-AccountTypeID] <Int32>] [[-GenericField1] <String>] [[-GenericField2] <String>]
+ [[-GenericField3] <String>] [[-GenericField4] <String>] [[-GenericField5] <String>]
+ [[-GenericField6] <String>] [[-GenericField7] <String>] [[-GenericField8] <String>]
+ [[-GenericField9] <String>] [[-GenericField10] <String>] [-GenerateGenFieldPassword]
+ [[-AddDaysToExpiryDate] <Int32>] [[-ScriptID] <Int32>] [[-PrivilegedAccountID] <Int32>]
+ [[-HeartbeatSchedule] <String>] [[-ExpiryDate] <String>] [-AllowExport] [[-WebUser_ID] <String>]
+ [[-WebPassword_ID] <String>] [[-Reason] <String>] [-WhatIf] [-Confirm] [<CommonParameters>]
 ```
 
 ### Heartbeat
 ```
-Set-PasswordStatePassword [-PasswordID] <Nullable`1[]> [[-Title] <String>] [[-Username] <String>]
+Set-PasswordStatePassword [-PasswordID] <Int32> [[-Title] <String>] [[-Username] <String>]
  [[-Password] <String>] [[-Description] <String>] [-GeneratePassword] [[-Notes] <String>] [[-Url] <String>]
- [[-AccountType] <String>] [[-AccountTypeID] <Nullable`1[]>] [[-GenericField1] <String>]
- [[-GenericField2] <String>] [[-GenericField3] <String>] [[-GenericField4] <String>]
- [[-GenericField5] <String>] [[-GenericField6] <String>] [[-GenericField7] <String>]
- [[-GenericField8] <String>] [[-GenericField9] <String>] [[-GenericField10] <String>]
- [-GenerateGenFieldPassword] [[-AddDaysToExpiryDate] <Nullable`1[]>] [[-ScriptID] <Nullable`1[]>]
- [[-PrivilegedAccountID] <Nullable`1[]>] [-HeartbeatEnabled] [[-HeartbeatSchedule] <String>]
- [[-ValidationScriptID] <Nullable`1[]>] [[-HostName] <String>] [[-ADDomainNetBIOS] <String>]
- [-ValidateWithPrivAccount] [[-ExpiryDate] <String>] [-AllowExport] [[-WebUser_ID] <String>]
- [[-WebPassword_ID] <String>] [[-Reason] <String>] [-WhatIf] [-Confirm] [<CommonParameters>]
+ [[-AccountType] <String>] [[-AccountTypeID] <Int32>] [[-GenericField1] <String>] [[-GenericField2] <String>]
+ [[-GenericField3] <String>] [[-GenericField4] <String>] [[-GenericField5] <String>]
+ [[-GenericField6] <String>] [[-GenericField7] <String>] [[-GenericField8] <String>]
+ [[-GenericField9] <String>] [[-GenericField10] <String>] [-GenerateGenFieldPassword]
+ [[-AddDaysToExpiryDate] <Int32>] [[-ScriptID] <Int32>] [[-PrivilegedAccountID] <Int32>] [-HeartbeatEnabled]
+ [[-HeartbeatSchedule] <String>] [[-ValidationScriptID] <Int32>] [[-HostName] <String>]
+ [[-ADDomainNetBIOS] <String>] [-ValidateWithPrivAccount] [[-ExpiryDate] <String>] [-AllowExport]
+ [[-WebUser_ID] <String>] [[-WebPassword_ID] <String>] [[-Reason] <String>] [-WhatIf] [-Confirm]
+ [<CommonParameters>]
 ```
 
 ### Reset
 ```
-Set-PasswordStatePassword [-PasswordID] <Nullable`1[]> [[-Title] <String>] [[-Username] <String>]
+Set-PasswordStatePassword [-PasswordID] <Int32> [[-Title] <String>] [[-Username] <String>]
  [[-Password] <String>] [[-Description] <String>] [-GeneratePassword] [[-Notes] <String>] [[-Url] <String>]
- [[-AccountType] <String>] [[-AccountTypeID] <Nullable`1[]>] [[-GenericField1] <String>]
- [[-GenericField2] <String>] [[-GenericField3] <String>] [[-GenericField4] <String>]
- [[-GenericField5] <String>] [[-GenericField6] <String>] [[-GenericField7] <String>]
- [[-GenericField8] <String>] [[-GenericField9] <String>] [[-GenericField10] <String>]
- [-GenerateGenFieldPassword] [-PasswordResetEnabled] [-EnablePasswordResetSchedule]
- [[-PasswordResetSchedule] <String>] [[-AddDaysToExpiryDate] <Nullable`1[]>] [[-ScriptID] <Nullable`1[]>]
- [[-PrivilegedAccountID] <Nullable`1[]>] [-HeartbeatEnabled] [[-HeartbeatSchedule] <String>]
- [[-ValidationScriptID] <Nullable`1[]>] [[-HostName] <String>] [[-ADDomainNetBIOS] <String>]
+ [[-AccountType] <String>] [[-AccountTypeID] <Int32>] [[-GenericField1] <String>] [[-GenericField2] <String>]
+ [[-GenericField3] <String>] [[-GenericField4] <String>] [[-GenericField5] <String>]
+ [[-GenericField6] <String>] [[-GenericField7] <String>] [[-GenericField8] <String>]
+ [[-GenericField9] <String>] [[-GenericField10] <String>] [-GenerateGenFieldPassword] [-PasswordResetEnabled]
+ [-EnablePasswordResetSchedule] [[-PasswordResetSchedule] <String>] [[-AddDaysToExpiryDate] <Int32>]
+ [[-ScriptID] <Int32>] [[-PrivilegedAccountID] <Int32>] [-HeartbeatEnabled] [[-HeartbeatSchedule] <String>]
+ [[-ValidationScriptID] <Int32>] [[-HostName] <String>] [[-ADDomainNetBIOS] <String>]
  [-ValidateWithPrivAccount] [[-ExpiryDate] <String>] [-AllowExport] [[-WebUser_ID] <String>]
  [[-WebPassword_ID] <String>] [[-Reason] <String>] [-WhatIf] [-Confirm] [<CommonParameters>]
 ```
 
 ### ResetSchedule
 ```
-Set-PasswordStatePassword [-PasswordID] <Nullable`1[]> [[-Title] <String>] [[-Username] <String>]
+Set-PasswordStatePassword [-PasswordID] <Int32> [[-Title] <String>] [[-Username] <String>]
  [[-Password] <String>] [[-Description] <String>] [-GeneratePassword] [[-Notes] <String>] [[-Url] <String>]
- [[-AccountType] <String>] [[-AccountTypeID] <Nullable`1[]>] [[-GenericField1] <String>]
- [[-GenericField2] <String>] [[-GenericField3] <String>] [[-GenericField4] <String>]
- [[-GenericField5] <String>] [[-GenericField6] <String>] [[-GenericField7] <String>]
- [[-GenericField8] <String>] [[-GenericField9] <String>] [[-GenericField10] <String>]
- [-GenerateGenFieldPassword] [-EnablePasswordResetSchedule] [-PasswordResetSchedule] <String>
- [[-AddDaysToExpiryDate] <Nullable`1[]>] [[-ScriptID] <Nullable`1[]>] [[-PrivilegedAccountID] <Nullable`1[]>]
- [-HeartbeatEnabled] [[-HeartbeatSchedule] <String>] [[-ValidationScriptID] <Nullable`1[]>]
- [[-HostName] <String>] [[-ADDomainNetBIOS] <String>] [-ValidateWithPrivAccount] [[-ExpiryDate] <String>]
- [-AllowExport] [[-WebUser_ID] <String>] [[-WebPassword_ID] <String>] [[-Reason] <String>] [-WhatIf] [-Confirm]
- [<CommonParameters>]
+ [[-AccountType] <String>] [[-AccountTypeID] <Int32>] [[-GenericField1] <String>] [[-GenericField2] <String>]
+ [[-GenericField3] <String>] [[-GenericField4] <String>] [[-GenericField5] <String>]
+ [[-GenericField6] <String>] [[-GenericField7] <String>] [[-GenericField8] <String>]
+ [[-GenericField9] <String>] [[-GenericField10] <String>] [-GenerateGenFieldPassword]
+ [-EnablePasswordResetSchedule] [-PasswordResetSchedule] <String> [[-AddDaysToExpiryDate] <Int32>]
+ [[-ScriptID] <Int32>] [[-PrivilegedAccountID] <Int32>] [-HeartbeatEnabled] [[-HeartbeatSchedule] <String>]
+ [[-ValidationScriptID] <Int32>] [[-HostName] <String>] [[-ADDomainNetBIOS] <String>]
+ [-ValidateWithPrivAccount] [[-ExpiryDate] <String>] [-AllowExport] [[-WebUser_ID] <String>]
+ [[-WebPassword_ID] <String>] [[-Reason] <String>] [-WhatIf] [-Confirm] [<CommonParameters>]
 ```
 
 ### Password
 ```
-Set-PasswordStatePassword [-PasswordID] <Nullable`1[]> [[-Title] <String>] [[-Username] <String>]
- [-Password] <String> [[-Description] <String>] [[-Notes] <String>] [[-Url] <String>] [[-AccountType] <String>]
- [[-AccountTypeID] <Nullable`1[]>] [[-GenericField1] <String>] [[-GenericField2] <String>]
- [[-GenericField3] <String>] [[-GenericField4] <String>] [[-GenericField5] <String>]
- [[-GenericField6] <String>] [[-GenericField7] <String>] [[-GenericField8] <String>]
- [[-GenericField9] <String>] [[-GenericField10] <String>] [-GenerateGenFieldPassword]
- [[-AddDaysToExpiryDate] <Nullable`1[]>] [[-ScriptID] <Nullable`1[]>] [[-PrivilegedAccountID] <Nullable`1[]>]
- [[-ExpiryDate] <String>] [-AllowExport] [[-WebUser_ID] <String>] [[-WebPassword_ID] <String>]
- [[-Reason] <String>] [-WhatIf] [-Confirm] [<CommonParameters>]
+Set-PasswordStatePassword [-PasswordID] <Int32> [[-Title] <String>] [[-Username] <String>] [-Password] <String>
+ [[-Description] <String>] [[-Notes] <String>] [[-Url] <String>] [[-AccountType] <String>]
+ [[-AccountTypeID] <Int32>] [[-GenericField1] <String>] [[-GenericField2] <String>] [[-GenericField3] <String>]
+ [[-GenericField4] <String>] [[-GenericField5] <String>] [[-GenericField6] <String>]
+ [[-GenericField7] <String>] [[-GenericField8] <String>] [[-GenericField9] <String>]
+ [[-GenericField10] <String>] [-GenerateGenFieldPassword] [[-AddDaysToExpiryDate] <Int32>]
+ [[-ScriptID] <Int32>] [[-PrivilegedAccountID] <Int32>] [[-ExpiryDate] <String>] [-AllowExport]
+ [[-WebUser_ID] <String>] [[-WebPassword_ID] <String>] [[-Reason] <String>] [-WhatIf] [-Confirm]
+ [<CommonParameters>]
 ```
 
 ### GeneratePassword
 ```
-Set-PasswordStatePassword [-PasswordID] <Nullable`1[]> [[-Title] <String>] [[-Username] <String>]
+Set-PasswordStatePassword [-PasswordID] <Int32> [[-Title] <String>] [[-Username] <String>]
  [[-Description] <String>] [-GeneratePassword] [[-Notes] <String>] [[-Url] <String>] [[-AccountType] <String>]
- [[-AccountTypeID] <Nullable`1[]>] [[-GenericField1] <String>] [[-GenericField2] <String>]
- [[-GenericField3] <String>] [[-GenericField4] <String>] [[-GenericField5] <String>]
- [[-GenericField6] <String>] [[-GenericField7] <String>] [[-GenericField8] <String>]
- [[-GenericField9] <String>] [[-GenericField10] <String>] [-GenerateGenFieldPassword]
- [[-AddDaysToExpiryDate] <Nullable`1[]>] [[-ScriptID] <Nullable`1[]>] [[-PrivilegedAccountID] <Nullable`1[]>]
- [[-ExpiryDate] <String>] [-AllowExport] [[-WebUser_ID] <String>] [[-WebPassword_ID] <String>]
- [[-Reason] <String>] [-WhatIf] [-Confirm] [<CommonParameters>]
+ [[-AccountTypeID] <Int32>] [[-GenericField1] <String>] [[-GenericField2] <String>] [[-GenericField3] <String>]
+ [[-GenericField4] <String>] [[-GenericField5] <String>] [[-GenericField6] <String>]
+ [[-GenericField7] <String>] [[-GenericField8] <String>] [[-GenericField9] <String>]
+ [[-GenericField10] <String>] [-GenerateGenFieldPassword] [[-AddDaysToExpiryDate] <Int32>]
+ [[-ScriptID] <Int32>] [[-PrivilegedAccountID] <Int32>] [[-ExpiryDate] <String>] [-AllowExport]
+ [[-WebUser_ID] <String>] [[-WebPassword_ID] <String>] [[-Reason] <String>] [-WhatIf] [-Confirm]
+ [<CommonParameters>]
 ```
 
 ## DESCRIPTION
@@ -172,7 +169,7 @@ The ID value representing the Account Type image (derived from the AccountTypes 
 You can either specify the AccountType or AccountTypeID if needed when changing password records. Account Types and their ID values can be seen on the screen `Administration -> Passwordstate Administration -> Images and Account Types`, and click on the '**Toggle ID Column Visibility**' button to determine the appropriate value.
 
 ```yaml
-Type: Nullable`1[]
+Type: Int32
 Parameter Sets: (All)
 Aliases:
 
@@ -187,7 +184,7 @@ Accept wildcard characters: False
 Once the password has been changed due to a scheduled reset, you can add an additional (x) number of days to the ExpiryDate field so another reset will occur again in 30, 60, 90 days, etc. This is the option on the Reset Options tab for the record.
 
 ```yaml
-Type: Nullable`1[]
+Type: Int32
 Parameter Sets: (All)
 Aliases:
 
@@ -613,7 +610,7 @@ Accept wildcard characters: False
 The ID of the password to be updated.
 
 ```yaml
-Type: Nullable`1[]
+Type: Int32
 Parameter Sets: (All)
 Aliases:
 
@@ -670,7 +667,7 @@ Accept wildcard characters: False
 Some Password Reset Scripts also require a `Privileged Account Credential` to be associated with the Password record, to initiate connection and perform the reset. Requirements for Privileged Accounts are documented in the User Manual, under the KB Article section. To look up the value of PrivilegedAccountID's, this can be done on the screen `Administration -> PasswordState Administration -> Privileged Account Credentials`.
 
 ```yaml
-Type: Nullable`1[]
+Type: Int32
 Parameter Sets: (All)
 Aliases:
 
@@ -700,7 +697,7 @@ Accept wildcard characters: False
 Most accounts require a Password Reset Script to be assigned to them, with the only exception being Active Directory Accounts - not to specify this field for AD Accounts. To look up the values of the ScriptID's, this can be done by using the '**Toggle ID Column Visibility**' button on the Password Reset Scripts screens in PasswordState.
 
 ```yaml
-Type: Nullable`1[]
+Type: Int32
 Parameter Sets: (All)
 Aliases:
 
@@ -777,7 +774,7 @@ Accept wildcard characters: False
 When enabling Account Heartbeat, you must associate the correct Password Validation Script to the record (all account types require a Validation Script to be selected). To look up the values of the ValidationScriptID's, this can be done by using the '**Toggle ID Column Visibility**' button on the Password Validation Scripts screens in PasswordState.
 
 ```yaml
-Type: Nullable`1[]
+Type: Int32
 Parameter Sets: Heartbeat, Reset, ResetSchedule
 Aliases:
 
@@ -854,7 +851,7 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 
 ## INPUTS
 
-### System.Nullable`1[[System.Int32, System.Private.CoreLib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=7cec85d7bea7798e]][]
+### System.Nullable`1[[System.Int32, System.Private.CoreLib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=7cec85d7bea7798e]]
 
 ### System.String
 

--- a/docs/Set-PasswordStatePasswordPermission.md
+++ b/docs/Set-PasswordStatePasswordPermission.md
@@ -21,8 +21,8 @@ Set-PasswordStatePasswordPermission [-PasswordID] <Int32> [-Permission] <String>
 ### PermissionID
 ```
 Set-PasswordStatePasswordPermission [-PasswordID] <Int32> [-Permission] <String>
- [[-ApplyPermissionsForUserID] <String>] [-ApplyPermissionsForSecurityGroupID] <Nullable`1[]> [-WhatIf]
- [-Confirm] [<CommonParameters>]
+ [[-ApplyPermissionsForUserID] <String>] [-ApplyPermissionsForSecurityGroupID] <Int32> [-WhatIf] [-Confirm]
+ [<CommonParameters>]
 ```
 
 ### PermissionName
@@ -58,7 +58,7 @@ The SecurityGroupID you wish to apply permissions for.
 You can only specify SecurityGroupID or SecurityGroupName, not both in the same call.
 
 ```yaml
-Type: Nullable`1[]
+Type: Int32
 Parameter Sets: PermissionID
 Aliases:
 
@@ -172,7 +172,7 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 
 ### System.String
 
-### System.Nullable`1[[System.Int32, System.Private.CoreLib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=7cec85d7bea7798e]][]
+### System.Nullable`1[[System.Int32, System.Private.CoreLib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=7cec85d7bea7798e]]
 
 ## OUTPUTS
 

--- a/en-us/passwordstate-management-help.xml
+++ b/en-us/passwordstate-management-help.xml
@@ -90,11 +90,13 @@
       <command:verb>Get</command:verb>
       <command:noun>PasswordStateFolder</command:noun>
       <maml:description>
-        <maml:para>Finds a password state entry and returns the object. If multiple matches it will return multiple entries.</maml:para>
+        <maml:para>Find a PasswordState folder entry and returns the object.
+If multiple matches it will return multiple objects.</maml:para>
       </maml:description>
     </command:details>
     <maml:description>
-      <maml:para>Finds a password state entry and returns the object. If multiple matches it will return multiple entries.</maml:para>
+      <maml:para>Find a PasswordState folder entry and returns the object.
+If multiple matches it will return multiple objects. Note 1 : You can perform an exact match search by enclosing your search criteria in double quotes, i.e. `'"MyFolder"'` Note 2 : By default, the retrieval of (all) folder records will add one Audit record for every folder record returned. If you wish to prevent audit records from being added, you can add the `-PreventAuditing` parameter.</maml:para>
     </maml:description>
     <command:syntax>
       <command:syntaxItem>
@@ -102,7 +104,7 @@
         <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="0" aliases="Name">
           <maml:name>FolderName</maml:name>
           <maml:Description>
-            <maml:para>The name for the folder to find</maml:para>
+            <maml:para>The name for the folder to search for.</maml:para>
           </maml:Description>
           <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
           <dev:type>
@@ -114,7 +116,7 @@
         <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="1" aliases="none">
           <maml:name>Description</maml:name>
           <maml:Description>
-            <maml:para>The description for the folder to find</maml:para>
+            <maml:para>An optional parameter to filter the search on description. The description is generally used as a longer verbose description of the nature of the Password object.</maml:para>
           </maml:Description>
           <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
           <dev:type>
@@ -126,7 +128,7 @@
         <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="2" aliases="none">
           <maml:name>TreePath</maml:name>
           <maml:Description>
-            <maml:para>The treepath where the folder should be found</maml:para>
+            <maml:para>The TreePath where the folder should be found.</maml:para>
           </maml:Description>
           <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
           <dev:type>
@@ -138,7 +140,8 @@
         <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="3" aliases="none">
           <maml:name>SiteID</maml:name>
           <maml:Description>
-            <maml:para>The siteID for the folder</maml:para>
+            <maml:para>An optional parameter to filter the search on the site ID.
+If you do not specify this parameter, it will report data based on all Site Locations. Values are 0 for Internal, and all other SiteID's can be found on the screen `Administration -&gt; Remote Site Administration -&gt; Remote Site Locations`.</maml:para>
           </maml:Description>
           <command:parameterValue required="true" variableLength="false">Int32</command:parameterValue>
           <dev:type>
@@ -150,7 +153,8 @@
         <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="4" aliases="none">
           <maml:name>SiteLocation</maml:name>
           <maml:Description>
-            <maml:para>The sitelocation for the folder</maml:para>
+            <maml:para>An optional parameter to filter the search on the site location.
+If you do not specify this parameter, it will report data based on all Site Locations. Values are the name of the Site Location that can be found on the screen `Administration -&gt; Remote Site Administration -&gt; Remote Site Locations`.</maml:para>
           </maml:Description>
           <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
           <dev:type>
@@ -170,13 +174,37 @@
           </dev:type>
           <dev:defaultValue>False</dev:defaultValue>
         </command:parameter>
+        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="named" aliases="none">
+          <maml:name>FolderID</maml:name>
+          <maml:Description>
+            <maml:para>The unique ID of the folder to filter the search for.</maml:para>
+          </maml:Description>
+          <command:parameterValue required="true" variableLength="false">Int32</command:parameterValue>
+          <dev:type>
+            <maml:name>Int32</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="named" aliases="none">
+          <maml:name>Reason</maml:name>
+          <maml:Description>
+            <maml:para>A reason which can be logged for auditing of why a folder was retrieved.</maml:para>
+          </maml:Description>
+          <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+          <dev:type>
+            <maml:name>String</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
       </command:syntaxItem>
     </command:syntax>
     <command:parameters>
       <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="1" aliases="none">
         <maml:name>Description</maml:name>
         <maml:Description>
-          <maml:para>The description for the folder to find</maml:para>
+          <maml:para>An optional parameter to filter the search on description. The description is generally used as a longer verbose description of the nature of the Password object.</maml:para>
         </maml:Description>
         <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
         <dev:type>
@@ -185,10 +213,22 @@
         </dev:type>
         <dev:defaultValue>None</dev:defaultValue>
       </command:parameter>
+      <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="named" aliases="none">
+        <maml:name>FolderID</maml:name>
+        <maml:Description>
+          <maml:para>The unique ID of the folder to filter the search for.</maml:para>
+        </maml:Description>
+        <command:parameterValue required="true" variableLength="false">Int32</command:parameterValue>
+        <dev:type>
+          <maml:name>Int32</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
       <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="0" aliases="Name">
         <maml:name>FolderName</maml:name>
         <maml:Description>
-          <maml:para>The name for the folder to find</maml:para>
+          <maml:para>The name for the folder to search for.</maml:para>
         </maml:Description>
         <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
         <dev:type>
@@ -209,10 +249,23 @@
         </dev:type>
         <dev:defaultValue>False</dev:defaultValue>
       </command:parameter>
+      <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="named" aliases="none">
+        <maml:name>Reason</maml:name>
+        <maml:Description>
+          <maml:para>A reason which can be logged for auditing of why a folder was retrieved.</maml:para>
+        </maml:Description>
+        <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+        <dev:type>
+          <maml:name>String</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
       <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="3" aliases="none">
         <maml:name>SiteID</maml:name>
         <maml:Description>
-          <maml:para>The siteID for the folder</maml:para>
+          <maml:para>An optional parameter to filter the search on the site ID.
+If you do not specify this parameter, it will report data based on all Site Locations. Values are 0 for Internal, and all other SiteID's can be found on the screen `Administration -&gt; Remote Site Administration -&gt; Remote Site Locations`.</maml:para>
         </maml:Description>
         <command:parameterValue required="true" variableLength="false">Int32</command:parameterValue>
         <dev:type>
@@ -224,7 +277,8 @@
       <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="4" aliases="none">
         <maml:name>SiteLocation</maml:name>
         <maml:Description>
-          <maml:para>The sitelocation for the folder</maml:para>
+          <maml:para>An optional parameter to filter the search on the site location.
+If you do not specify this parameter, it will report data based on all Site Locations. Values are the name of the Site Location that can be found on the screen `Administration -&gt; Remote Site Administration -&gt; Remote Site Locations`.</maml:para>
         </maml:Description>
         <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
         <dev:type>
@@ -236,7 +290,7 @@
       <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="2" aliases="none">
         <maml:name>TreePath</maml:name>
         <maml:Description>
-          <maml:para>The treepath where the folder should be found</maml:para>
+          <maml:para>The TreePath where the folder should be found.</maml:para>
         </maml:Description>
         <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
         <dev:type>
@@ -290,16 +344,23 @@
     <command:examples>
       <command:example>
         <maml:title>-------------------------- EXAMPLE 1 --------------------------</maml:title>
-        <dev:code>Find-PasswordStateFolder -FolderName "test"</dev:code>
+        <dev:code>Get-PasswordStateFolder -FolderName "test"</dev:code>
         <dev:remarks>
-          <maml:para>Returns the test folder object.</maml:para>
+          <maml:para>Returns the folder object(s) with name "test".</maml:para>
         </dev:remarks>
       </command:example>
       <command:example>
         <maml:title>-------------------------- EXAMPLE 2 --------------------------</maml:title>
-        <dev:code>Find-PasswordStateFolder -Description "testfolder"</dev:code>
+        <dev:code>Get-PasswordStateFolder -Description "testfolder"</dev:code>
         <dev:remarks>
-          <maml:para>Returns the folder objects that contain testfolder in the description.</maml:para>
+          <maml:para>Returns the folder object(s) that contains testfolder in the description.</maml:para>
+        </dev:remarks>
+      </command:example>
+      <command:example>
+        <maml:title>-------------------------- EXAMPLE 3 --------------------------</maml:title>
+        <dev:code>Get-PasswordStateFolder -FolderID 12</dev:code>
+        <dev:remarks>
+          <maml:para>Returns the folder object(s) with FolderID 12 if found.</maml:para>
         </dev:remarks>
       </command:example>
     </command:examples>
@@ -584,7 +645,7 @@
       </maml:description>
     </command:details>
     <maml:description>
-      <maml:para>Gets all password lists from the API (Only those you have permissions to.)</maml:para>
+      <maml:para>Gets all password lists from the API (Only those you have permissions to.) Note 1 : You can perform an exact match search by enclosing your search criteria in double quotes, i.e. `'"MyList"'` Note 2 : By default, the retrieval of (all) PasswordList records will add one Audit record for every PasswordList record returned. If you wish to prevent audit records from being added, you can add the `-PreventAuditing` parameter.</maml:para>
     </maml:description>
     <command:syntax>
       <command:syntaxItem>
@@ -592,7 +653,7 @@
         <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="0" aliases="none">
           <maml:name>PasswordList</maml:name>
           <maml:Description>
-            <maml:para>The name for the PasswordList to find</maml:para>
+            <maml:para>The name for the PasswordList to search for.</maml:para>
           </maml:Description>
           <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
           <dev:type>
@@ -604,7 +665,7 @@
         <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="1" aliases="none">
           <maml:name>Description</maml:name>
           <maml:Description>
-            <maml:para>The description for the PasswordList to find</maml:para>
+            <maml:para>An optional parameter to filter the search on description. The description is generally used as a longer verbose description of the nature of the Password object.</maml:para>
           </maml:Description>
           <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
           <dev:type>
@@ -616,7 +677,7 @@
         <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="2" aliases="none">
           <maml:name>TreePath</maml:name>
           <maml:Description>
-            <maml:para>The treepath where the PasswordList should be found</maml:para>
+            <maml:para>The TreePath where the PasswordList can be found.</maml:para>
           </maml:Description>
           <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
           <dev:type>
@@ -628,7 +689,8 @@
         <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="3" aliases="none">
           <maml:name>SiteID</maml:name>
           <maml:Description>
-            <maml:para>The siteID for the PasswordList</maml:para>
+            <maml:para>An optional parameter to filter the search on the site ID.
+If you do not specify this parameter, it will report data based on all Site Locations. Values are 0 for Internal, and all other SiteID's can be found on the screen `Administration -&gt; Remote Site Administration -&gt; Remote Site Locations`.</maml:para>
           </maml:Description>
           <command:parameterValue required="true" variableLength="false">Int32</command:parameterValue>
           <dev:type>
@@ -640,7 +702,8 @@
         <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="4" aliases="none">
           <maml:name>SiteLocation</maml:name>
           <maml:Description>
-            <maml:para>The sitelocation for the PasswordList</maml:para>
+            <maml:para>An optional parameter to filter the search on the site location.
+If you do not specify this parameter, it will report data based on all Site Locations. Values are the name of the Site Location that can be found on the screen `Administration -&gt; Remote Site Administration -&gt; Remote Site Locations`.</maml:para>
           </maml:Description>
           <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
           <dev:type>
@@ -660,13 +723,25 @@
           </dev:type>
           <dev:defaultValue>False</dev:defaultValue>
         </command:parameter>
+        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="named" aliases="none">
+          <maml:name>Reason</maml:name>
+          <maml:Description>
+            <maml:para>A reason which can be logged for auditing of why a password was retrieved.</maml:para>
+          </maml:Description>
+          <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+          <dev:type>
+            <maml:name>String</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
       </command:syntaxItem>
       <command:syntaxItem>
         <maml:name>Get-PasswordStateList</maml:name>
         <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="0" aliases="none">
           <maml:name>PasswordListID</maml:name>
           <maml:Description>
-            <maml:para>Gets the passwordlist based on ID, when omitted, gets all the passord lists</maml:para>
+            <maml:para>Gets the PasswordList based on ID, when omitted, gets all the password lists.</maml:para>
           </maml:Description>
           <command:parameterValue required="true" variableLength="false">Int32</command:parameterValue>
           <dev:type>
@@ -686,13 +761,25 @@
           </dev:type>
           <dev:defaultValue>False</dev:defaultValue>
         </command:parameter>
+        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="named" aliases="none">
+          <maml:name>Reason</maml:name>
+          <maml:Description>
+            <maml:para>A reason which can be logged for auditing of why a password was retrieved.</maml:para>
+          </maml:Description>
+          <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+          <dev:type>
+            <maml:name>String</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
       </command:syntaxItem>
     </command:syntax>
     <command:parameters>
       <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="1" aliases="none">
         <maml:name>Description</maml:name>
         <maml:Description>
-          <maml:para>The description for the PasswordList to find</maml:para>
+          <maml:para>An optional parameter to filter the search on description. The description is generally used as a longer verbose description of the nature of the Password object.</maml:para>
         </maml:Description>
         <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
         <dev:type>
@@ -704,7 +791,7 @@
       <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="0" aliases="none">
         <maml:name>PasswordList</maml:name>
         <maml:Description>
-          <maml:para>The name for the PasswordList to find</maml:para>
+          <maml:para>The name for the PasswordList to search for.</maml:para>
         </maml:Description>
         <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
         <dev:type>
@@ -716,7 +803,7 @@
       <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="0" aliases="none">
         <maml:name>PasswordListID</maml:name>
         <maml:Description>
-          <maml:para>Gets the passwordlist based on ID, when omitted, gets all the passord lists</maml:para>
+          <maml:para>Gets the PasswordList based on ID, when omitted, gets all the password lists.</maml:para>
         </maml:Description>
         <command:parameterValue required="true" variableLength="false">Int32</command:parameterValue>
         <dev:type>
@@ -737,10 +824,23 @@
         </dev:type>
         <dev:defaultValue>False</dev:defaultValue>
       </command:parameter>
+      <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="named" aliases="none">
+        <maml:name>Reason</maml:name>
+        <maml:Description>
+          <maml:para>A reason which can be logged for auditing of why a password was retrieved.</maml:para>
+        </maml:Description>
+        <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+        <dev:type>
+          <maml:name>String</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
       <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="3" aliases="none">
         <maml:name>SiteID</maml:name>
         <maml:Description>
-          <maml:para>The siteID for the PasswordList</maml:para>
+          <maml:para>An optional parameter to filter the search on the site ID.
+If you do not specify this parameter, it will report data based on all Site Locations. Values are 0 for Internal, and all other SiteID's can be found on the screen `Administration -&gt; Remote Site Administration -&gt; Remote Site Locations`.</maml:para>
         </maml:Description>
         <command:parameterValue required="true" variableLength="false">Int32</command:parameterValue>
         <dev:type>
@@ -752,7 +852,8 @@
       <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="4" aliases="none">
         <maml:name>SiteLocation</maml:name>
         <maml:Description>
-          <maml:para>The sitelocation for the PasswordList</maml:para>
+          <maml:para>An optional parameter to filter the search on the site location.
+If you do not specify this parameter, it will report data based on all Site Locations. Values are the name of the Site Location that can be found on the screen `Administration -&gt; Remote Site Administration -&gt; Remote Site Locations`.</maml:para>
         </maml:Description>
         <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
         <dev:type>
@@ -764,7 +865,7 @@
       <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="2" aliases="none">
         <maml:name>TreePath</maml:name>
         <maml:Description>
-          <maml:para>The treepath where the PasswordList should be found</maml:para>
+          <maml:para>The TreePath where the PasswordList can be found.</maml:para>
         </maml:Description>
         <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
         <dev:type>
@@ -820,21 +921,29 @@
         <maml:title>-------------------------- EXAMPLE 1 --------------------------</maml:title>
         <dev:code>Get-PasswordStateList</dev:code>
         <dev:remarks>
-          <maml:para></maml:para>
+          <maml:para>Get all available PasswordState Lists the user/api key has access to.</maml:para>
         </dev:remarks>
       </command:example>
       <command:example>
         <maml:title>-------------------------- EXAMPLE 2 --------------------------</maml:title>
         <dev:code>Get-PasswordStateList -PasswordListID 3</dev:code>
         <dev:remarks>
-          <maml:para></maml:para>
+          <maml:para>Get the PasswordState List with ID 3.</maml:para>
         </dev:remarks>
       </command:example>
       <command:example>
         <maml:title>-------------------------- EXAMPLE 3 --------------------------</maml:title>
         <dev:code>Get-PasswordStateList -PasswordList 'Test' -TreePath '\TestPath\Lists' -SiteID 123</dev:code>
         <dev:remarks>
-          <maml:para></maml:para>
+          <maml:para>Search for a PasswordState List with Name Test on Path \TestPath\Lists and on Site with ID 123.</maml:para>
+        </dev:remarks>
+      </command:example>
+      <command:example>
+        <maml:title>-------------------------- EXAMPLE 4 --------------------------</maml:title>
+        <dev:code>Get-PasswordStateList -PasswordList 'Test' -TreePath '\TestPath\Lists' -SiteID 123 -Reason "Ticket #202005151234567"</dev:code>
+        <dev:remarks>
+          <maml:para>Search for a PasswordState List with Name Test on Path \TestPath\Lists and on Site with ID 123. Also specifying the reason "Ticket #202005151234567" why the search for the passwordlist object was requested.
+The Reason will be added as audit entry to every PasswordList object that will be found with these search criteria.</maml:para>
         </dev:remarks>
       </command:example>
     </command:examples>
@@ -1919,7 +2028,8 @@ Some systems require a username and password to authenticate. This field represe
         <maml:title>-------------------------- EXAMPLE 13 --------------------------</maml:title>
         <dev:code>Get-PasswordStatePassword -HostName "SecureComputer.local" -UserName "Administrator" -Reason "Ticket #202005151234567"</dev:code>
         <dev:remarks>
-          <maml:para>Returns the password object with UserName "Administrator" and/on HostName "SecureComputer.local". Also specifying the reason "Ticket #202005151234567" why the password object was requested.</maml:para>
+          <maml:para>Returns the password object with UserName "Administrator" and/on HostName "SecureComputer.local". Also specifying the reason "Ticket #202005151234567" why the password object was requested.
+The Reason will be added as audit entry to every password object that will be found with these search criteria.</maml:para>
         </dev:remarks>
       </command:example>
       <command:example>

--- a/en-us/passwordstate-management-help.xml
+++ b/en-us/passwordstate-management-help.xml
@@ -163,18 +163,7 @@ If you do not specify this parameter, it will report data based on all Site Loca
           </dev:type>
           <dev:defaultValue>None</dev:defaultValue>
         </command:parameter>
-        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="5" aliases="none">
-          <maml:name>PreventAuditing</maml:name>
-          <maml:Description>
-            <maml:para>By default, the creation/modification or retrieval of (all) Passwords records will add one Audit record for every Password record returned. If you wish to prevent audit records from being added, you can add this `-PreventAuditing` parameter.</maml:para>
-          </maml:Description>
-          <dev:type>
-            <maml:name>SwitchParameter</maml:name>
-            <maml:uri />
-          </dev:type>
-          <dev:defaultValue>False</dev:defaultValue>
-        </command:parameter>
-        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="named" aliases="none">
+        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="6" aliases="none">
           <maml:name>FolderID</maml:name>
           <maml:Description>
             <maml:para>The unique ID of the folder to filter the search for.</maml:para>
@@ -186,7 +175,18 @@ If you do not specify this parameter, it will report data based on all Site Loca
           </dev:type>
           <dev:defaultValue>None</dev:defaultValue>
         </command:parameter>
-        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="named" aliases="none">
+        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="7" aliases="none">
+          <maml:name>PreventAuditing</maml:name>
+          <maml:Description>
+            <maml:para>By default, the creation/modification or retrieval of (all) Passwords records will add one Audit record for every Password record returned. If you wish to prevent audit records from being added, you can add this `-PreventAuditing` parameter.</maml:para>
+          </maml:Description>
+          <dev:type>
+            <maml:name>SwitchParameter</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>False</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="8" aliases="none">
           <maml:name>Reason</maml:name>
           <maml:Description>
             <maml:para>A reason which can be logged for auditing of why a folder was retrieved.</maml:para>
@@ -213,7 +213,7 @@ If you do not specify this parameter, it will report data based on all Site Loca
         </dev:type>
         <dev:defaultValue>None</dev:defaultValue>
       </command:parameter>
-      <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="named" aliases="none">
+      <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="6" aliases="none">
         <maml:name>FolderID</maml:name>
         <maml:Description>
           <maml:para>The unique ID of the folder to filter the search for.</maml:para>
@@ -237,7 +237,7 @@ If you do not specify this parameter, it will report data based on all Site Loca
         </dev:type>
         <dev:defaultValue>None</dev:defaultValue>
       </command:parameter>
-      <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="5" aliases="none">
+      <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="7" aliases="none">
         <maml:name>PreventAuditing</maml:name>
         <maml:Description>
           <maml:para>By default, the creation/modification or retrieval of (all) Passwords records will add one Audit record for every Password record returned. If you wish to prevent audit records from being added, you can add this `-PreventAuditing` parameter.</maml:para>
@@ -249,7 +249,7 @@ If you do not specify this parameter, it will report data based on all Site Loca
         </dev:type>
         <dev:defaultValue>False</dev:defaultValue>
       </command:parameter>
-      <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="named" aliases="none">
+      <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="8" aliases="none">
         <maml:name>Reason</maml:name>
         <maml:Description>
           <maml:para>A reason which can be logged for auditing of why a folder was retrieved.</maml:para>
@@ -311,7 +311,7 @@ If you do not specify this parameter, it will report data based on all Site Loca
       </command:inputType>
       <command:inputType>
         <dev:type>
-          <maml:name>System.Int32</maml:name>
+          <maml:name>System.Nullable`1[[System.Int32, System.Private.CoreLib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=7cec85d7bea7798e]]</maml:name>
         </dev:type>
         <maml:description>
           <maml:para></maml:para>
@@ -723,7 +723,7 @@ If you do not specify this parameter, it will report data based on all Site Loca
           </dev:type>
           <dev:defaultValue>False</dev:defaultValue>
         </command:parameter>
-        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="named" aliases="none">
+        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="6" aliases="none">
           <maml:name>Reason</maml:name>
           <maml:Description>
             <maml:para>A reason which can be logged for auditing of why a password was retrieved.</maml:para>
@@ -761,7 +761,7 @@ If you do not specify this parameter, it will report data based on all Site Loca
           </dev:type>
           <dev:defaultValue>False</dev:defaultValue>
         </command:parameter>
-        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="named" aliases="none">
+        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="6" aliases="none">
           <maml:name>Reason</maml:name>
           <maml:Description>
             <maml:para>A reason which can be logged for auditing of why a password was retrieved.</maml:para>
@@ -824,7 +824,7 @@ If you do not specify this parameter, it will report data based on all Site Loca
         </dev:type>
         <dev:defaultValue>False</dev:defaultValue>
       </command:parameter>
-      <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="named" aliases="none">
+      <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="6" aliases="none">
         <maml:name>Reason</maml:name>
         <maml:Description>
           <maml:para>A reason which can be logged for auditing of why a password was retrieved.</maml:para>
@@ -2255,9 +2255,9 @@ Possible values: '23', '24', '25', '26', '27', '28', '37', '38', '43', '44'.
             <maml:para>If you leave this parameter blank , it will report data based on all Site Locations. Values are 0 for Internal , and all other SiteID's can be found on the screen `Administration -&gt; Remote Site Administration -&gt; Remote Site Locations`.
 SiteID 0 = Default site 'Internal'</maml:para>
           </maml:Description>
-          <command:parameterValue required="true" variableLength="false">Nullable`1[]</command:parameterValue>
+          <command:parameterValue required="true" variableLength="false">Int32</command:parameterValue>
           <dev:type>
-            <maml:name>Nullable`1[]</maml:name>
+            <maml:name>Int32</maml:name>
             <maml:uri />
           </dev:type>
           <dev:defaultValue>None</dev:defaultValue>
@@ -2268,9 +2268,9 @@ SiteID 0 = Default site 'Internal'</maml:para>
             <maml:para>The period in which data can be reported against. Possible values are `0 for current month`, `1 for the past 30 days`, and then `any other integer representing the quantity of months`.</maml:para>
             <maml:para>For the ' What passwords are expiring soon? ' report however, Duration refers to the number of days you wish to look ahead for passwords which are going to expire.</maml:para>
           </maml:Description>
-          <command:parameterValue required="true" variableLength="false">Nullable`1[]</command:parameterValue>
+          <command:parameterValue required="true" variableLength="false">Int32</command:parameterValue>
           <dev:type>
-            <maml:name>Nullable`1[]</maml:name>
+            <maml:name>Int32</maml:name>
             <maml:uri />
           </dev:type>
           <dev:defaultValue>None</dev:defaultValue>
@@ -2317,9 +2317,9 @@ SiteID 0 = Default site 'Internal'</maml:para>
           <maml:para>The period in which data can be reported against. Possible values are `0 for current month`, `1 for the past 30 days`, and then `any other integer representing the quantity of months`.</maml:para>
           <maml:para>For the ' What passwords are expiring soon? ' report however, Duration refers to the number of days you wish to look ahead for passwords which are going to expire.</maml:para>
         </maml:Description>
-        <command:parameterValue required="true" variableLength="false">Nullable`1[]</command:parameterValue>
+        <command:parameterValue required="true" variableLength="false">Int32</command:parameterValue>
         <dev:type>
-          <maml:name>Nullable`1[]</maml:name>
+          <maml:name>Int32</maml:name>
           <maml:uri />
         </dev:type>
         <dev:defaultValue>None</dev:defaultValue>
@@ -2368,9 +2368,9 @@ Possible values: '23', '24', '25', '26', '27', '28', '37', '38', '43', '44'.
           <maml:para>If you leave this parameter blank , it will report data based on all Site Locations. Values are 0 for Internal , and all other SiteID's can be found on the screen `Administration -&gt; Remote Site Administration -&gt; Remote Site Locations`.
 SiteID 0 = Default site 'Internal'</maml:para>
         </maml:Description>
-        <command:parameterValue required="true" variableLength="false">Nullable`1[]</command:parameterValue>
+        <command:parameterValue required="true" variableLength="false">Int32</command:parameterValue>
         <dev:type>
-          <maml:name>Nullable`1[]</maml:name>
+          <maml:name>Int32</maml:name>
           <maml:uri />
         </dev:type>
         <dev:defaultValue>None</dev:defaultValue>
@@ -2431,7 +2431,7 @@ SiteID 0 = Default site 'Internal'</maml:para>
       </command:inputType>
       <command:inputType>
         <dev:type>
-          <maml:name>System.Nullable`1[[System.Int32, System.Private.CoreLib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=7cec85d7bea7798e]][]</maml:name>
+          <maml:name>System.Nullable`1[[System.Int32, System.Private.CoreLib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=7cec85d7bea7798e]]</maml:name>
         </dev:type>
         <maml:description>
           <maml:para></maml:para>
@@ -2924,7 +2924,7 @@ SiteID 0 = Default site 'Internal'</maml:para>
           </dev:type>
           <dev:defaultValue>None</dev:defaultValue>
         </command:parameter>
-        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="named" aliases="none">
+        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="3" aliases="none">
           <maml:name>Reason</maml:name>
           <maml:Description>
             <maml:para>A reason which can be logged for auditing of why a password was retrieved.</maml:para>
@@ -2985,7 +2985,7 @@ SiteID 0 = Default site 'Internal'</maml:para>
         </dev:type>
         <dev:defaultValue>None</dev:defaultValue>
       </command:parameter>
-      <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="named" aliases="none">
+      <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="3" aliases="none">
         <maml:name>Reason</maml:name>
         <maml:Description>
           <maml:para>A reason which can be logged for auditing of why a password was retrieved.</maml:para>
@@ -6549,9 +6549,9 @@ A for Administrator, M for Modify or V for View permissions.</maml:para>
             <maml:para>The SecurityGroupID you wish to apply permissions for.
 You can only specify SecurityGroupID or SecurityGroupName, not both in the same call.</maml:para>
           </maml:Description>
-          <command:parameterValue required="true" variableLength="false">Nullable`1[]</command:parameterValue>
+          <command:parameterValue required="true" variableLength="false">Int32</command:parameterValue>
           <dev:type>
-            <maml:name>Nullable`1[]</maml:name>
+            <maml:name>Int32</maml:name>
             <maml:uri />
           </dev:type>
           <dev:defaultValue>None</dev:defaultValue>
@@ -6667,9 +6667,9 @@ You can only specify SecurityGroupID or SecurityGroupName, not both in the same 
           <maml:para>The SecurityGroupID you wish to apply permissions for.
 You can only specify SecurityGroupID or SecurityGroupName, not both in the same call.</maml:para>
         </maml:Description>
-        <command:parameterValue required="true" variableLength="false">Nullable`1[]</command:parameterValue>
+        <command:parameterValue required="true" variableLength="false">Int32</command:parameterValue>
         <dev:type>
-          <maml:name>Nullable`1[]</maml:name>
+          <maml:name>Int32</maml:name>
           <maml:uri />
         </dev:type>
         <dev:defaultValue>None</dev:defaultValue>
@@ -6768,7 +6768,7 @@ A for Administrator, M for Modify or V for View permissions.</maml:para>
       </command:inputType>
       <command:inputType>
         <dev:type>
-          <maml:name>System.Nullable`1[[System.Int32, System.Private.CoreLib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=7cec85d7bea7798e]][]</maml:name>
+          <maml:name>System.Nullable`1[[System.Int32, System.Private.CoreLib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=7cec85d7bea7798e]]</maml:name>
         </dev:type>
         <maml:description>
           <maml:para></maml:para>
@@ -10072,9 +10072,9 @@ M for Modify or V for View permissions.</maml:para>
             <maml:para>The SecurityGroupID you wish to apply permissions for.
 You can only specify SecurityGroupID or SecurityGroupName, not both in the same call.</maml:para>
           </maml:Description>
-          <command:parameterValue required="true" variableLength="false">Nullable`1[]</command:parameterValue>
+          <command:parameterValue required="true" variableLength="false">Int32</command:parameterValue>
           <dev:type>
-            <maml:name>Nullable`1[]</maml:name>
+            <maml:name>Int32</maml:name>
             <maml:uri />
           </dev:type>
           <dev:defaultValue>None</dev:defaultValue>
@@ -10189,9 +10189,9 @@ You can only specify SecurityGroupID or SecurityGroupName, not both in the same 
           <maml:para>The SecurityGroupID you wish to apply permissions for.
 You can only specify SecurityGroupID or SecurityGroupName, not both in the same call.</maml:para>
         </maml:Description>
-        <command:parameterValue required="true" variableLength="false">Nullable`1[]</command:parameterValue>
+        <command:parameterValue required="true" variableLength="false">Int32</command:parameterValue>
         <dev:type>
-          <maml:name>Nullable`1[]</maml:name>
+          <maml:name>Int32</maml:name>
           <maml:uri />
         </dev:type>
         <dev:defaultValue>None</dev:defaultValue>
@@ -10290,7 +10290,7 @@ M for Modify or V for View permissions.</maml:para>
       </command:inputType>
       <command:inputType>
         <dev:type>
-          <maml:name>System.Nullable`1[[System.Int32, System.Private.CoreLib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=7cec85d7bea7798e]][]</maml:name>
+          <maml:name>System.Nullable`1[[System.Int32, System.Private.CoreLib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=7cec85d7bea7798e]]</maml:name>
         </dev:type>
         <maml:description>
           <maml:para></maml:para>
@@ -10332,6 +10332,454 @@ M for Modify or V for View permissions.</maml:para>
       <maml:navigationLink>
         <maml:linkText>Online Version:</maml:linkText>
         <maml:uri>https://github.com/dnewsholme/PasswordState-Management/blob/master/docs/New-PasswordStatePasswordPermission.md</maml:uri>
+      </maml:navigationLink>
+    </command:relatedLinks>
+  </command:command>
+  <command:command xmlns:maml="http://schemas.microsoft.com/maml/2004/10" xmlns:command="http://schemas.microsoft.com/maml/dev/command/2004/10" xmlns:dev="http://schemas.microsoft.com/maml/dev/2004/10" xmlns:MSHelp="http://msdn.microsoft.com/mshelp">
+    <command:details>
+      <command:name>New-PasswordStateSelfDestructMessage</command:name>
+      <command:verb>New</command:verb>
+      <command:noun>PasswordStateSelfDestructMessage</command:noun>
+      <maml:description>
+        <maml:para>Sending Self Destruct Messages via the API.</maml:para>
+      </maml:description>
+    </command:details>
+    <maml:description>
+      <maml:para>Sending Self Destruct Messages via the API.</maml:para>
+      <maml:para>To send Self Destruct Messages, you must have access to the following features within PasswordState:</maml:para>
+      <maml:para>- When sending messages based on a Password record - your account must have access this Password record.</maml:para>
+      <maml:para>- When sending a message that is not related to a Password record i.e. free-form message body - you must have access to the '`Self Destruct Message`' menu in PasswordState.</maml:para>
+      <maml:para>With the email the recipient receives for the Self Destruct message, you can either use the supplied Email Template '`Self Destruct Message Email`' found on the screen `Administration -&gt; Email Templates`, or you can specify the entire body of the message yourself. Note 1 : Never send the passphrase + url in the same self destruct message!</maml:para>
+    </maml:description>
+    <command:syntax>
+      <command:syntaxItem>
+        <maml:name>New-PasswordStateSelfDestructMessage</maml:name>
+        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="0" aliases="none">
+          <maml:name>PasswordID</maml:name>
+          <maml:Description>
+            <maml:para>The PasswordID value of the password record you are sending a Self Destruct Message for.</maml:para>
+          </maml:Description>
+          <command:parameterValue required="true" variableLength="false">Int32</command:parameterValue>
+          <dev:type>
+            <maml:name>Int32</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="1" aliases="none">
+          <maml:name>Message</maml:name>
+          <maml:Description>
+            <maml:para>Use this field is you are wanting to specify the entire Self Destruct Message yourself, instead of it being based off of a password record - HTML tags can be used if required. Note 1: All diacritics, german umlauts and other invalid characters that the api does not understand will be converted from the given string.</maml:para>
+          </maml:Description>
+          <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+          <dev:type>
+            <maml:name>String</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="10" aliases="none">
+          <maml:name>Passphrase</maml:name>
+          <maml:Description>
+            <maml:para>If you would like to Passphrase protect the Self Destruct Message, you can use this field to do that - the recipient must know the Passphrase in order to read the message. Note 1 : Never send the passphrase + url in the same self destruct message!</maml:para>
+          </maml:Description>
+          <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+          <dev:type>
+            <maml:name>String</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="11" aliases="none">
+          <maml:name>Reason</maml:name>
+          <maml:Description>
+            <maml:para>You can specify a Reason for sending this Self Destruct Message, and it will be added to the appropriate auditing data.</maml:para>
+          </maml:Description>
+          <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+          <dev:type>
+            <maml:name>String</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="2" aliases="none">
+          <maml:name>PrefixMessageContent</maml:name>
+          <maml:Description>
+            <maml:para>If you are sending a message based off of a password record, you can prefix information before the password record details with content from this field - HTML tags can be used if required. Note 1: All diacritics, german umlauts and other invalid characters that the api does not understand will be converted from the given string.</maml:para>
+          </maml:Description>
+          <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+          <dev:type>
+            <maml:name>String</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="3" aliases="none">
+          <maml:name>AppendMessageContent</maml:name>
+          <maml:Description>
+            <maml:para>If you are sending a message based of a password record, you can append information after the password record details with content from this field - HTML tags can be used if required. Note 1: All diacritics, german umlauts and other invalid characters that the api does not understand will be converted from the given string.</maml:para>
+          </maml:Description>
+          <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+          <dev:type>
+            <maml:name>String</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="4" aliases="none">
+          <maml:name>ExpiresAt</maml:name>
+          <maml:Description>
+            <maml:para>This is the duration for how long the self destruct message exists before it is deleted due to not being viewed.
+You specify the duration and time period for this field, as per the following examples `30m (30 minutes), 3h (3 hours), or 2d (2 days)`.</maml:para>
+            <maml:para>Defaults to `1d`.</maml:para>
+          </maml:Description>
+          <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+          <dev:type>
+            <maml:name>String</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="5" aliases="none">
+          <maml:name>NoViews</maml:name>
+          <maml:Description>
+            <maml:para>How many times the Self Destruct Message can be viewed, before it is removed.</maml:para>
+            <maml:para>Defaults to `1`.</maml:para>
+          </maml:Description>
+          <command:parameterValue required="true" variableLength="false">Int32</command:parameterValue>
+          <dev:type>
+            <maml:name>Int32</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="true" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="6" aliases="none">
+          <maml:name>ToEmailAddress</maml:name>
+          <maml:Description>
+            <maml:para>The Email Address of the recipient who is to receive the Self Destruct Message.</maml:para>
+          </maml:Description>
+          <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+          <dev:type>
+            <maml:name>String</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="7" aliases="none">
+          <maml:name>ToFirstName</maml:name>
+          <maml:Description>
+            <maml:para>The First Name of the recipient who is to receive the Self Destruct Message - this is used in the email which is sent to the recipient}</maml:para>
+          </maml:Description>
+          <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+          <dev:type>
+            <maml:name>String</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="8" aliases="none">
+          <maml:name>EmailSubject</maml:name>
+          <maml:Description>
+            <maml:para>The Subject Line of the email sent to the recipient - if not specified, the Subject will be used from the Email Template '`Self Destruct Message Email`'</maml:para>
+          </maml:Description>
+          <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+          <dev:type>
+            <maml:name>String</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="9" aliases="none">
+          <maml:name>EmailBody</maml:name>
+          <maml:Description>
+            <maml:para>If left blank, the Email Template '`Self Destruct Message Email`' will be used, but you can use this field to specify the entire Email Body if you wish - HTML tags can be used if required.</maml:para>
+            <maml:para>There are also certain variables in the EmailBody that will be replaced as appropriate, when the email is sent - and they are:</maml:para>
+            <maml:para>- `[ToFirstName]`   - the First Name of the recipient who will receive the email   - You need to specify the `-ToFirstName` parameter - `[UserName]`   - this is the FirstName and Surname of the user sending the Self Destruct Message - `[ExpirePeriod]`   - How long the message will be alive until it is automatically deleted   - You need to specify the `-ExpiresAt` parameter - `[URL]`   - This is the URL for the recipient to click on to view the Self Destruct Message - `[Version]`   - The Version Number for your PasswordState instance - `[SiteURL]`   - The URL of your PasswordState instance Note 1: All diacritics, german umlauts and other invalid characters that the api does not understand will be converted from the given string.</maml:para>
+          </maml:Description>
+          <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+          <dev:type>
+            <maml:name>String</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="cf">
+          <maml:name>Confirm</maml:name>
+          <maml:Description>
+            <maml:para>Prompts you for confirmation before running the cmdlet.</maml:para>
+          </maml:Description>
+          <dev:type>
+            <maml:name>SwitchParameter</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>False</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="wi">
+          <maml:name>WhatIf</maml:name>
+          <maml:Description>
+            <maml:para>Shows what would happen if the cmdlet runs. The cmdlet is not run.</maml:para>
+          </maml:Description>
+          <dev:type>
+            <maml:name>SwitchParameter</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>False</dev:defaultValue>
+        </command:parameter>
+      </command:syntaxItem>
+    </command:syntax>
+    <command:parameters>
+      <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="3" aliases="none">
+        <maml:name>AppendMessageContent</maml:name>
+        <maml:Description>
+          <maml:para>If you are sending a message based of a password record, you can append information after the password record details with content from this field - HTML tags can be used if required. Note 1: All diacritics, german umlauts and other invalid characters that the api does not understand will be converted from the given string.</maml:para>
+        </maml:Description>
+        <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+        <dev:type>
+          <maml:name>String</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="9" aliases="none">
+        <maml:name>EmailBody</maml:name>
+        <maml:Description>
+          <maml:para>If left blank, the Email Template '`Self Destruct Message Email`' will be used, but you can use this field to specify the entire Email Body if you wish - HTML tags can be used if required.</maml:para>
+          <maml:para>There are also certain variables in the EmailBody that will be replaced as appropriate, when the email is sent - and they are:</maml:para>
+          <maml:para>- `[ToFirstName]`   - the First Name of the recipient who will receive the email   - You need to specify the `-ToFirstName` parameter - `[UserName]`   - this is the FirstName and Surname of the user sending the Self Destruct Message - `[ExpirePeriod]`   - How long the message will be alive until it is automatically deleted   - You need to specify the `-ExpiresAt` parameter - `[URL]`   - This is the URL for the recipient to click on to view the Self Destruct Message - `[Version]`   - The Version Number for your PasswordState instance - `[SiteURL]`   - The URL of your PasswordState instance Note 1: All diacritics, german umlauts and other invalid characters that the api does not understand will be converted from the given string.</maml:para>
+        </maml:Description>
+        <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+        <dev:type>
+          <maml:name>String</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="8" aliases="none">
+        <maml:name>EmailSubject</maml:name>
+        <maml:Description>
+          <maml:para>The Subject Line of the email sent to the recipient - if not specified, the Subject will be used from the Email Template '`Self Destruct Message Email`'</maml:para>
+        </maml:Description>
+        <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+        <dev:type>
+          <maml:name>String</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="4" aliases="none">
+        <maml:name>ExpiresAt</maml:name>
+        <maml:Description>
+          <maml:para>This is the duration for how long the self destruct message exists before it is deleted due to not being viewed.
+You specify the duration and time period for this field, as per the following examples `30m (30 minutes), 3h (3 hours), or 2d (2 days)`.</maml:para>
+          <maml:para>Defaults to `1d`.</maml:para>
+        </maml:Description>
+        <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+        <dev:type>
+          <maml:name>String</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="1" aliases="none">
+        <maml:name>Message</maml:name>
+        <maml:Description>
+          <maml:para>Use this field is you are wanting to specify the entire Self Destruct Message yourself, instead of it being based off of a password record - HTML tags can be used if required. Note 1: All diacritics, german umlauts and other invalid characters that the api does not understand will be converted from the given string.</maml:para>
+        </maml:Description>
+        <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+        <dev:type>
+          <maml:name>String</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="5" aliases="none">
+        <maml:name>NoViews</maml:name>
+        <maml:Description>
+          <maml:para>How many times the Self Destruct Message can be viewed, before it is removed.</maml:para>
+          <maml:para>Defaults to `1`.</maml:para>
+        </maml:Description>
+        <command:parameterValue required="true" variableLength="false">Int32</command:parameterValue>
+        <dev:type>
+          <maml:name>Int32</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="10" aliases="none">
+        <maml:name>Passphrase</maml:name>
+        <maml:Description>
+          <maml:para>If you would like to Passphrase protect the Self Destruct Message, you can use this field to do that - the recipient must know the Passphrase in order to read the message. Note 1 : Never send the passphrase + url in the same self destruct message!</maml:para>
+        </maml:Description>
+        <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+        <dev:type>
+          <maml:name>String</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="0" aliases="none">
+        <maml:name>PasswordID</maml:name>
+        <maml:Description>
+          <maml:para>The PasswordID value of the password record you are sending a Self Destruct Message for.</maml:para>
+        </maml:Description>
+        <command:parameterValue required="true" variableLength="false">Int32</command:parameterValue>
+        <dev:type>
+          <maml:name>Int32</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="2" aliases="none">
+        <maml:name>PrefixMessageContent</maml:name>
+        <maml:Description>
+          <maml:para>If you are sending a message based off of a password record, you can prefix information before the password record details with content from this field - HTML tags can be used if required. Note 1: All diacritics, german umlauts and other invalid characters that the api does not understand will be converted from the given string.</maml:para>
+        </maml:Description>
+        <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+        <dev:type>
+          <maml:name>String</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="11" aliases="none">
+        <maml:name>Reason</maml:name>
+        <maml:Description>
+          <maml:para>You can specify a Reason for sending this Self Destruct Message, and it will be added to the appropriate auditing data.</maml:para>
+        </maml:Description>
+        <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+        <dev:type>
+          <maml:name>String</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="true" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="6" aliases="none">
+        <maml:name>ToEmailAddress</maml:name>
+        <maml:Description>
+          <maml:para>The Email Address of the recipient who is to receive the Self Destruct Message.</maml:para>
+        </maml:Description>
+        <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+        <dev:type>
+          <maml:name>String</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="7" aliases="none">
+        <maml:name>ToFirstName</maml:name>
+        <maml:Description>
+          <maml:para>The First Name of the recipient who is to receive the Self Destruct Message - this is used in the email which is sent to the recipient}</maml:para>
+        </maml:Description>
+        <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+        <dev:type>
+          <maml:name>String</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="cf">
+        <maml:name>Confirm</maml:name>
+        <maml:Description>
+          <maml:para>Prompts you for confirmation before running the cmdlet.</maml:para>
+        </maml:Description>
+        <command:parameterValue required="false" variableLength="false">SwitchParameter</command:parameterValue>
+        <dev:type>
+          <maml:name>SwitchParameter</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>False</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="wi">
+        <maml:name>WhatIf</maml:name>
+        <maml:Description>
+          <maml:para>Shows what would happen if the cmdlet runs. The cmdlet is not run.</maml:para>
+        </maml:Description>
+        <command:parameterValue required="false" variableLength="false">SwitchParameter</command:parameterValue>
+        <dev:type>
+          <maml:name>SwitchParameter</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>False</dev:defaultValue>
+      </command:parameter>
+    </command:parameters>
+    <command:inputTypes>
+      <command:inputType>
+        <dev:type>
+          <maml:name>System.Nullable`1[[System.Int32, System.Private.CoreLib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=7cec85d7bea7798e]]</maml:name>
+        </dev:type>
+        <maml:description>
+          <maml:para></maml:para>
+        </maml:description>
+      </command:inputType>
+      <command:inputType>
+        <dev:type>
+          <maml:name>System.String</maml:name>
+        </dev:type>
+        <maml:description>
+          <maml:para></maml:para>
+        </maml:description>
+      </command:inputType>
+      <command:inputType>
+        <dev:type>
+          <maml:name>System.Int32</maml:name>
+        </dev:type>
+        <maml:description>
+          <maml:para></maml:para>
+        </maml:description>
+      </command:inputType>
+    </command:inputTypes>
+    <command:returnValues>
+      <command:returnValue>
+        <dev:type>
+          <maml:name>System.Object</maml:name>
+        </dev:type>
+        <maml:description>
+          <maml:para></maml:para>
+        </maml:description>
+      </command:returnValue>
+    </command:returnValues>
+    <maml:alertSet>
+      <maml:alert>
+        <maml:para></maml:para>
+      </maml:alert>
+    </maml:alertSet>
+    <command:examples>
+      <command:example>
+        <maml:title>-------------------------- Example 1 --------------------------</maml:title>
+        <dev:code>PS C:\&gt; New-PasswordStateSelfDestructMessage -ToEmailAddress "surname.lastname@example.com" -PasswordID 114</dev:code>
+        <dev:remarks>
+          <maml:para>Sending a self destruct message for PasswordID 114 to the desired recipient. The url is not restricted and can be accessed by anyone that has the url/email. The default values for `ExpiresAt` and `NoViews` will be used.</maml:para>
+        </dev:remarks>
+      </command:example>
+      <command:example>
+        <maml:title>-------------------------- Example 2 --------------------------</maml:title>
+        <dev:code>PS C:\&gt; New-PasswordStateSelfDestructMessage -ToEmailAddress "surname.lastname@example.com" -PasswordID 114 -Passphrase "API=Cool" -Reason "This is a cool reason" -EmailSubject "Highly Secure" -PrefixMessageContent "&lt;br&gt;Only for your eyes&lt;/br&gt;"</dev:code>
+        <dev:remarks>
+          <maml:para>Sending a self destruct message for PasswordID 114 to the desired recipient. The url is restricted and can be accessed with the defined Passphrase. A audit log entry with the Reason will be created. The Email will be send with the given Subject and the default Self Destruct Email Template will be used. The default values for `ExpiresAt` and `NoViews` will be used.
+After opening the url, a PrefixMessage will be displayed above the Password Details.</maml:para>
+        </dev:remarks>
+      </command:example>
+      <command:example>
+        <maml:title>-------------------------- Example 3 --------------------------</maml:title>
+        <dev:code>PS C:\&gt; New-PasswordStateSelfDestructMessage -ToEmailAddress "surname.lastname@example.com" -PasswordID 114 -Passphrase "API=Cool" -Reason "This is a cool reason" -EmailSubject "Highly Secure" -ToFirstName "surname.lastname" -PrefixMessageContent "&lt;br&gt;Only for your eyes&lt;/br&gt;" -EmailBody "Hello [ToFirstName],
+         &lt;p&gt; A secure message was sent to you from &lt;a href=""https://passwordstate.local/""&gt;PasswordState Passwordmanager&lt;/a&gt;&lt;br&gt;
+         &lt;p&gt; These message was triggered by [UserName]. &lt;br&gt; Please check the following link: [URL].&lt;br&gt;
+         &lt;p&gt; You have [ExpirePeriod] until the message will be expire.&lt;br&gt;
+         &lt;p&gt; Please enter the Passphrase you got from [UserName] after opening the website.&lt;br&gt;
+         &lt;br&gt;
+         &lt;/p&gt;"</dev:code>
+        <dev:remarks>
+          <maml:para>Sending a self destruct message for PasswordID 114 to the desired recipient. The url is restricted and can be accessed with the defined Passphrase. A audit log entry with the Reason will be created.
+The Email will be send with the given Subject and the HTML email body specified will be used as email text. ToFirstName is needed for the email body variable `[ToFirstName]`.
+After opening the url, a PrefixMessage will be displayed above the Password Details.
+The default values for `ExpiresAt` and `NoViews` will be used.</maml:para>
+        </dev:remarks>
+      </command:example>
+    </command:examples>
+    <command:relatedLinks>
+      <maml:navigationLink>
+        <maml:linkText>Online Version:</maml:linkText>
+        <maml:uri>https://github.com/dnewsholme/PasswordState-Management/blob/master/docs/New-PasswordStateSelfDestructMessage.md</maml:uri>
       </maml:navigationLink>
     </command:relatedLinks>
   </command:command>
@@ -11286,9 +11734,9 @@ A for Administrator, M for Modify or V for View permissions. Note : This is opti
             <maml:para>The SecurityGroupID you wish to remove permissions for.
 You can only specify SecurityGroupID or SecurityGroupName, not both in the same call.</maml:para>
           </maml:Description>
-          <command:parameterValue required="true" variableLength="false">Nullable`1[]</command:parameterValue>
+          <command:parameterValue required="true" variableLength="false">Int32</command:parameterValue>
           <dev:type>
-            <maml:name>Nullable`1[]</maml:name>
+            <maml:name>Int32</maml:name>
             <maml:uri />
           </dev:type>
           <dev:defaultValue>None</dev:defaultValue>
@@ -11404,9 +11852,9 @@ You can only specify SecurityGroupID or SecurityGroupName, not both in the same 
           <maml:para>The SecurityGroupID you wish to remove permissions for.
 You can only specify SecurityGroupID or SecurityGroupName, not both in the same call.</maml:para>
         </maml:Description>
-        <command:parameterValue required="true" variableLength="false">Nullable`1[]</command:parameterValue>
+        <command:parameterValue required="true" variableLength="false">Int32</command:parameterValue>
         <dev:type>
-          <maml:name>Nullable`1[]</maml:name>
+          <maml:name>Int32</maml:name>
           <maml:uri />
         </dev:type>
         <dev:defaultValue>None</dev:defaultValue>
@@ -11505,7 +11953,7 @@ A for Administrator, M for Modify or V for View permissions. Note : This is opti
       </command:inputType>
       <command:inputType>
         <dev:type>
-          <maml:name>System.Nullable`1[[System.Int32, System.Private.CoreLib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=7cec85d7bea7798e]][]</maml:name>
+          <maml:name>System.Nullable`1[[System.Int32, System.Private.CoreLib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=7cec85d7bea7798e]]</maml:name>
         </dev:type>
         <maml:description>
           <maml:para></maml:para>
@@ -11835,9 +12283,9 @@ M for Modify or V for View permissions. Note : This is optional. If omitted, all
             <maml:para>The SecurityGroupID you wish to remove permissions for.
 You can only specify SecurityGroupID or SecurityGroupName, not both in the same call.</maml:para>
           </maml:Description>
-          <command:parameterValue required="true" variableLength="false">Nullable`1[]</command:parameterValue>
+          <command:parameterValue required="true" variableLength="false">Int32</command:parameterValue>
           <dev:type>
-            <maml:name>Nullable`1[]</maml:name>
+            <maml:name>Int32</maml:name>
             <maml:uri />
           </dev:type>
           <dev:defaultValue>None</dev:defaultValue>
@@ -11952,9 +12400,9 @@ You can only specify SecurityGroupID or SecurityGroupName, not both in the same 
           <maml:para>The SecurityGroupID you wish to remove permissions for.
 You can only specify SecurityGroupID or SecurityGroupName, not both in the same call.</maml:para>
         </maml:Description>
-        <command:parameterValue required="true" variableLength="false">Nullable`1[]</command:parameterValue>
+        <command:parameterValue required="true" variableLength="false">Int32</command:parameterValue>
         <dev:type>
-          <maml:name>Nullable`1[]</maml:name>
+          <maml:name>Int32</maml:name>
           <maml:uri />
         </dev:type>
         <dev:defaultValue>None</dev:defaultValue>
@@ -12053,7 +12501,7 @@ M for Modify or V for View permissions. Note : This is optional. If omitted, all
       </command:inputType>
       <command:inputType>
         <dev:type>
-          <maml:name>System.Nullable`1[[System.Int32, System.Private.CoreLib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=7cec85d7bea7798e]][]</maml:name>
+          <maml:name>System.Nullable`1[[System.Int32, System.Private.CoreLib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=7cec85d7bea7798e]]</maml:name>
         </dev:type>
         <maml:description>
           <maml:para></maml:para>
@@ -13058,9 +13506,9 @@ A for Administrator, M for Modify or V for View permissions.</maml:para>
             <maml:para>The SecurityGroupID you wish to apply permissions for.
 You can only specify SecurityGroupID or SecurityGroupName, not both in the same call.</maml:para>
           </maml:Description>
-          <command:parameterValue required="true" variableLength="false">Nullable`1[]</command:parameterValue>
+          <command:parameterValue required="true" variableLength="false">Int32</command:parameterValue>
           <dev:type>
-            <maml:name>Nullable`1[]</maml:name>
+            <maml:name>Int32</maml:name>
             <maml:uri />
           </dev:type>
           <dev:defaultValue>None</dev:defaultValue>
@@ -13176,9 +13624,9 @@ You can only specify SecurityGroupID or SecurityGroupName, not both in the same 
           <maml:para>The SecurityGroupID you wish to apply permissions for.
 You can only specify SecurityGroupID or SecurityGroupName, not both in the same call.</maml:para>
         </maml:Description>
-        <command:parameterValue required="true" variableLength="false">Nullable`1[]</command:parameterValue>
+        <command:parameterValue required="true" variableLength="false">Int32</command:parameterValue>
         <dev:type>
-          <maml:name>Nullable`1[]</maml:name>
+          <maml:name>Int32</maml:name>
           <maml:uri />
         </dev:type>
         <dev:defaultValue>None</dev:defaultValue>
@@ -13277,7 +13725,7 @@ A for Administrator, M for Modify or V for View permissions.</maml:para>
       </command:inputType>
       <command:inputType>
         <dev:type>
-          <maml:name>System.Nullable`1[[System.Int32, System.Private.CoreLib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=7cec85d7bea7798e]][]</maml:name>
+          <maml:name>System.Nullable`1[[System.Int32, System.Private.CoreLib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=7cec85d7bea7798e]]</maml:name>
         </dev:type>
         <maml:description>
           <maml:para></maml:para>
@@ -13343,9 +13791,9 @@ If the password record being updated is 'Managed', in that it is enabled to perf
           <maml:Description>
             <maml:para>The ID of the password to be updated.</maml:para>
           </maml:Description>
-          <command:parameterValue required="true" variableLength="false">Nullable`1[]</command:parameterValue>
+          <command:parameterValue required="true" variableLength="false">Int32</command:parameterValue>
           <dev:type>
-            <maml:name>Nullable`1[]</maml:name>
+            <maml:name>Int32</maml:name>
             <maml:uri />
           </dev:type>
           <dev:defaultValue>0</dev:defaultValue>
@@ -13534,9 +13982,9 @@ Some systems require a username and password to authenticate. This field represe
           <maml:Description>
             <maml:para>Once the password has been changed due to a scheduled reset, you can add an additional (x) number of days to the ExpiryDate field so another reset will occur again in 30, 60, 90 days, etc. This is the option on the Reset Options tab for the record.</maml:para>
           </maml:Description>
-          <command:parameterValue required="true" variableLength="false">Nullable`1[]</command:parameterValue>
+          <command:parameterValue required="true" variableLength="false">Int32</command:parameterValue>
           <dev:type>
-            <maml:name>Nullable`1[]</maml:name>
+            <maml:name>Int32</maml:name>
             <maml:uri />
           </dev:type>
           <dev:defaultValue>None</dev:defaultValue>
@@ -13546,9 +13994,9 @@ Some systems require a username and password to authenticate. This field represe
           <maml:Description>
             <maml:para>Most accounts require a Password Reset Script to be assigned to them, with the only exception being Active Directory Accounts - not to specify this field for AD Accounts. To look up the values of the ScriptID's, this can be done by using the ' Toggle ID Column Visibility ' button on the Password Reset Scripts screens in PasswordState.</maml:para>
           </maml:Description>
-          <command:parameterValue required="true" variableLength="false">Nullable`1[]</command:parameterValue>
+          <command:parameterValue required="true" variableLength="false">Int32</command:parameterValue>
           <dev:type>
-            <maml:name>Nullable`1[]</maml:name>
+            <maml:name>Int32</maml:name>
             <maml:uri />
           </dev:type>
           <dev:defaultValue>None</dev:defaultValue>
@@ -13558,9 +14006,9 @@ Some systems require a username and password to authenticate. This field represe
           <maml:Description>
             <maml:para>Some Password Reset Scripts also require a `Privileged Account Credential` to be associated with the Password record, to initiate connection and perform the reset. Requirements for Privileged Accounts are documented in the User Manual, under the KB Article section. To look up the value of PrivilegedAccountID's, this can be done on the screen `Administration -&gt; PasswordState Administration -&gt; Privileged Account Credentials`.</maml:para>
           </maml:Description>
-          <command:parameterValue required="true" variableLength="false">Nullable`1[]</command:parameterValue>
+          <command:parameterValue required="true" variableLength="false">Int32</command:parameterValue>
           <dev:type>
-            <maml:name>Nullable`1[]</maml:name>
+            <maml:name>Int32</maml:name>
             <maml:uri />
           </dev:type>
           <dev:defaultValue>None</dev:defaultValue>
@@ -13690,9 +14138,9 @@ Can be used as a longer verbose description of the nature of the Password object
           <maml:Description>
             <maml:para>When enabling Account Heartbeat, you must associate the correct Password Validation Script to the record (all account types require a Validation Script to be selected). To look up the values of the ValidationScriptID's, this can be done by using the ' Toggle ID Column Visibility ' button on the Password Validation Scripts screens in PasswordState.</maml:para>
           </maml:Description>
-          <command:parameterValue required="true" variableLength="false">Nullable`1[]</command:parameterValue>
+          <command:parameterValue required="true" variableLength="false">Int32</command:parameterValue>
           <dev:type>
-            <maml:name>Nullable`1[]</maml:name>
+            <maml:name>Int32</maml:name>
             <maml:uri />
           </dev:type>
           <dev:defaultValue>None</dev:defaultValue>
@@ -13752,9 +14200,9 @@ You can either specify the AccountType or AccountTypeID if needed when changing 
             <maml:para>The ID value representing the Account Type image (derived from the AccountTypes table). An AccountTypeID of 0 (zero) means there is no associated Account Type image for this Password.
 You can either specify the AccountType or AccountTypeID if needed when changing password records. Account Types and their ID values can be seen on the screen `Administration -&gt; Passwordstate Administration -&gt; Images and Account Types`, and click on the ' Toggle ID Column Visibility ' button to determine the appropriate value.</maml:para>
           </maml:Description>
-          <command:parameterValue required="true" variableLength="false">Nullable`1[]</command:parameterValue>
+          <command:parameterValue required="true" variableLength="false">Int32</command:parameterValue>
           <dev:type>
-            <maml:name>Nullable`1[]</maml:name>
+            <maml:name>Int32</maml:name>
             <maml:uri />
           </dev:type>
           <dev:defaultValue>None</dev:defaultValue>
@@ -13801,9 +14249,9 @@ You can either specify the AccountType or AccountTypeID if needed when changing 
           <maml:Description>
             <maml:para>The ID of the password to be updated.</maml:para>
           </maml:Description>
-          <command:parameterValue required="true" variableLength="false">Nullable`1[]</command:parameterValue>
+          <command:parameterValue required="true" variableLength="false">Int32</command:parameterValue>
           <dev:type>
-            <maml:name>Nullable`1[]</maml:name>
+            <maml:name>Int32</maml:name>
             <maml:uri />
           </dev:type>
           <dev:defaultValue>0</dev:defaultValue>
@@ -14026,9 +14474,9 @@ Some systems require a username and password to authenticate. This field represe
           <maml:Description>
             <maml:para>Once the password has been changed due to a scheduled reset, you can add an additional (x) number of days to the ExpiryDate field so another reset will occur again in 30, 60, 90 days, etc. This is the option on the Reset Options tab for the record.</maml:para>
           </maml:Description>
-          <command:parameterValue required="true" variableLength="false">Nullable`1[]</command:parameterValue>
+          <command:parameterValue required="true" variableLength="false">Int32</command:parameterValue>
           <dev:type>
-            <maml:name>Nullable`1[]</maml:name>
+            <maml:name>Int32</maml:name>
             <maml:uri />
           </dev:type>
           <dev:defaultValue>None</dev:defaultValue>
@@ -14038,9 +14486,9 @@ Some systems require a username and password to authenticate. This field represe
           <maml:Description>
             <maml:para>Most accounts require a Password Reset Script to be assigned to them, with the only exception being Active Directory Accounts - not to specify this field for AD Accounts. To look up the values of the ScriptID's, this can be done by using the ' Toggle ID Column Visibility ' button on the Password Reset Scripts screens in PasswordState.</maml:para>
           </maml:Description>
-          <command:parameterValue required="true" variableLength="false">Nullable`1[]</command:parameterValue>
+          <command:parameterValue required="true" variableLength="false">Int32</command:parameterValue>
           <dev:type>
-            <maml:name>Nullable`1[]</maml:name>
+            <maml:name>Int32</maml:name>
             <maml:uri />
           </dev:type>
           <dev:defaultValue>None</dev:defaultValue>
@@ -14050,9 +14498,9 @@ Some systems require a username and password to authenticate. This field represe
           <maml:Description>
             <maml:para>Some Password Reset Scripts also require a `Privileged Account Credential` to be associated with the Password record, to initiate connection and perform the reset. Requirements for Privileged Accounts are documented in the User Manual, under the KB Article section. To look up the value of PrivilegedAccountID's, this can be done on the screen `Administration -&gt; PasswordState Administration -&gt; Privileged Account Credentials`.</maml:para>
           </maml:Description>
-          <command:parameterValue required="true" variableLength="false">Nullable`1[]</command:parameterValue>
+          <command:parameterValue required="true" variableLength="false">Int32</command:parameterValue>
           <dev:type>
-            <maml:name>Nullable`1[]</maml:name>
+            <maml:name>Int32</maml:name>
             <maml:uri />
           </dev:type>
           <dev:defaultValue>None</dev:defaultValue>
@@ -14182,9 +14630,9 @@ Can be used as a longer verbose description of the nature of the Password object
           <maml:Description>
             <maml:para>When enabling Account Heartbeat, you must associate the correct Password Validation Script to the record (all account types require a Validation Script to be selected). To look up the values of the ValidationScriptID's, this can be done by using the ' Toggle ID Column Visibility ' button on the Password Validation Scripts screens in PasswordState.</maml:para>
           </maml:Description>
-          <command:parameterValue required="true" variableLength="false">Nullable`1[]</command:parameterValue>
+          <command:parameterValue required="true" variableLength="false">Int32</command:parameterValue>
           <dev:type>
-            <maml:name>Nullable`1[]</maml:name>
+            <maml:name>Int32</maml:name>
             <maml:uri />
           </dev:type>
           <dev:defaultValue>None</dev:defaultValue>
@@ -14244,9 +14692,9 @@ You can either specify the AccountType or AccountTypeID if needed when changing 
             <maml:para>The ID value representing the Account Type image (derived from the AccountTypes table). An AccountTypeID of 0 (zero) means there is no associated Account Type image for this Password.
 You can either specify the AccountType or AccountTypeID if needed when changing password records. Account Types and their ID values can be seen on the screen `Administration -&gt; Passwordstate Administration -&gt; Images and Account Types`, and click on the ' Toggle ID Column Visibility ' button to determine the appropriate value.</maml:para>
           </maml:Description>
-          <command:parameterValue required="true" variableLength="false">Nullable`1[]</command:parameterValue>
+          <command:parameterValue required="true" variableLength="false">Int32</command:parameterValue>
           <dev:type>
-            <maml:name>Nullable`1[]</maml:name>
+            <maml:name>Int32</maml:name>
             <maml:uri />
           </dev:type>
           <dev:defaultValue>None</dev:defaultValue>
@@ -14293,9 +14741,9 @@ You can either specify the AccountType or AccountTypeID if needed when changing 
           <maml:Description>
             <maml:para>The ID of the password to be updated.</maml:para>
           </maml:Description>
-          <command:parameterValue required="true" variableLength="false">Nullable`1[]</command:parameterValue>
+          <command:parameterValue required="true" variableLength="false">Int32</command:parameterValue>
           <dev:type>
-            <maml:name>Nullable`1[]</maml:name>
+            <maml:name>Int32</maml:name>
             <maml:uri />
           </dev:type>
           <dev:defaultValue>0</dev:defaultValue>
@@ -14507,9 +14955,9 @@ Some systems require a username and password to authenticate. This field represe
           <maml:Description>
             <maml:para>Once the password has been changed due to a scheduled reset, you can add an additional (x) number of days to the ExpiryDate field so another reset will occur again in 30, 60, 90 days, etc. This is the option on the Reset Options tab for the record.</maml:para>
           </maml:Description>
-          <command:parameterValue required="true" variableLength="false">Nullable`1[]</command:parameterValue>
+          <command:parameterValue required="true" variableLength="false">Int32</command:parameterValue>
           <dev:type>
-            <maml:name>Nullable`1[]</maml:name>
+            <maml:name>Int32</maml:name>
             <maml:uri />
           </dev:type>
           <dev:defaultValue>None</dev:defaultValue>
@@ -14519,9 +14967,9 @@ Some systems require a username and password to authenticate. This field represe
           <maml:Description>
             <maml:para>Most accounts require a Password Reset Script to be assigned to them, with the only exception being Active Directory Accounts - not to specify this field for AD Accounts. To look up the values of the ScriptID's, this can be done by using the ' Toggle ID Column Visibility ' button on the Password Reset Scripts screens in PasswordState.</maml:para>
           </maml:Description>
-          <command:parameterValue required="true" variableLength="false">Nullable`1[]</command:parameterValue>
+          <command:parameterValue required="true" variableLength="false">Int32</command:parameterValue>
           <dev:type>
-            <maml:name>Nullable`1[]</maml:name>
+            <maml:name>Int32</maml:name>
             <maml:uri />
           </dev:type>
           <dev:defaultValue>None</dev:defaultValue>
@@ -14531,9 +14979,9 @@ Some systems require a username and password to authenticate. This field represe
           <maml:Description>
             <maml:para>Some Password Reset Scripts also require a `Privileged Account Credential` to be associated with the Password record, to initiate connection and perform the reset. Requirements for Privileged Accounts are documented in the User Manual, under the KB Article section. To look up the value of PrivilegedAccountID's, this can be done on the screen `Administration -&gt; PasswordState Administration -&gt; Privileged Account Credentials`.</maml:para>
           </maml:Description>
-          <command:parameterValue required="true" variableLength="false">Nullable`1[]</command:parameterValue>
+          <command:parameterValue required="true" variableLength="false">Int32</command:parameterValue>
           <dev:type>
-            <maml:name>Nullable`1[]</maml:name>
+            <maml:name>Int32</maml:name>
             <maml:uri />
           </dev:type>
           <dev:defaultValue>None</dev:defaultValue>
@@ -14663,9 +15111,9 @@ Can be used as a longer verbose description of the nature of the Password object
           <maml:Description>
             <maml:para>When enabling Account Heartbeat, you must associate the correct Password Validation Script to the record (all account types require a Validation Script to be selected). To look up the values of the ValidationScriptID's, this can be done by using the ' Toggle ID Column Visibility ' button on the Password Validation Scripts screens in PasswordState.</maml:para>
           </maml:Description>
-          <command:parameterValue required="true" variableLength="false">Nullable`1[]</command:parameterValue>
+          <command:parameterValue required="true" variableLength="false">Int32</command:parameterValue>
           <dev:type>
-            <maml:name>Nullable`1[]</maml:name>
+            <maml:name>Int32</maml:name>
             <maml:uri />
           </dev:type>
           <dev:defaultValue>None</dev:defaultValue>
@@ -14725,9 +15173,9 @@ You can either specify the AccountType or AccountTypeID if needed when changing 
             <maml:para>The ID value representing the Account Type image (derived from the AccountTypes table). An AccountTypeID of 0 (zero) means there is no associated Account Type image for this Password.
 You can either specify the AccountType or AccountTypeID if needed when changing password records. Account Types and their ID values can be seen on the screen `Administration -&gt; Passwordstate Administration -&gt; Images and Account Types`, and click on the ' Toggle ID Column Visibility ' button to determine the appropriate value.</maml:para>
           </maml:Description>
-          <command:parameterValue required="true" variableLength="false">Nullable`1[]</command:parameterValue>
+          <command:parameterValue required="true" variableLength="false">Int32</command:parameterValue>
           <dev:type>
-            <maml:name>Nullable`1[]</maml:name>
+            <maml:name>Int32</maml:name>
             <maml:uri />
           </dev:type>
           <dev:defaultValue>None</dev:defaultValue>
@@ -14774,9 +15222,9 @@ You can either specify the AccountType or AccountTypeID if needed when changing 
           <maml:Description>
             <maml:para>The ID of the password to be updated.</maml:para>
           </maml:Description>
-          <command:parameterValue required="true" variableLength="false">Nullable`1[]</command:parameterValue>
+          <command:parameterValue required="true" variableLength="false">Int32</command:parameterValue>
           <dev:type>
-            <maml:name>Nullable`1[]</maml:name>
+            <maml:name>Int32</maml:name>
             <maml:uri />
           </dev:type>
           <dev:defaultValue>0</dev:defaultValue>
@@ -14965,9 +15413,9 @@ Some systems require a username and password to authenticate. This field represe
           <maml:Description>
             <maml:para>Once the password has been changed due to a scheduled reset, you can add an additional (x) number of days to the ExpiryDate field so another reset will occur again in 30, 60, 90 days, etc. This is the option on the Reset Options tab for the record.</maml:para>
           </maml:Description>
-          <command:parameterValue required="true" variableLength="false">Nullable`1[]</command:parameterValue>
+          <command:parameterValue required="true" variableLength="false">Int32</command:parameterValue>
           <dev:type>
-            <maml:name>Nullable`1[]</maml:name>
+            <maml:name>Int32</maml:name>
             <maml:uri />
           </dev:type>
           <dev:defaultValue>None</dev:defaultValue>
@@ -14977,9 +15425,9 @@ Some systems require a username and password to authenticate. This field represe
           <maml:Description>
             <maml:para>Most accounts require a Password Reset Script to be assigned to them, with the only exception being Active Directory Accounts - not to specify this field for AD Accounts. To look up the values of the ScriptID's, this can be done by using the ' Toggle ID Column Visibility ' button on the Password Reset Scripts screens in PasswordState.</maml:para>
           </maml:Description>
-          <command:parameterValue required="true" variableLength="false">Nullable`1[]</command:parameterValue>
+          <command:parameterValue required="true" variableLength="false">Int32</command:parameterValue>
           <dev:type>
-            <maml:name>Nullable`1[]</maml:name>
+            <maml:name>Int32</maml:name>
             <maml:uri />
           </dev:type>
           <dev:defaultValue>None</dev:defaultValue>
@@ -14989,9 +15437,9 @@ Some systems require a username and password to authenticate. This field represe
           <maml:Description>
             <maml:para>Some Password Reset Scripts also require a `Privileged Account Credential` to be associated with the Password record, to initiate connection and perform the reset. Requirements for Privileged Accounts are documented in the User Manual, under the KB Article section. To look up the value of PrivilegedAccountID's, this can be done on the screen `Administration -&gt; PasswordState Administration -&gt; Privileged Account Credentials`.</maml:para>
           </maml:Description>
-          <command:parameterValue required="true" variableLength="false">Nullable`1[]</command:parameterValue>
+          <command:parameterValue required="true" variableLength="false">Int32</command:parameterValue>
           <dev:type>
-            <maml:name>Nullable`1[]</maml:name>
+            <maml:name>Int32</maml:name>
             <maml:uri />
           </dev:type>
           <dev:defaultValue>None</dev:defaultValue>
@@ -15125,9 +15573,9 @@ You can either specify the AccountType or AccountTypeID if needed when changing 
             <maml:para>The ID value representing the Account Type image (derived from the AccountTypes table). An AccountTypeID of 0 (zero) means there is no associated Account Type image for this Password.
 You can either specify the AccountType or AccountTypeID if needed when changing password records. Account Types and their ID values can be seen on the screen `Administration -&gt; Passwordstate Administration -&gt; Images and Account Types`, and click on the ' Toggle ID Column Visibility ' button to determine the appropriate value.</maml:para>
           </maml:Description>
-          <command:parameterValue required="true" variableLength="false">Nullable`1[]</command:parameterValue>
+          <command:parameterValue required="true" variableLength="false">Int32</command:parameterValue>
           <dev:type>
-            <maml:name>Nullable`1[]</maml:name>
+            <maml:name>Int32</maml:name>
             <maml:uri />
           </dev:type>
           <dev:defaultValue>None</dev:defaultValue>
@@ -15174,9 +15622,9 @@ You can either specify the AccountType or AccountTypeID if needed when changing 
           <maml:Description>
             <maml:para>The ID of the password to be updated.</maml:para>
           </maml:Description>
-          <command:parameterValue required="true" variableLength="false">Nullable`1[]</command:parameterValue>
+          <command:parameterValue required="true" variableLength="false">Int32</command:parameterValue>
           <dev:type>
-            <maml:name>Nullable`1[]</maml:name>
+            <maml:name>Int32</maml:name>
             <maml:uri />
           </dev:type>
           <dev:defaultValue>0</dev:defaultValue>
@@ -15365,9 +15813,9 @@ Some systems require a username and password to authenticate. This field represe
           <maml:Description>
             <maml:para>Once the password has been changed due to a scheduled reset, you can add an additional (x) number of days to the ExpiryDate field so another reset will occur again in 30, 60, 90 days, etc. This is the option on the Reset Options tab for the record.</maml:para>
           </maml:Description>
-          <command:parameterValue required="true" variableLength="false">Nullable`1[]</command:parameterValue>
+          <command:parameterValue required="true" variableLength="false">Int32</command:parameterValue>
           <dev:type>
-            <maml:name>Nullable`1[]</maml:name>
+            <maml:name>Int32</maml:name>
             <maml:uri />
           </dev:type>
           <dev:defaultValue>None</dev:defaultValue>
@@ -15377,9 +15825,9 @@ Some systems require a username and password to authenticate. This field represe
           <maml:Description>
             <maml:para>Most accounts require a Password Reset Script to be assigned to them, with the only exception being Active Directory Accounts - not to specify this field for AD Accounts. To look up the values of the ScriptID's, this can be done by using the ' Toggle ID Column Visibility ' button on the Password Reset Scripts screens in PasswordState.</maml:para>
           </maml:Description>
-          <command:parameterValue required="true" variableLength="false">Nullable`1[]</command:parameterValue>
+          <command:parameterValue required="true" variableLength="false">Int32</command:parameterValue>
           <dev:type>
-            <maml:name>Nullable`1[]</maml:name>
+            <maml:name>Int32</maml:name>
             <maml:uri />
           </dev:type>
           <dev:defaultValue>None</dev:defaultValue>
@@ -15389,9 +15837,9 @@ Some systems require a username and password to authenticate. This field represe
           <maml:Description>
             <maml:para>Some Password Reset Scripts also require a `Privileged Account Credential` to be associated with the Password record, to initiate connection and perform the reset. Requirements for Privileged Accounts are documented in the User Manual, under the KB Article section. To look up the value of PrivilegedAccountID's, this can be done on the screen `Administration -&gt; PasswordState Administration -&gt; Privileged Account Credentials`.</maml:para>
           </maml:Description>
-          <command:parameterValue required="true" variableLength="false">Nullable`1[]</command:parameterValue>
+          <command:parameterValue required="true" variableLength="false">Int32</command:parameterValue>
           <dev:type>
-            <maml:name>Nullable`1[]</maml:name>
+            <maml:name>Int32</maml:name>
             <maml:uri />
           </dev:type>
           <dev:defaultValue>None</dev:defaultValue>
@@ -15513,9 +15961,9 @@ You can either specify the AccountType or AccountTypeID if needed when changing 
             <maml:para>The ID value representing the Account Type image (derived from the AccountTypes table). An AccountTypeID of 0 (zero) means there is no associated Account Type image for this Password.
 You can either specify the AccountType or AccountTypeID if needed when changing password records. Account Types and their ID values can be seen on the screen `Administration -&gt; Passwordstate Administration -&gt; Images and Account Types`, and click on the ' Toggle ID Column Visibility ' button to determine the appropriate value.</maml:para>
           </maml:Description>
-          <command:parameterValue required="true" variableLength="false">Nullable`1[]</command:parameterValue>
+          <command:parameterValue required="true" variableLength="false">Int32</command:parameterValue>
           <dev:type>
-            <maml:name>Nullable`1[]</maml:name>
+            <maml:name>Int32</maml:name>
             <maml:uri />
           </dev:type>
           <dev:defaultValue>None</dev:defaultValue>
@@ -15550,9 +15998,9 @@ You can either specify the AccountType or AccountTypeID if needed when changing 
           <maml:Description>
             <maml:para>The ID of the password to be updated.</maml:para>
           </maml:Description>
-          <command:parameterValue required="true" variableLength="false">Nullable`1[]</command:parameterValue>
+          <command:parameterValue required="true" variableLength="false">Int32</command:parameterValue>
           <dev:type>
-            <maml:name>Nullable`1[]</maml:name>
+            <maml:name>Int32</maml:name>
             <maml:uri />
           </dev:type>
           <dev:defaultValue>0</dev:defaultValue>
@@ -15729,9 +16177,9 @@ Some systems require a username and password to authenticate. This field represe
           <maml:Description>
             <maml:para>Once the password has been changed due to a scheduled reset, you can add an additional (x) number of days to the ExpiryDate field so another reset will occur again in 30, 60, 90 days, etc. This is the option on the Reset Options tab for the record.</maml:para>
           </maml:Description>
-          <command:parameterValue required="true" variableLength="false">Nullable`1[]</command:parameterValue>
+          <command:parameterValue required="true" variableLength="false">Int32</command:parameterValue>
           <dev:type>
-            <maml:name>Nullable`1[]</maml:name>
+            <maml:name>Int32</maml:name>
             <maml:uri />
           </dev:type>
           <dev:defaultValue>None</dev:defaultValue>
@@ -15741,9 +16189,9 @@ Some systems require a username and password to authenticate. This field represe
           <maml:Description>
             <maml:para>Most accounts require a Password Reset Script to be assigned to them, with the only exception being Active Directory Accounts - not to specify this field for AD Accounts. To look up the values of the ScriptID's, this can be done by using the ' Toggle ID Column Visibility ' button on the Password Reset Scripts screens in PasswordState.</maml:para>
           </maml:Description>
-          <command:parameterValue required="true" variableLength="false">Nullable`1[]</command:parameterValue>
+          <command:parameterValue required="true" variableLength="false">Int32</command:parameterValue>
           <dev:type>
-            <maml:name>Nullable`1[]</maml:name>
+            <maml:name>Int32</maml:name>
             <maml:uri />
           </dev:type>
           <dev:defaultValue>None</dev:defaultValue>
@@ -15753,9 +16201,9 @@ Some systems require a username and password to authenticate. This field represe
           <maml:Description>
             <maml:para>Some Password Reset Scripts also require a `Privileged Account Credential` to be associated with the Password record, to initiate connection and perform the reset. Requirements for Privileged Accounts are documented in the User Manual, under the KB Article section. To look up the value of PrivilegedAccountID's, this can be done on the screen `Administration -&gt; PasswordState Administration -&gt; Privileged Account Credentials`.</maml:para>
           </maml:Description>
-          <command:parameterValue required="true" variableLength="false">Nullable`1[]</command:parameterValue>
+          <command:parameterValue required="true" variableLength="false">Int32</command:parameterValue>
           <dev:type>
-            <maml:name>Nullable`1[]</maml:name>
+            <maml:name>Int32</maml:name>
             <maml:uri />
           </dev:type>
           <dev:defaultValue>None</dev:defaultValue>
@@ -15877,9 +16325,9 @@ You can either specify the AccountType or AccountTypeID if needed when changing 
             <maml:para>The ID value representing the Account Type image (derived from the AccountTypes table). An AccountTypeID of 0 (zero) means there is no associated Account Type image for this Password.
 You can either specify the AccountType or AccountTypeID if needed when changing password records. Account Types and their ID values can be seen on the screen `Administration -&gt; Passwordstate Administration -&gt; Images and Account Types`, and click on the ' Toggle ID Column Visibility ' button to determine the appropriate value.</maml:para>
           </maml:Description>
-          <command:parameterValue required="true" variableLength="false">Nullable`1[]</command:parameterValue>
+          <command:parameterValue required="true" variableLength="false">Int32</command:parameterValue>
           <dev:type>
-            <maml:name>Nullable`1[]</maml:name>
+            <maml:name>Int32</maml:name>
             <maml:uri />
           </dev:type>
           <dev:defaultValue>None</dev:defaultValue>
@@ -15940,9 +16388,9 @@ You can either specify the AccountType or AccountTypeID if needed when changing 
           <maml:para>The ID value representing the Account Type image (derived from the AccountTypes table). An AccountTypeID of 0 (zero) means there is no associated Account Type image for this Password.
 You can either specify the AccountType or AccountTypeID if needed when changing password records. Account Types and their ID values can be seen on the screen `Administration -&gt; Passwordstate Administration -&gt; Images and Account Types`, and click on the ' Toggle ID Column Visibility ' button to determine the appropriate value.</maml:para>
         </maml:Description>
-        <command:parameterValue required="true" variableLength="false">Nullable`1[]</command:parameterValue>
+        <command:parameterValue required="true" variableLength="false">Int32</command:parameterValue>
         <dev:type>
-          <maml:name>Nullable`1[]</maml:name>
+          <maml:name>Int32</maml:name>
           <maml:uri />
         </dev:type>
         <dev:defaultValue>None</dev:defaultValue>
@@ -15952,9 +16400,9 @@ You can either specify the AccountType or AccountTypeID if needed when changing 
         <maml:Description>
           <maml:para>Once the password has been changed due to a scheduled reset, you can add an additional (x) number of days to the ExpiryDate field so another reset will occur again in 30, 60, 90 days, etc. This is the option on the Reset Options tab for the record.</maml:para>
         </maml:Description>
-        <command:parameterValue required="true" variableLength="false">Nullable`1[]</command:parameterValue>
+        <command:parameterValue required="true" variableLength="false">Int32</command:parameterValue>
         <dev:type>
-          <maml:name>Nullable`1[]</maml:name>
+          <maml:name>Int32</maml:name>
           <maml:uri />
         </dev:type>
         <dev:defaultValue>None</dev:defaultValue>
@@ -16241,9 +16689,9 @@ A generic field is a string field which can be renamed to a different value when
         <maml:Description>
           <maml:para>The ID of the password to be updated.</maml:para>
         </maml:Description>
-        <command:parameterValue required="true" variableLength="false">Nullable`1[]</command:parameterValue>
+        <command:parameterValue required="true" variableLength="false">Int32</command:parameterValue>
         <dev:type>
-          <maml:name>Nullable`1[]</maml:name>
+          <maml:name>Int32</maml:name>
           <maml:uri />
         </dev:type>
         <dev:defaultValue>0</dev:defaultValue>
@@ -16277,9 +16725,9 @@ A generic field is a string field which can be renamed to a different value when
         <maml:Description>
           <maml:para>Some Password Reset Scripts also require a `Privileged Account Credential` to be associated with the Password record, to initiate connection and perform the reset. Requirements for Privileged Accounts are documented in the User Manual, under the KB Article section. To look up the value of PrivilegedAccountID's, this can be done on the screen `Administration -&gt; PasswordState Administration -&gt; Privileged Account Credentials`.</maml:para>
         </maml:Description>
-        <command:parameterValue required="true" variableLength="false">Nullable`1[]</command:parameterValue>
+        <command:parameterValue required="true" variableLength="false">Int32</command:parameterValue>
         <dev:type>
-          <maml:name>Nullable`1[]</maml:name>
+          <maml:name>Int32</maml:name>
           <maml:uri />
         </dev:type>
         <dev:defaultValue>None</dev:defaultValue>
@@ -16301,9 +16749,9 @@ A generic field is a string field which can be renamed to a different value when
         <maml:Description>
           <maml:para>Most accounts require a Password Reset Script to be assigned to them, with the only exception being Active Directory Accounts - not to specify this field for AD Accounts. To look up the values of the ScriptID's, this can be done by using the ' Toggle ID Column Visibility ' button on the Password Reset Scripts screens in PasswordState.</maml:para>
         </maml:Description>
-        <command:parameterValue required="true" variableLength="false">Nullable`1[]</command:parameterValue>
+        <command:parameterValue required="true" variableLength="false">Int32</command:parameterValue>
         <dev:type>
-          <maml:name>Nullable`1[]</maml:name>
+          <maml:name>Int32</maml:name>
           <maml:uri />
         </dev:type>
         <dev:defaultValue>None</dev:defaultValue>
@@ -16364,9 +16812,9 @@ Some systems require a username and password to authenticate. This field represe
         <maml:Description>
           <maml:para>When enabling Account Heartbeat, you must associate the correct Password Validation Script to the record (all account types require a Validation Script to be selected). To look up the values of the ValidationScriptID's, this can be done by using the ' Toggle ID Column Visibility ' button on the Password Validation Scripts screens in PasswordState.</maml:para>
         </maml:Description>
-        <command:parameterValue required="true" variableLength="false">Nullable`1[]</command:parameterValue>
+        <command:parameterValue required="true" variableLength="false">Int32</command:parameterValue>
         <dev:type>
-          <maml:name>Nullable`1[]</maml:name>
+          <maml:name>Int32</maml:name>
           <maml:uri />
         </dev:type>
         <dev:defaultValue>None</dev:defaultValue>
@@ -16423,7 +16871,7 @@ Some systems require a username and password to authenticate. This field represe
     <command:inputTypes>
       <command:inputType>
         <dev:type>
-          <maml:name>System.Nullable`1[[System.Int32, System.Private.CoreLib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=7cec85d7bea7798e]][]</maml:name>
+          <maml:name>System.Nullable`1[[System.Int32, System.Private.CoreLib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=7cec85d7bea7798e]]</maml:name>
         </dev:type>
         <maml:description>
           <maml:para></maml:para>
@@ -16560,9 +17008,9 @@ M for Modify or V for View permissions.</maml:para>
             <maml:para>The SecurityGroupID you wish to apply permissions for.
 You can only specify SecurityGroupID or SecurityGroupName, not both in the same call.</maml:para>
           </maml:Description>
-          <command:parameterValue required="true" variableLength="false">Nullable`1[]</command:parameterValue>
+          <command:parameterValue required="true" variableLength="false">Int32</command:parameterValue>
           <dev:type>
-            <maml:name>Nullable`1[]</maml:name>
+            <maml:name>Int32</maml:name>
             <maml:uri />
           </dev:type>
           <dev:defaultValue>None</dev:defaultValue>
@@ -16677,9 +17125,9 @@ You can only specify SecurityGroupID or SecurityGroupName, not both in the same 
           <maml:para>The SecurityGroupID you wish to apply permissions for.
 You can only specify SecurityGroupID or SecurityGroupName, not both in the same call.</maml:para>
         </maml:Description>
-        <command:parameterValue required="true" variableLength="false">Nullable`1[]</command:parameterValue>
+        <command:parameterValue required="true" variableLength="false">Int32</command:parameterValue>
         <dev:type>
-          <maml:name>Nullable`1[]</maml:name>
+          <maml:name>Int32</maml:name>
           <maml:uri />
         </dev:type>
         <dev:defaultValue>None</dev:defaultValue>
@@ -16778,7 +17226,7 @@ M for Modify or V for View permissions.</maml:para>
       </command:inputType>
       <command:inputType>
         <dev:type>
-          <maml:name>System.Nullable`1[[System.Int32, System.Private.CoreLib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=7cec85d7bea7798e]][]</maml:name>
+          <maml:name>System.Nullable`1[[System.Int32, System.Private.CoreLib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=7cec85d7bea7798e]]</maml:name>
         </dev:type>
         <maml:description>
           <maml:para></maml:para>

--- a/en-us/passwordstate-management-help.xml
+++ b/en-us/passwordstate-management-help.xml
@@ -2924,6 +2924,18 @@ SiteID 0 = Default site 'Internal'</maml:para>
           </dev:type>
           <dev:defaultValue>None</dev:defaultValue>
         </command:parameter>
+        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="named" aliases="none">
+          <maml:name>Reason</maml:name>
+          <maml:Description>
+            <maml:para>A reason which can be logged for auditing of why a password was retrieved.</maml:para>
+          </maml:Description>
+          <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+          <dev:type>
+            <maml:name>String</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
         <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="cf">
           <maml:name>Confirm</maml:name>
           <maml:Description>
@@ -2965,6 +2977,18 @@ SiteID 0 = Default site 'Internal'</maml:para>
         <maml:name>Description</maml:name>
         <maml:Description>
           <maml:para>A description for the Security Group. The description of the Active Directory Security Group will not be imported (missing API feature), you need to specify the description.</maml:para>
+        </maml:Description>
+        <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+        <dev:type>
+          <maml:name>String</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="named" aliases="none">
+        <maml:name>Reason</maml:name>
+        <maml:Description>
+          <maml:para>A reason which can be logged for auditing of why a password was retrieved.</maml:para>
         </maml:Description>
         <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
         <dev:type>
@@ -3038,9 +3062,9 @@ SiteID 0 = Default site 'Internal'</maml:para>
     <command:examples>
       <command:example>
         <maml:title>-------------------------- Example 1 --------------------------</maml:title>
-        <dev:code>PS C:\&gt; {{ Add example code here }}</dev:code>
+        <dev:code>PS C:\&gt; New-PasswordStateADSecurityGroup -SecurityGroupName "Administrators" -ADDomainNetBIOS "domain.local" -Description "Domain Administrators"</dev:code>
         <dev:remarks>
-          <maml:para>{{ Add example description here }}</maml:para>
+          <maml:para>Adding Administrators group from domain "domain.local" with description to PasswordState if found in ActiveDirectory.</maml:para>
         </dev:remarks>
       </command:example>
     </command:examples>

--- a/functions/Get-PasswordStateFolder.ps1
+++ b/functions/Get-PasswordStateFolder.ps1
@@ -31,7 +31,7 @@
                 $uri += "&PreventAuditing=true"
             }
             try {
-                $result = Get-PasswordStateResource -uri $uri @parms -ErrorAction Stop | Where-Object { $_.FolderID -eq $FolderID }   
+                $result = Get-PasswordStateResource -uri $uri @parms -ErrorAction Stop | Where-Object { $_.FolderID -eq $FolderID }
             }
             catch {
                 throw $_.Exception

--- a/functions/Get-PasswordStateFolder.ps1
+++ b/functions/Get-PasswordStateFolder.ps1
@@ -5,22 +5,51 @@
         [Parameter(ValueFromPipelineByPropertyName, Position = 0)][Alias('Name')][string]$FolderName,
         [Parameter(ValueFromPipelineByPropertyName, Position = 1)][string]$Description,
         [Parameter(ValueFromPipelineByPropertyName, Position = 2)][string]$TreePath,
-        [Parameter(ValueFromPipelineByPropertyName, Position = 3)][int32]$SiteID,
+        [Parameter(ValueFromPipelineByPropertyName, Position = 3)][AllowNull()][Nullable[System.Int32]]$SiteID = 0,
         [Parameter(ValueFromPipelineByPropertyName, Position = 4)][string]$SiteLocation,
-        [parameter(ValueFromPipelineByPropertyName, Position = 5)][switch]$PreventAuditing
+        [parameter(ValueFromPipelineByPropertyName, Position = 6)][Nullable[System.Int32]]$FolderID,
+        [parameter(ValueFromPipelineByPropertyName, Position = 7)][switch]$PreventAuditing,
+        [parameter(ValueFromPipelineByPropertyName, Position = 8)][string]$Reason
     )
 
+    Begin {
+        # Add a reason to the audit log if specified
+        if ($Reason) {
+            $headerreason = @{"Reason" = "$Reason" }
+            $parms = @{ExtraParams = @{"Header" = $headerreason } }
+        }
+        else { $parms = @{ } }
+    }
+
     Process {
-        If ($PSBoundParameters.Count -eq 0) {
+        if ($PSBoundParameters.Count -eq 0) {
             $uri = "/api/folders"
         }
-        Else {
+        elseif ($PSBoundParameters.ContainsKey('FolderID')) {
+            $uri = "/api/folders"
+            if ($PreventAuditing) {
+                $uri += "&PreventAuditing=true"
+            }
+            try {
+                $result = Get-PasswordStateResource -uri $uri @parms -ErrorAction Stop | Where-Object { $_.FolderID -eq $FolderID }   
+            }
+            catch {
+                throw $_.Exception
+            }
+            if ($result) {
+                return $result
+            }
+            else {
+                throw "You search for folder records with FolderID '$FolderID' return zero results."
+            }
+        }
+        else {
             $BuildURL = '?'
-            If ($FolderName) {   $BuildURL += "FolderName=$([System.Web.HttpUtility]::UrlEncode($FolderName))&" }
-            If ($Description) {  $BuildURL += "Description=$([System.Web.HttpUtility]::UrlEncode($Description))&" }
-            If ($TreePath) {     $BuildURL += "TreePath=$([System.Web.HttpUtility]::UrlEncode($TreePath))&" }
-            If ($SiteID) {       $BuildURL += "SiteID=$([System.Web.HttpUtility]::UrlEncode($SiteID))&" }
-            If ($SiteLocation) { $BuildURL += "SiteLocation=$([System.Web.HttpUtility]::UrlEncode($SiteLocation))&" }
+            if ($FolderName) { $BuildURL += "FolderName=$([System.Web.HttpUtility]::UrlEncode($FolderName))&" }
+            if ($Description) { $BuildURL += "Description=$([System.Web.HttpUtility]::UrlEncode($Description))&" }
+            if ($TreePath) { $BuildURL += "TreePath=$([System.Web.HttpUtility]::UrlEncode($TreePath))&" }
+            if ($SiteID) { $BuildURL += "SiteID=$([System.Web.HttpUtility]::UrlEncode($SiteID))&" }
+            if ($SiteLocation) { $BuildURL += "SiteLocation=$([System.Web.HttpUtility]::UrlEncode($SiteLocation))&" }
 
             $BuildURL = $BuildURL -Replace ".$"
 
@@ -35,10 +64,10 @@
             }
         }
         Try {
-            Get-PasswordStateResource -uri $uri -method GET
+            Get-PasswordStateResource -uri $uri @parms -ErrorAction Stop
         }
         Catch {
-            Throw $_.Exception
+            throw $_.Exception
         }
     }
 }

--- a/functions/Get-PasswordStateList.ps1
+++ b/functions/Get-PasswordStateList.ps1
@@ -10,28 +10,37 @@
         [Parameter(ParameterSetName = 'Specific', ValueFromPipelineByPropertyName, Position = 2)][string]$TreePath,
         [Parameter(ParameterSetName = 'Specific', ValueFromPipelineByPropertyName, Position = 3)][int32]$SiteID,
         [Parameter(ParameterSetName = 'Specific', ValueFromPipelineByPropertyName, Position = 4)][string]$SiteLocation,
-        [parameter(ValueFromPipelineByPropertyName, Position = 5)][switch]$PreventAuditing
+        [parameter(ValueFromPipelineByPropertyName, Position = 5)][switch]$PreventAuditing,
+        [parameter(ValueFromPipelineByPropertyName, Position = 6)][string]$Reason
 
     )
 
+    Begin {
+        # Add a reason to the audit log if specified
+        If ($Reason) {
+            $headerreason = @{"Reason" = "$Reason" }
+            $parms = @{ExtraParams = @{"Header" = $headerreason } }
+        }
+        else { $parms = @{ } }
+    }
     Process {
         Switch ($PSCmdlet.ParameterSetName) {
             'ID' {
                 If (!($PSBoundParameters.ContainsKey('PasswordListID'))) {
-                    [string]$PasswordListID = ''
+                    $uri = "/api/passwordlists/"
                 }
                 else {
                     # if only PasswordListID is specified, so searching for a specific ID, PreventAuditing is not possible
-                    [switch]$PreventAuditing = $false
+                    $PreventAuditing = $false
+                    $uri = "/api/passwordlists/$($PasswordListID)"
                 }
-                $uri = "/api/passwordlists/$($PasswordListID)"
             }
             'Specific' {
                 $BuildURL = '?'
                 If ($PasswordList) { $BuildURL += "PasswordList=$([System.Web.HttpUtility]::UrlEncode($PasswordList))&" }
-                If ($Description) {  $BuildURL += "Description=$([System.Web.HttpUtility]::UrlEncode($Description))&" }
-                If ($TreePath) {     $BuildURL += "TreePath=$([System.Web.HttpUtility]::UrlEncode($TreePath))&" }
-                If ($SiteID) {       $BuildURL += "SiteID=$([System.Web.HttpUtility]::UrlEncode($SiteID))&" }
+                If ($Description) { $BuildURL += "Description=$([System.Web.HttpUtility]::UrlEncode($Description))&" }
+                If ($TreePath) { $BuildURL += "TreePath=$([System.Web.HttpUtility]::UrlEncode($TreePath))&" }
+                If ($SiteID) { $BuildURL += "SiteID=$([System.Web.HttpUtility]::UrlEncode($SiteID))&" }
                 If ($SiteLocation) { $BuildURL += "SiteLocation=$([System.Web.HttpUtility]::UrlEncode($SiteLocation))&" }
 
                 $BuildURL = $BuildURL -Replace ".$"
@@ -48,7 +57,7 @@
             }
         }
         Try {
-            Get-PasswordStateResource -uri $uri -method GET
+            Get-PasswordStateResource -uri $uri @parms -ErrorAction Stop
         }
         Catch {
             Throw $_.Exception
@@ -56,4 +65,4 @@
     }
 }
 
-Set-Alias -Name Find-PasswordstateList -Value Get-PasswordStateList -Force
+Set-Alias -Name Find-PasswordStateList -Value Get-PasswordStateList -Force

--- a/functions/Get-PasswordStatePassword.ps1
+++ b/functions/Get-PasswordStatePassword.ps1
@@ -98,6 +98,10 @@
             }
             # Search on a specific password ID
             'PasswordID' {
+                If ($PSBoundParameters.ContainsKey('PasswordID')) {
+                    # if only PasswordID is specified, so searching for a specific ID, PreventAuditing is not possible
+                    $PreventAuditing = $false
+                }
                 $uri = "/api/passwords/$($PasswordID)"
             }
             # Search with a variety of filters

--- a/functions/Get-PasswordStatePermission.ps1
+++ b/functions/Get-PasswordStatePermission.ps1
@@ -19,10 +19,10 @@
         [Parameter(ParameterSetName = 'Specific', ValueFromPipelineByPropertyName, Position = 2, HelpMessage = "Possible values are 0 for current month, 1 for the past 30 days, and then any other integer representing the quantity of months.")]
         [AllowNull()]
         [Alias('Duration')]
-        [Nullable[System.Int32][]]$DurationInMonth,
+        [Nullable[System.Int32]]$DurationInMonth,
         [Parameter(ValueFromPipelineByPropertyName, Position = 1, HelpMessage = "SiteID 0 = Default site 'Internal'")]
         [AllowNull()]
-        [Nullable[System.Int32][]]$SiteID = 0,
+        [Nullable[System.Int32]]$SiteID = 0,
         [Parameter(ValueFromPipelineByPropertyName, Position = 2)][switch]$ShowReportIDs
     )
 

--- a/functions/New-PasswordStateADSecurityGroup.ps1
+++ b/functions/New-PasswordStateADSecurityGroup.ps1
@@ -9,7 +9,9 @@
         [ValidateLength(0, 255)]
         [string]$Description,
         [parameter(ValueFromPipelineByPropertyName, Position = 2, Mandatory = $true)]
-        [string]$ADDomainNetBIOS
+        [string]$ADDomainNetBIOS,
+        [parameter(ValueFromPipelineByPropertyName, Position = 3, Mandatory = $false)]
+        [string]$Reason
     )
 
     begin {

--- a/functions/New-PasswordStateADSecurityGroup.ps1
+++ b/functions/New-PasswordStateADSecurityGroup.ps1
@@ -13,6 +13,14 @@
     )
 
     begin {
+        # Import PasswordState Environment for validation of PasswordsInPlainText setting
+        $PWSProfile = Get-PasswordStateEnvironment
+        # Add a reason to the audit log if specified
+        If ($Reason) {
+            $headerreason = @{"Reason" = "$Reason" }
+            $parms = @{ExtraParams = @{"Header" = $headerreason } }
+        }
+        else { $parms = @{ } }
     }
     process {
         # Build the Custom object to convert to json and send to the api.
@@ -23,18 +31,24 @@
         # Add description if parameter was given.
         # Currently the description of PasswordState is NOT synced during import of an AD Security group when using the API.
         # If this will be implemented in the future, the description is optional and will not be sent as an empty string or null in the request.
-        if ($Permission) {
+        if ($Description) {
             $body | Add-Member -NotePropertyName "Description" -NotePropertyValue $Description
         }
         # Adding API Key to the body if using APIKey as Authentication Type to use the api instead of winAPI
-        $penv = Get-PasswordStateEnvironment
-        if ($penv.AuthType -eq "APIKey") {
-            $body | Add-Member -MemberType NoteProperty -Name "APIKey" -Value $penv.Apikey
+        if ($PWSProfile.AuthType -eq "APIKey") {
+            $body | Add-Member -MemberType NoteProperty -Name "APIKey" -Value $PWSProfile.Apikey
         }
         if ($PSCmdlet.ShouldProcess("Creating AD Security Group '$SecurityGroupName' for Domain '$ADDomainNetBIOS' (Description: '$Description')")) {
             # Covert body to json and execute the api query
             $body = "$($body |ConvertTo-Json)"
-            $output = New-PasswordStateResource -uri "/api/securitygroup" -body $body -Sort:$Sort
+            if ($body) {
+                try {
+                    $output = New-PasswordStateResource -uri "/api/securitygroup" -body $body @parms -ErrorAction Stop
+                }
+                catch {
+                    throw $_.Exception
+                }
+            }
         }
     }
 

--- a/functions/New-PasswordStateListPermission.ps1
+++ b/functions/New-PasswordStateListPermission.ps1
@@ -11,7 +11,7 @@
         [ValidateLength(0, 100)]
         [string]$ApplyPermissionsForUserID = $null,
         [parameter(parameterSetName = 'PermissionID', Position = 3, ValueFromPipelineByPropertyName, Mandatory = $true)]
-        [Nullable[System.Int32][]]$ApplyPermissionsForSecurityGroupID = $null,
+        [Nullable[System.Int32]]$ApplyPermissionsForSecurityGroupID = $null,
         [parameter(parameterSetName = 'PermissionName', Position = 3, ValueFromPipelineByPropertyName, Mandatory = $true)]
         [string]$ApplyPermissionsForSecurityGroupName = $null
     )

--- a/functions/New-PasswordStatePasswordPermission.ps1
+++ b/functions/New-PasswordStatePasswordPermission.ps1
@@ -11,7 +11,7 @@
         [ValidateLength(0, 100)]
         [string]$ApplyPermissionsForUserID = $null,
         [parameter(parameterSetName = 'PermissionID', Position = 3, ValueFromPipelineByPropertyName, Mandatory = $true)]
-        [Nullable[System.Int32][]]$ApplyPermissionsForSecurityGroupID = $null,
+        [Nullable[System.Int32]]$ApplyPermissionsForSecurityGroupID = $null,
         [parameter(parameterSetName = 'PermissionName', Position = 3, ValueFromPipelineByPropertyName, Mandatory = $true)]
         [string]$ApplyPermissionsForSecurityGroupName = $null
     )

--- a/functions/New-PasswordStateSelfDestructMessage.ps1
+++ b/functions/New-PasswordStateSelfDestructMessage.ps1
@@ -1,6 +1,5 @@
 ﻿function New-PasswordStateSelfDestructMessage {
     [Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSAvoidUsingPlainTextForPassword', '', Justification = 'Not a password field.')]
-    [Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSAvoidUsingUserNameAndPassWordParams', '', Justification = '*UserID and *PasswordID are not a user and not a password')]
     [cmdletbinding(SupportsShouldProcess = $true, DefaultParameterSetName = 'All')]
     param (
         [parameter(ValueFromPipelineByPropertyName, Position = 0, Mandatory = $false)]
@@ -22,7 +21,7 @@
             })]
         [string]$ExpiresAt = "1d",
         [parameter(ValueFromPipelineByPropertyName, Position = 5, Mandatory = $false)]
-        [Nullable[System.Int32]]$NoViews = 1,
+        [int32]$NoViews = 1,
         [parameter(ValueFromPipelineByPropertyName, Position = 6, Mandatory = $true)]
         [ValidateScript( {
                 if ($_ -notmatch '^([\w-\.]+)@((\[[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.)|(([\w-]+\.)+))([a-zA-Z]{2,4}|[0-9]{1,3})(\]?)$') {

--- a/functions/New-PasswordStateSelfDestructMessage.ps1
+++ b/functions/New-PasswordStateSelfDestructMessage.ps1
@@ -1,0 +1,131 @@
+﻿function New-PasswordStateSelfDestructMessage {
+    [Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSAvoidUsingPlainTextForPassword', '', Justification = 'Not a password field.')]
+    [Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSAvoidUsingUserNameAndPassWordParams', '', Justification = '*UserID and *PasswordID are not a user and not a password')]
+    [cmdletbinding(SupportsShouldProcess = $true, DefaultParameterSetName = 'All')]
+    param (
+        [parameter(ValueFromPipelineByPropertyName, Position = 0, Mandatory = $false)]
+        [Nullable[System.Int32]]$PasswordID,
+        [parameter(ValueFromPipelineByPropertyName, Position = 1, Mandatory = $false)]
+        [string]$Message,
+        [parameter(ValueFromPipelineByPropertyName, Position = 2, Mandatory = $false)]
+        [string]$PrefixMessageContent,
+        [parameter(ValueFromPipelineByPropertyName, Position = 3, Mandatory = $false)]
+        [string]$AppendMessageContent,
+        [parameter(ValueFromPipelineByPropertyName, Position = 4, Mandatory = $false)]
+        [ValidateScript( {
+                if ($_ -notmatch '^[0-9]{1,4}d|m|h$') {
+                    throw "Given ExpiresAt '$_' is not a ExpiresAt format! Please specify a correct duration/time period as per the following examples: 30m (30 minutes), 3h (3 hours), or 2d (2 days)"
+                }
+                else {
+                    $true
+                }
+            })]
+        [string]$ExpiresAt = "1d",
+        [parameter(ValueFromPipelineByPropertyName, Position = 5, Mandatory = $false)]
+        [Nullable[System.Int32]]$NoViews = 1,
+        [parameter(ValueFromPipelineByPropertyName, Position = 6, Mandatory = $true)]
+        [ValidateScript( {
+                if ($_ -notmatch '^([\w-\.]+)@((\[[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.)|(([\w-]+\.)+))([a-zA-Z]{2,4}|[0-9]{1,3})(\]?)$') {
+                    throw "Given ToEmailAddress '$_' is not a valid mail address! Please specify a correct mail address, e.g. user@example.com, surname.lastname@example.com etc."
+                }
+                else {
+                    $true
+                }
+            })]
+        [string]$ToEmailAddress,
+        [parameter(ValueFromPipelineByPropertyName, Position = 7, Mandatory = $false)]
+        [ValidateScript( {
+                # Exclude german umlauts and other latin/non-latin diacritics or invalid characters that the api does not understand.
+                $InvalidChars = 'ßàáâãäåæçèéêëìíîïðñòóôõöøùúûüýþÿ'
+                $regex = [Regex]::Escape($InvalidChars)
+                $regex = "[$regex]"
+                $Invalid = [Regex]::Matches($_, $regex, 'IgnoreCase') | Select-Object -ExpandProperty Value | Sort-Object -Unique
+                if ($null -ne $Invalid) {
+                    throw "ERROR: The specified FirstName contains the following illegal characters: '$Invalid'. Please do not use the characters '$InvalidChars' for the FirstName since the api does not understand/convert these characters."
+                }
+                return $true
+            })]
+        [string]$ToFirstName,
+        [parameter(ValueFromPipelineByPropertyName, Position = 8, Mandatory = $false)]
+        [ValidateScript( {
+                # Exclude german umlauts and other latin/non-latin diacritics or invalid characters that the api does not understand.
+                $InvalidChars = 'ßàáâãäåæçèéêëìíîïðñòóôõöøùúûüýþÿ'
+                $regex = [Regex]::Escape($InvalidChars)
+                $regex = "[$regex]"
+                $Invalid = [Regex]::Matches($_, $regex, 'IgnoreCase') | Select-Object -ExpandProperty Value | Sort-Object -Unique
+                if ($null -ne $Invalid) {
+                    throw "ERROR: The specified Subject contains the following illegal characters: '$Invalid'. Please do not use the characters '$InvalidChars' for the Subject since the api does not understand/convert these characters."
+                }
+                return $true
+            })]
+        [string]$EmailSubject,
+        [parameter(ValueFromPipelineByPropertyName, Position = 9, Mandatory = $false)]
+        [string]$EmailBody,
+        [parameter(ValueFromPipelineByPropertyName, Position = 10, Mandatory = $false)]
+        [ValidateScript( {
+                # Exclude german umlauts and other latin/non-latin diacritics or invalid characters that the api does not understand.
+                $InvalidChars = 'ßàáâãäåæçèéêëìíîïðñòóôõöøùúûüýþÿ'
+                $regex = [Regex]::Escape($InvalidChars)
+                $regex = "[$regex]"
+                $Invalid = [Regex]::Matches($_, $regex, 'IgnoreCase') | Select-Object -ExpandProperty Value | Sort-Object -Unique
+                if ($null -ne $Invalid) {
+                    throw "ERROR: The specified Passphrase contains the following illegal characters: '$Invalid'. Please do not use the characters '$InvalidChars' for the Passphrase since the api does not understand these characters."
+                }
+                return $true
+            })]
+        [string]$Passphrase,
+        [parameter(ValueFromPipelineByPropertyName, Position = 11, Mandatory = $false)]
+        [string]$Reason
+    )
+
+    begin {
+        # Import PasswordState Environment for validation of PasswordsInPlainText setting
+        $PWSProfile = Get-PasswordStateEnvironment
+        # Add a reason to the audit log if specified
+        If ($Reason) {
+            $headerreason = @{"Reason" = "$Reason" }
+            $parms = @{ExtraParams = @{"Header" = $headerreason } }
+        }
+        else { $parms = @{ } }
+    }
+    process {
+        # Build the Custom object to convert to json and send to the api.
+        # Remove Diacritics and other from the api not understandable characters from the variables that can contain HTML
+        $body = [PSCustomObject]@{
+            "PasswordID"           = $PasswordID
+            "PrefixMessageContent" = $PrefixMessageContent | Remove-DiacriticsFromString
+            "AppendMessageContent" = $AppendMessageContent | Remove-DiacriticsFromString
+            "ExpiresAt"            = $ExpiresAt
+            "NoViews"              = $NoViews
+            "ToEmailAddress"       = $ToEmailAddress
+            "ToFirstName"          = $ToFirstName
+            "EmailSubject"         = $EmailSubject
+            "EmailBody"            = $EmailBody | Remove-DiacriticsFromString
+            "Message"              = $message | Remove-DiacriticsFromString
+            "Reason"               = $Reason
+            "Passphrase"           = $Passphrase
+        }
+        # Adding API Key to the body if using APIKey as Authentication Type to use the api instead of winAPI
+        if ($PWSProfile.AuthType -eq "APIKey") {
+            $body | Add-Member -MemberType NoteProperty -Name "APIKey" -Value $PWSProfile.Apikey
+        }
+        if ($PSCmdlet.ShouldProcess("Sending self destruct message to '$ToEmailAddress' for PasswordID '$PasswordID' and/or Message '$Message' which expires at '$ExpiresAt' and can be viewed '$NoViews' times")) {
+            # Sort the CustomObject and then covert body to json and execute the api query
+            if ($body) {
+                $body = "$($body |ConvertTo-Json)"
+                try {
+                    $output = New-PasswordStateResource -uri "/winapi/selfdestruct" -body $body @parms -ErrorAction Stop
+                }
+                catch {
+                    throw $_.Exception
+                }
+            }
+        }
+    }
+
+    end {
+        if ($output) {
+            return $output
+        }
+    }
+}

--- a/functions/Remove-PasswordStateListPermission.ps1
+++ b/functions/Remove-PasswordStateListPermission.ps1
@@ -12,7 +12,7 @@
         [ValidateLength(0, 100)]
         [string]$ApplyPermissionsForUserID = $null,
         [parameter(parameterSetName = 'PermissionID', Position = 3, ValueFromPipelineByPropertyName, Mandatory = $true)]
-        [Nullable[System.Int32][]]$ApplyPermissionsForSecurityGroupID = $null,
+        [Nullable[System.Int32]]$ApplyPermissionsForSecurityGroupID = $null,
         [parameter(parameterSetName = 'PermissionName', Position = 3, ValueFromPipelineByPropertyName, Mandatory = $true)]
         [string]$ApplyPermissionsForSecurityGroupName = $null
     )

--- a/functions/Remove-PasswordStatePasswordPermission.ps1
+++ b/functions/Remove-PasswordStatePasswordPermission.ps1
@@ -11,7 +11,7 @@
         [ValidateLength(0, 100)]
         [string]$ApplyPermissionsForUserID = $null,
         [parameter(parameterSetName = 'PermissionID', Position = 3, ValueFromPipelineByPropertyName, Mandatory = $true)]
-        [Nullable[System.Int32][]]$ApplyPermissionsForSecurityGroupID = $null,
+        [Nullable[System.Int32]]$ApplyPermissionsForSecurityGroupID = $null,
         [parameter(parameterSetName = 'PermissionName', Position = 3, ValueFromPipelineByPropertyName, Mandatory = $true)]
         [string]$ApplyPermissionsForSecurityGroupName = $null
     )

--- a/functions/Set-PasswordStateListPermission.ps1
+++ b/functions/Set-PasswordStateListPermission.ps1
@@ -11,7 +11,7 @@
         [ValidateLength(0, 100)]
         [string]$ApplyPermissionsForUserID = $null,
         [parameter(parameterSetName = 'PermissionID', Position = 3, ValueFromPipelineByPropertyName, Mandatory = $true)]
-        [Nullable[System.Int32][]]$ApplyPermissionsForSecurityGroupID = $null,
+        [Nullable[System.Int32]]$ApplyPermissionsForSecurityGroupID = $null,
         [parameter(parameterSetName = 'PermissionName', Position = 3, ValueFromPipelineByPropertyName, Mandatory = $true)]
         [string]$ApplyPermissionsForSecurityGroupName = $null
     )

--- a/functions/Set-PasswordStatePassword.ps1
+++ b/functions/Set-PasswordStatePassword.ps1
@@ -4,7 +4,7 @@
     [Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSAvoidGlobalVars', '', Justification = 'Needed for backward compatability')]
     [CmdletBinding(SupportsShouldProcess = $true, DefaultParameterSetName = 'All')]
     param (
-        [parameter(ValueFromPipelineByPropertyName, Mandatory = $true, Position = 0)][Nullable[System.Int32][]]$PasswordID,
+        [parameter(ValueFromPipelineByPropertyName, Mandatory = $true, Position = 0)][Nullable[System.Int32]]$PasswordID,
         [parameter(ValueFromPipelineByPropertyName, Mandatory = $false, Position = 1)][ValidateLength(1, 255)][string]$Title,
         [parameter(ValueFromPipelineByPropertyName, Mandatory = $false, Position = 2)][ValidateLength(1, 255)][string]$Username,
         [parameter(ValueFromPipelineByPropertyName, Mandatory = $true, ParameterSetName = "Password", Position = 0)]
@@ -34,7 +34,7 @@
         [parameter(ValueFromPipelineByPropertyName, Mandatory = $false, Position = 6)][string]$Notes,
         [parameter(ValueFromPipelineByPropertyName, Mandatory = $false, Position = 7)][ValidateLength(1, 255)][string]$Url,
         [parameter(ValueFromPipelineByPropertyName, Mandatory = $false, Position = 8)][ValidateLength(1, 50)][string]$AccountType,
-        [parameter(ValueFromPipelineByPropertyName, Mandatory = $false, Position = 9)][AllowNull()][Nullable[System.Int32][]]$AccountTypeID = $null,
+        [parameter(ValueFromPipelineByPropertyName, Mandatory = $false, Position = 9)][AllowNull()][Nullable[System.Int32]]$AccountTypeID = $null,
         [Parameter(ValueFromPipelineByPropertyName, Mandatory = $false, Position = 10)][string]$GenericField1 = $null,
         [Parameter(ValueFromPipelineByPropertyName, Mandatory = $false, Position = 11)][string]$GenericField2 = $null,
         [Parameter(ValueFromPipelineByPropertyName, Mandatory = $false, Position = 12)][string]$GenericField3 = $null,
@@ -62,9 +62,9 @@
                 }
             })]
         [string]$PasswordResetSchedule,
-        [parameter(ValueFromPipelineByPropertyName, Mandatory = $false, Position = 21)][Nullable[System.Int32][]]$AddDaysToExpiryDate = $null,
-        [parameter(ValueFromPipelineByPropertyName, Mandatory = $false, Position = 22)][Nullable[System.Int32][]]$ScriptID = $null,
-        [parameter(ValueFromPipelineByPropertyName, Mandatory = $false, Position = 23)][Nullable[System.Int32][]]$PrivilegedAccountID = $null,
+        [parameter(ValueFromPipelineByPropertyName, Mandatory = $false, Position = 21)][Nullable[System.Int32]]$AddDaysToExpiryDate = $null,
+        [parameter(ValueFromPipelineByPropertyName, Mandatory = $false, Position = 22)][Nullable[System.Int32]]$ScriptID = $null,
+        [parameter(ValueFromPipelineByPropertyName, Mandatory = $false, Position = 23)][Nullable[System.Int32]]$PrivilegedAccountID = $null,
         [parameter(ValueFromPipelineByPropertyName, Mandatory = $true, ParameterSetName = "Heartbeat", Position = 0)]
         [parameter(ValueFromPipelineByPropertyName, Mandatory = $false, ParameterSetName = "Reset", Position = 3)]
         [parameter(ValueFromPipelineByPropertyName, Mandatory = $false, ParameterSetName = "ResetSchedule", Position = 3)]
@@ -85,7 +85,7 @@
         [parameter(ValueFromPipelineByPropertyName, Mandatory = $false, ParameterSetName = "Heartbeat", Position = 2)]
         [parameter(ValueFromPipelineByPropertyName, Mandatory = $false, ParameterSetName = "Reset", Position = 5)]
         [parameter(ValueFromPipelineByPropertyName, Mandatory = $false, ParameterSetName = "ResetSchedule", Position = 5)]
-        [Nullable[System.Int32][]]$ValidationScriptID = $null,
+        [Nullable[System.Int32]]$ValidationScriptID = $null,
         [parameter(ValueFromPipelineByPropertyName, Mandatory = $false, ParameterSetName = "Reset", Position = 6)]
         [parameter(ValueFromPipelineByPropertyName, Mandatory = $false, ParameterSetName = "ResetSchedule", Position = 6)]
         [parameter(ValueFromPipelineByPropertyName, Mandatory = $false, ParameterSetName = "Heartbeat", Position = 3)]

--- a/functions/Set-PasswordStatePasswordPermission.ps1
+++ b/functions/Set-PasswordStatePasswordPermission.ps1
@@ -11,7 +11,7 @@
         [ValidateLength(0, 100)]
         [string]$ApplyPermissionsForUserID = $null,
         [parameter(parameterSetName = 'PermissionID', Position = 3, ValueFromPipelineByPropertyName, Mandatory = $true)]
-        [Nullable[System.Int32][]]$ApplyPermissionsForSecurityGroupID = $null,
+        [Nullable[System.Int32]]$ApplyPermissionsForSecurityGroupID = $null,
         [parameter(parameterSetName = 'PermissionName', Position = 3, ValueFromPipelineByPropertyName, Mandatory = $true)]
         [string]$ApplyPermissionsForSecurityGroupName = $null
     )

--- a/functions/Set-PasswordStatePasswordPermission.ps1
+++ b/functions/Set-PasswordStatePasswordPermission.ps1
@@ -17,6 +17,84 @@
     )
 
     begin {
+        switch ($Permission) {
+            M {
+                $PermissionLevel = "Modify"
+                $AvailablePermissionLevel = @("View", "Mobile Access")
+            }
+            V {
+                $PermissionLevel = "View"
+                $AvailablePermissionLevel = @("Modify", "Mobile Access")
+            }
+        }
+        if ($ApplyPermissionsForUserID) {
+            try {
+                $AllPermissions = Get-PasswordStatePermission -ReportID 43 -ErrorAction Stop | Where-Object { ($_.UserID -eq $ApplyPermissionsForUserID) -and ($_.PasswordID -eq $PasswordID) }
+            }
+            catch {
+                $_.Exception
+            }
+            if ($AllPermissions) {
+                foreach ($Permissions in $AllPermissions) {
+                    # We cannot identify if existing permissions were applied to password objects directly or on password lists. This is not supported for now with the api.
+                    if (($Permissions.PasswordID -eq $PasswordID) -and ($Permissions.UserID -eq $ApplyPermissionsForUserID) -and ($Permissions.$PermissionLevel -eq "Yes")) {
+                        Write-PSFMessage -Level Verbose -Message "UserID '$ApplyPermissionsForUserID' already has directly or indirectly (PasswordList) permissions (Permission '$Permission' ($PermissionLevel)) on Password '$($Permissions.Title)' with ID '$PasswordID' (PasswordList: '$($Permissions.PasswordList)', Path: '$($Permissions.TreePath)'  )!"
+                        break
+                    }
+                    elseif (($Permissions.PasswordID -eq $PasswordID) -and ($Permissions.UserID -eq $ApplyPermissionsForUserID)) {
+                        foreach ($AvailablePermission in $AvailablePermissionLevel) {
+                            if ($Permissions.$AvailablePermission -eq "Yes") {
+                                Write-PSFMessage -Level Verbose -Message "UserID '$ApplyPermissionsForUserID' has directly or indirectly (PasswordList) Permission '$AvailablePermission' on Password '$($Permissions.Title)' with ID '$PasswordID' (PasswordList: '$($Permissions.PasswordList)', Path: '$($Permissions.TreePath)'  ), moving on!"
+                                break
+                            }
+                        }
+                    }
+                    else {
+                        Write-PSFMessage -Level Warning -Message "UserID '$ApplyPermissionsForUserID' does not have any permission on Password '$($Permissions.Title)' with ID '$PasswordID' (PasswordList: '$($Permissions.PasswordList)', Path: '$($Permissions.TreePath)'  ) so far! Please use 'New-PasswordStatePasswordPermission -Permission '$Permission' -ApplyPermissionsForUserID '$ApplyPermissionsForUserID' -PasswordID '$PasswordID'' to add new permissions."
+                        break
+                    }
+                }
+            }
+            else {
+                Write-PSFMessage -Level Warning -Message "UserID '$ApplyPermissionsForUserID' does not have any permission on Password '$($Permissions.Title)' with ID '$PasswordID' (PasswordList: '$($Permissions.PasswordList)', Path: '$($Permissions.TreePath)'  ) so far! Please use 'New-PasswordStatePasswordPermission -Permission '$Permission' -ApplyPermissionsForUserID '$ApplyPermissionsForUserID' -PasswordID '$PasswordID'' to add new permissions."
+            }
+        }
+        if ($ApplyPermissionsForSecurityGroupName) {
+            try {
+                $AllPermissions = Get-PasswordStatePermission -ReportID 43 -ErrorAction Stop | Where-Object { ($_.SecurityGroupName -eq $ApplyPermissionsForSecurityGroupName) -and ($_.PasswordID -eq $PasswordID) }
+            }
+            catch {
+                $_.Exception
+            }
+            if ($AllPermissions) {
+                foreach ($Permissions in $AllPermissions) {
+                    # We cannot identify if existing permissions were applied to password objects directly or on password lists. This is not supported for now with the api.
+                    if (($Permissions.PasswordID -eq $PasswordID) -and ($Permissions.SecurityGroupName -eq $ApplyPermissionsForSecurityGroupName) -and ($Permissions.$PermissionLevel -eq "Yes")) {
+                        Write-PSFMessage -Level Verbose -Message "SecurityGroup '$ApplyPermissionsForSecurityGroupName' already has directly or indirectly (PasswordList) permissions (Permission '$Permission' ($PermissionLevel)) on Password '$($Permissions.Title)' with ID '$PasswordID' (PasswordList: '$($Permissions.PasswordList)', Path: '$($Permissions.TreePath)'  ). Please also check PasswordList permissions!"
+                        break
+                    }
+                    elseif (($Permissions.PasswordID -eq $PasswordID) -and ($Permissions.SecurityGroupName -eq $ApplyPermissionsForSecurityGroupName)) {
+                        foreach ($AvailablePermission in $AvailablePermissionLevel) {
+                            if ($Permissions.$AvailablePermission -eq "Yes") {
+                                Write-PSFMessage -Level Verbose -Message "SecurityGroup '$ApplyPermissionsForSecurityGroupName' has directly or indirectly (PasswordList) Permission '$AvailablePermission' on Password '$($Permissions.Title)' with ID '$PasswordID' (PasswordList: '$($Permissions.PasswordList)', Path: '$($Permissions.TreePath)'  ), moving on!"
+                                break
+                            }
+                        }
+                    }
+                    else {
+                        Write-PSFMessage -Level Warning -Message "SecurityGroup '$ApplyPermissionsForSecurityGroupName' does not have any permission on Password '$($Permissions.Title)' with ID '$PasswordID' (PasswordList: '$($Permissions.PasswordList)', Path: '$($Permissions.TreePath)'  ) so far! Please use 'New-PasswordStatePasswordPermission -Permission '$Permission' -ApplyPermissionsForSecurityGroupName '$ApplyPermissionsForSecurityGroupName' -PasswordID '$PasswordID'' to add new permissions."
+                        break
+                    }
+                }
+            }
+            else {
+                Write-PSFMessage -Level Warning -Message "SecurityGroup '$ApplyPermissionsForSecurityGroupName' does not have any permission on Password '$($Permissions.Title)' with ID '$PasswordID' (PasswordList: '$($Permissions.PasswordList)', Path: '$($Permissions.TreePath)'  ) so far! Please use 'New-PasswordStatePasswordPermission -Permission '$Permission' -ApplyPermissionsForSecurityGroupName '$ApplyPermissionsForSecurityGroupName' -PasswordID '$PasswordID'' to add new permissions."
+            }
+        }
+        if ($ApplyPermissionsForSecurityGroupID) {
+            # Cannot validate SecurityGroupID for now because the api has not implemented a possibility to query the IDs of security groups in any method/report
+            Continue
+        }
     }
     process {
         # Build the Custom object to convert to json and send to the api.

--- a/internal/functions/Remove-DiacriticsFromString.ps1
+++ b/internal/functions/Remove-DiacriticsFromString.ps1
@@ -1,4 +1,4 @@
-function Remove-DiacriticsFromString {
+﻿function Remove-DiacriticsFromString {
     [CmdletBinding(DefaultParameterSetName = 'All')]
     param (
         [parameter(ValueFromPipelineByPropertyName, valueFromPipeline, Position = 0, Mandatory = $true)]$InputString

--- a/internal/functions/Remove-DiacriticsFromString.ps1
+++ b/internal/functions/Remove-DiacriticsFromString.ps1
@@ -1,0 +1,17 @@
+function Remove-DiacriticsFromString {
+    [CmdletBinding(DefaultParameterSetName = 'All')]
+    param (
+        [parameter(ValueFromPipelineByPropertyName, valueFromPipeline, Position = 0, Mandatory = $true)]$InputString
+    )
+    # First convert german umlauts and other latin/non-latin diacritics to readable text (not ö to o -> ö to oe)
+    $ReplaceDictionary = @{"ß" = "ss"; "à" = "a"; "á" = "a"; "â" = "a"; "ã" = "a"; "ä" = "ae"; "å" = "a"; "æ" = "ae"; "ç" = "c"; "è" = "e"; "é" = "e"; "ê" = "e"; "ë" = "e"; "ì" = "i"; "í" = "i"; "î" = "i"; "ï" = "i"; "ð" = "d"; "ñ" = "n"; "ò" = "o"; "ó" = "o"; "ô" = "o"; "õ" = "o"; "ö" = "oe"; "ø" = "o"; "ù" = "u"; "ú" = "u"; "û" = "u"; "ü" = "ue"; "ý" = "y"; "þ" = "p"; "ÿ" = "y" }
+
+    foreach ($key in $ReplaceDictionary.Keys) {
+        $InputString = $InputString -Replace ($key, $ReplaceDictionary.$key)
+    }
+    # Second, just to make sure some characters were not in the list, convert the full input string.
+    $InputString = [Text.Encoding]::ASCII.GetString([Text.Encoding]::GetEncoding("Cyrillic").GetBytes($InputString))
+
+    return $InputString
+}
+

--- a/internal/functions/Remove-DiacriticsFromString.ps1
+++ b/internal/functions/Remove-DiacriticsFromString.ps1
@@ -1,17 +1,24 @@
 ﻿function Remove-DiacriticsFromString {
-    [CmdletBinding(DefaultParameterSetName = 'All')]
+    [CmdletBinding(SupportsShouldProcess = $true)]
     param (
         [parameter(ValueFromPipelineByPropertyName, valueFromPipeline, Position = 0, Mandatory = $true)]$InputString
     )
-    # First convert german umlauts and other latin/non-latin diacritics to readable text (not ö to o -> ö to oe)
-    $ReplaceDictionary = @{"ß" = "ss"; "à" = "a"; "á" = "a"; "â" = "a"; "ã" = "a"; "ä" = "ae"; "å" = "a"; "æ" = "ae"; "ç" = "c"; "è" = "e"; "é" = "e"; "ê" = "e"; "ë" = "e"; "ì" = "i"; "í" = "i"; "î" = "i"; "ï" = "i"; "ð" = "d"; "ñ" = "n"; "ò" = "o"; "ó" = "o"; "ô" = "o"; "õ" = "o"; "ö" = "oe"; "ø" = "o"; "ù" = "u"; "ú" = "u"; "û" = "u"; "ü" = "ue"; "ý" = "y"; "þ" = "p"; "ÿ" = "y" }
 
-    foreach ($key in $ReplaceDictionary.Keys) {
-        $InputString = $InputString -Replace ($key, $ReplaceDictionary.$key)
+    Begin { }
+    Process {
+        if ($PSCmdlet.ShouldProcess("InputString:$($InputString)")) {
+            # First convert german umlauts and other latin/non-latin diacritics to readable text (not ö to o -> ö to oe)
+            $ReplaceDictionary = @{"ß" = "ss"; "à" = "a"; "á" = "a"; "â" = "a"; "ã" = "a"; "ä" = "ae"; "å" = "a"; "æ" = "ae"; "ç" = "c"; "è" = "e"; "é" = "e"; "ê" = "e"; "ë" = "e"; "ì" = "i"; "í" = "i"; "î" = "i"; "ï" = "i"; "ð" = "d"; "ñ" = "n"; "ò" = "o"; "ó" = "o"; "ô" = "o"; "õ" = "o"; "ö" = "oe"; "ø" = "o"; "ù" = "u"; "ú" = "u"; "û" = "u"; "ü" = "ue"; "ý" = "y"; "þ" = "p"; "ÿ" = "y" }
+
+            foreach ($key in $ReplaceDictionary.Keys) {
+                $InputString = $InputString -Replace ($key, $ReplaceDictionary.$key)
+            }
+            # Second, just to make sure some characters were not in the list, convert the full input string.
+            $InputString = [Text.Encoding]::ASCII.GetString([Text.Encoding]::GetEncoding("Cyrillic").GetBytes($InputString))
+        }
     }
-    # Second, just to make sure some characters were not in the list, convert the full input string.
-    $InputString = [Text.Encoding]::ASCII.GetString([Text.Encoding]::GetEncoding("Cyrillic").GetBytes($InputString))
-
-    return $InputString
+    end {
+        return $InputString
+    }
 }
 

--- a/passwordstate-management.psd1
+++ b/passwordstate-management.psd1
@@ -71,7 +71,7 @@
     # Functions to export from this module, for best performance, do not use wildcards and do not delete the entry, use an empty array if there are no functions to export.
     FunctionsToExport = @('Get-PasswordStateEnvironment', 'Get-PasswordStateFolder', 'Get-PasswordStateHost', 'Get-PasswordStateList', 'Get-PasswordStatePassword', 'Get-PasswordStatePasswordHistory', 'Get-PasswordStatePermission'
         , 'Invoke-PasswordStateReport'
-        , 'New-PasswordStateADSecurityGroup', 'New-PasswordStateDependency', 'New-PasswordStateDocument', 'New-PasswordStateFolder', 'New-PasswordStateFolderPermission', 'New-PasswordStateHost', 'New-PasswordStateList', 'New-PasswordStateListPermission', 'New-PasswordStatePassword', 'New-PasswordStatePasswordPermission', 'New-RandomPassword'
+        , 'New-PasswordStateADSecurityGroup', 'New-PasswordStateDependency', 'New-PasswordStateDocument', 'New-PasswordStateFolder', 'New-PasswordStateFolderPermission', 'New-PasswordStateHost', 'New-PasswordStateList', 'New-PasswordStateListPermission', 'New-PasswordStatePassword', 'New-PasswordStatePasswordPermission', 'New-PasswordStateSelfDestructMessage', 'New-RandomPassword'
         , 'Remove-PasswordStateFolderPermission', 'Remove-PasswordStateHost', 'Remove-PasswordStateListPermission', 'Remove-PasswordStatePassword', 'Remove-PasswordStatePasswordPermission'
         , 'Save-PasswordStateDocument'
         , 'Set-PasswordStateEnvironment', 'Set-PasswordStateFolderPermission', 'Set-PasswordStateListPermission', 'Set-PasswordStatePassword', 'Set-PasswordStatePasswordPermission'

--- a/tests/general/Help.Exceptions.ps1
+++ b/tests/general/Help.Exceptions.ps1
@@ -24,6 +24,14 @@ $global:FunctionHelpTestExceptions = @(
   , 'Test-PasswordPwned'
   , 'New-PasswordStateResource'
   , 'Remove-PasswordStateResource'
+  , 'Get-PasswordStatePermission'
+  , 'New-PasswordStateListPermission'
+  , 'New-PasswordStatePasswordPermission'
+  , 'Remove-PasswordStateListPermission'
+  , 'Remove-PasswordStatePasswordPermission'
+  , 'Set-PasswordStateListPermission'
+  , 'Set-PasswordStatePassword'
+  , 'Set-PasswordStatePasswordPermission'
 )
 
 <#

--- a/tests/general/Help.Exceptions.ps1
+++ b/tests/general/Help.Exceptions.ps1
@@ -32,6 +32,7 @@ $global:FunctionHelpTestExceptions = @(
   , 'Set-PasswordStateListPermission'
   , 'Set-PasswordStatePassword'
   , 'Set-PasswordStatePasswordPermission'
+  , 'New-PasswordStateSelfDestructMessage'
 )
 
 <#


### PR DESCRIPTION
Major changes:

## Added

- [`New-PasswordStateSelfDestructMessage`](https://github.com/dnewsholme/PasswordState-Management/commit/ffa9922b268286effa5275e1bcf3ef797a4d072a) for sending self destruct messages with the api.
  - [Check Documentation for more information](https://github.com/dnewsholme/PasswordState-Management/commit/693675d71a17a1e4540652247a4206550a29942d)
- Added helper function [Remove-DiacriticsFromString](https://github.com/dnewsholme/PasswordState-Management/commit/e97abf3dcce1b80bcbc4b8a4eaf1da899e0e3f12) to convert german umlauts and other latin/non-latin diacritics to a readable string that the api can understand. By default the api does not understand some german umlauts and some diacritics

## Changed

- [New-PasswordStatePasswordPermission.ps1](https://github.com/dnewsholme/PasswordState-Management/commit/fa9b58c03c1276bb365ee1b8a51e12c2f53b7a46)
  - Added validation if user/group already has access to the desired password object and continue or not.
  - Updated documentation
- [Get-PasswordStateList.ps1](https://github.com/dnewsholme/PasswordState-Management/commit/268cac0eef5ea766cfb5373039885e8005f5b907)
  - Added Reason parameter and fixed api uri if only passwordlistid was specified
  - Updated documentation
- [Get-PasswordStateFolder.ps1](https://github.com/dnewsholme/PasswordState-Management/commit/d14e3592f127464f5d7a7d2a8e3c8a2d24b6e19f)
  - Added possiblity to specifiy a Reason.
  - Added possibility to query for the FolderID directly with the Get-PasswordStateFolder function. (Validating response for the right FolderID and throwing an error if ID was not found)
  - Updated documentation
- [New-PasswordStateADSecurityGroup.ps1](https://github.com/dnewsholme/PasswordState-Management/commit/d6d34ad865314006a4d784e6cace3714156cc422)
  - Fixed Description parameter
  - added reason and error handling
  - Updated documentation
- [Changed [Nullable[System.Int32][]] back to [Nullable[System.Int32]]](https://github.com/dnewsholme/PasswordState-Management/commit/8dff4588544dea168830138547ba0647bad4d5cc)
  - Since the api has some problems (not in every api method) if it is getting an array and not only an integer. For now, until the bug in platyPS is fixed, added the functions to the Exclusion list (full documentation is okay, tested it before)
  - Updated documentation

## Fixed

- [Get-PasswordStatePassword.ps1](https://github.com/dnewsholme/PasswordState-Management/commit/d209ce64b389a9c2e2b77eac8a0f1d9b9b5bb941)
  - Fixed: if only PasswordID is specified, so searching for a specific ID, PreventAuditing is not possible