### PR TITLE
ToPSCredential method will now work with username: username@domain

### DIFF
--- a/internal/functions/PasswordStateClass.ps1
+++ b/internal/functions/PasswordStateClass.ps1
@@ -41,10 +41,15 @@ class PasswordResult {
     }
     [PSCredential]ToPSCredential() {
         $user = ''
-        If (-not ([String]::IsNullOrEmpty($this.Domain))) {
-            $user += "$($this.Domain)\"
+        if ($this.Username -match '(.*)@(.*)') {
+            $user = "$($this.Username)"
         }
-        $user += "$($this.Username)"
+        else {
+            if (-not ([String]::IsNullOrEmpty($this.Domain))) {
+                $user += "$($this.Domain)\"
+            }
+            $user += "$($this.Username)"
+        }
         $result = [String]::IsNullOrEmpty($this.Password.Password)
         If ($this.Password.GetType().Name -ne 'String' -and $result -eq $false) {
             $output = [PSCredential]::new($user, $this.Password.Password)


### PR DESCRIPTION
If a username in format "user@domain" is specified in the username field in passwordmanager the ToPSCredential() method will generate the wrong username because the method will add "domain\\" before the username. Results to: "domain\user@domain" instead of only the username that already includes the domain name.

For some applications the "old" format of domain\username cannot be used.
I added the possibility to check if a "@" symbol is found in the username field. If this is the case the username field will be used as it is. If not and the domain is also found in the passwordmanager username field, the format domain\username will be used.

So it doesn't matter in which format the username is entered into the field, ToPSCredential should now work correctly.

![image](https://user-images.githubusercontent.com/6794362/90873220-13845900-e39e-11ea-9b81-5b552eb2817b.png)

Note: If password resets are used, the entry in the Username field must not contain the domain, only the username (i.e. not domain\user and also not user@domain). This has however nothing to do with the ToPSCredential method.