### PR TITLE
Allow passing across pipeline for existing entries

### DIFF
--- a/docs/New-PasswordStateList.md
+++ b/docs/New-PasswordStateList.md
@@ -410,7 +410,7 @@ When apply permissions to the newly created Password List (for a User or Securit
 Type: String
 Parameter Sets: Permission
 Aliases:
-Accepted values: A, M, V
+Accepted values: A, M, V, A, M, V
 
 Required: True
 Position: 12
@@ -423,7 +423,7 @@ Accept wildcard characters: False
 Type: String
 Parameter Sets: Private
 Aliases:
-Accepted values: A, M, V
+Accepted values: A, M, V, A, M, V
 
 Required: False
 Position: 12

--- a/docs/New-PasswordStatePassword.md
+++ b/docs/New-PasswordStatePassword.md
@@ -20,9 +20,9 @@ New-PasswordStatePassword [-PasswordListID] <Int32> [-Title] <String> [[-Usernam
  [[-GenericField4] <String>] [[-GenericField5] <String>] [[-GenericField6] <String>]
  [[-GenericField7] <String>] [[-GenericField8] <String>] [[-GenericField9] <String>]
  [[-GenericField10] <String>] [-GenerateGenFieldPassword] [[-AddDaysToExpiryDate] <Int32>]
- [[-ScriptID] <Int32>] [[-PrivilegedAccountID] <Int32>] [[-ExpiryDate] <String>] [-AllowExport]
- [[-WebUser_ID] <String>] [[-WebPassword_ID] <String>] [-SkipExistenceCheck] [[-Reason] <String>] [-WhatIf]
- [-Confirm] [<CommonParameters>]
+ [[-ScriptID] <Int32>] [[-PrivilegedAccountID] <Int32>] [[-HostName] <String>] [[-ADDomainNetBIOS] <String>]
+ [[-ExpiryDate] <String>] [-AllowExport] [[-WebUser_ID] <String>] [[-WebPassword_ID] <String>]
+ [-SkipExistenceCheck] [[-Reason] <String>] [-WhatIf] [-Confirm] [<CommonParameters>]
 ```
 
 ### HeartbeatSchedule
@@ -34,9 +34,9 @@ New-PasswordStatePassword [-PasswordListID] <Int32> [-Title] <String> [[-Usernam
  [[-GenericField6] <String>] [[-GenericField7] <String>] [[-GenericField8] <String>]
  [[-GenericField9] <String>] [[-GenericField10] <String>] [-GenerateGenFieldPassword]
  [[-AddDaysToExpiryDate] <Int32>] [[-ScriptID] <Int32>] [[-PrivilegedAccountID] <Int32>]
- [-HeartbeatSchedule] <String> [[-ExpiryDate] <String>] [-AllowExport] [[-WebUser_ID] <String>]
- [[-WebPassword_ID] <String>] [-SkipExistenceCheck] [[-Reason] <String>] [-WhatIf] [-Confirm]
- [<CommonParameters>]
+ [-HeartbeatSchedule] <String> [[-HostName] <String>] [[-ADDomainNetBIOS] <String>] [[-ExpiryDate] <String>]
+ [-AllowExport] [[-WebUser_ID] <String>] [[-WebPassword_ID] <String>] [-SkipExistenceCheck]
+ [[-Reason] <String>] [-WhatIf] [-Confirm] [<CommonParameters>]
 ```
 
 ### Heartbeat
@@ -94,9 +94,9 @@ New-PasswordStatePassword [-PasswordListID] <Int32> [-Title] <String> [[-Usernam
  [[-GenericField4] <String>] [[-GenericField5] <String>] [[-GenericField6] <String>]
  [[-GenericField7] <String>] [[-GenericField8] <String>] [[-GenericField9] <String>]
  [[-GenericField10] <String>] [-GenerateGenFieldPassword] [[-AddDaysToExpiryDate] <Int32>]
- [[-ScriptID] <Int32>] [[-PrivilegedAccountID] <Int32>] [[-ExpiryDate] <String>] [-AllowExport]
- [[-WebUser_ID] <String>] [[-WebPassword_ID] <String>] [-SkipExistenceCheck] [[-Reason] <String>] [-WhatIf]
- [-Confirm] [<CommonParameters>]
+ [[-ScriptID] <Int32>] [[-PrivilegedAccountID] <Int32>] [[-HostName] <String>] [[-ADDomainNetBIOS] <String>]
+ [[-ExpiryDate] <String>] [-AllowExport] [[-WebUser_ID] <String>] [[-WebPassword_ID] <String>]
+ [-SkipExistenceCheck] [[-Reason] <String>] [-WhatIf] [-Confirm] [<CommonParameters>]
 ```
 
 ### GeneratePassword
@@ -107,9 +107,9 @@ New-PasswordStatePassword [-PasswordListID] <Int32> [-Title] <String> [[-Usernam
  [[-GenericField4] <String>] [[-GenericField5] <String>] [[-GenericField6] <String>]
  [[-GenericField7] <String>] [[-GenericField8] <String>] [[-GenericField9] <String>]
  [[-GenericField10] <String>] [-GenerateGenFieldPassword] [[-AddDaysToExpiryDate] <Int32>]
- [[-ScriptID] <Int32>] [[-PrivilegedAccountID] <Int32>] [[-ExpiryDate] <String>] [-AllowExport]
- [[-WebUser_ID] <String>] [[-WebPassword_ID] <String>] [-SkipExistenceCheck] [[-Reason] <String>] [-WhatIf]
- [-Confirm] [<CommonParameters>]
+ [[-ScriptID] <Int32>] [[-PrivilegedAccountID] <Int32>] [[-HostName] <String>] [[-ADDomainNetBIOS] <String>]
+ [[-ExpiryDate] <String>] [-AllowExport] [[-WebUser_ID] <String>] [[-WebPassword_ID] <String>]
+ [-SkipExistenceCheck] [[-Reason] <String>] [-WhatIf] [-Confirm] [<CommonParameters>]
 ```
 
 ## DESCRIPTION
@@ -213,13 +213,13 @@ If the record relates to an Active Directory account, then you must specify the 
 
 ```yaml
 Type: String
-Parameter Sets: Heartbeat, Reset, ResetSchedule
+Parameter Sets: (All)
 Aliases:
 
 Required: False
 Position: 4
 Default value: None
-Accept pipeline input: True (ByPropertyName)
+Accept pipeline input: False
 Accept wildcard characters: False
 ```
 
@@ -569,13 +569,13 @@ If the record relates to account on a Host, then you must specify the Host Name 
 
 ```yaml
 Type: String
-Parameter Sets: Heartbeat, Reset, ResetSchedule
+Parameter Sets: (All)
 Aliases:
 
 Required: False
 Position: 3
 Default value: None
-Accept pipeline input: True (ByPropertyName)
+Accept pipeline input: False
 Accept wildcard characters: False
 ```
 

--- a/docs/Set-PasswordStatePassword.md
+++ b/docs/Set-PasswordStatePassword.md
@@ -20,9 +20,9 @@ Set-PasswordStatePassword [-PasswordID] <Int32> [[-Title] <String>] [[-Username]
  [[-GenericField4] <String>] [[-GenericField5] <String>] [[-GenericField6] <String>]
  [[-GenericField7] <String>] [[-GenericField8] <String>] [[-GenericField9] <String>]
  [[-GenericField10] <String>] [-GenerateGenFieldPassword] [[-AddDaysToExpiryDate] <Int32>]
- [[-ScriptID] <Int32>] [[-PrivilegedAccountID] <Int32>] [[-ExpiryDate] <String>] [-AllowExport]
- [[-WebUser_ID] <String>] [[-WebPassword_ID] <String>] [[-Reason] <String>] [-WhatIf] [-Confirm]
- [<CommonParameters>]
+ [[-ScriptID] <Int32>] [[-PrivilegedAccountID] <Int32>] [[-HostName] <String>] [[-ADDomainNetBIOS] <String>]
+ [[-ExpiryDate] <String>] [-AllowExport] [[-WebUser_ID] <String>] [[-WebPassword_ID] <String>]
+ [[-Reason] <String>] [-WhatIf] [-Confirm] [<CommonParameters>]
 ```
 
 ### HeartbeatSchedule
@@ -34,8 +34,9 @@ Set-PasswordStatePassword [-PasswordID] <Int32> [[-Title] <String>] [[-Username]
  [[-GenericField6] <String>] [[-GenericField7] <String>] [[-GenericField8] <String>]
  [[-GenericField9] <String>] [[-GenericField10] <String>] [-GenerateGenFieldPassword]
  [[-AddDaysToExpiryDate] <Int32>] [[-ScriptID] <Int32>] [[-PrivilegedAccountID] <Int32>]
- [[-HeartbeatSchedule] <String>] [[-ExpiryDate] <String>] [-AllowExport] [[-WebUser_ID] <String>]
- [[-WebPassword_ID] <String>] [[-Reason] <String>] [-WhatIf] [-Confirm] [<CommonParameters>]
+ [[-HeartbeatSchedule] <String>] [[-HostName] <String>] [[-ADDomainNetBIOS] <String>] [[-ExpiryDate] <String>]
+ [-AllowExport] [[-WebUser_ID] <String>] [[-WebPassword_ID] <String>] [[-Reason] <String>] [-WhatIf] [-Confirm]
+ [<CommonParameters>]
 ```
 
 ### Heartbeat
@@ -91,9 +92,9 @@ Set-PasswordStatePassword [-PasswordID] <Int32> [[-Title] <String>] [[-Username]
  [[-GenericField4] <String>] [[-GenericField5] <String>] [[-GenericField6] <String>]
  [[-GenericField7] <String>] [[-GenericField8] <String>] [[-GenericField9] <String>]
  [[-GenericField10] <String>] [-GenerateGenFieldPassword] [-PasswordResetEnabled]
- [[-AddDaysToExpiryDate] <Int32>] [[-ScriptID] <Int32>] [[-PrivilegedAccountID] <Int32>]
- [[-ExpiryDate] <String>] [-AllowExport] [[-WebUser_ID] <String>] [[-WebPassword_ID] <String>]
- [[-Reason] <String>] [-WhatIf] [-Confirm] [<CommonParameters>]
+ [[-AddDaysToExpiryDate] <Int32>] [[-ScriptID] <Int32>] [[-PrivilegedAccountID] <Int32>] [[-HostName] <String>]
+ [[-ADDomainNetBIOS] <String>] [[-ExpiryDate] <String>] [-AllowExport] [[-WebUser_ID] <String>]
+ [[-WebPassword_ID] <String>] [[-Reason] <String>] [-WhatIf] [-Confirm] [<CommonParameters>]
 ```
 
 ### GeneratePassword
@@ -104,9 +105,9 @@ Set-PasswordStatePassword [-PasswordID] <Int32> [[-Title] <String>] [[-Username]
  [[-GenericField4] <String>] [[-GenericField5] <String>] [[-GenericField6] <String>]
  [[-GenericField7] <String>] [[-GenericField8] <String>] [[-GenericField9] <String>]
  [[-GenericField10] <String>] [-GenerateGenFieldPassword] [-PasswordResetEnabled]
- [[-AddDaysToExpiryDate] <Int32>] [[-ScriptID] <Int32>] [[-PrivilegedAccountID] <Int32>]
- [[-ExpiryDate] <String>] [-AllowExport] [[-WebUser_ID] <String>] [[-WebPassword_ID] <String>]
- [[-Reason] <String>] [-WhatIf] [-Confirm] [<CommonParameters>]
+ [[-AddDaysToExpiryDate] <Int32>] [[-ScriptID] <Int32>] [[-PrivilegedAccountID] <Int32>] [[-HostName] <String>]
+ [[-ADDomainNetBIOS] <String>] [[-ExpiryDate] <String>] [-AllowExport] [[-WebUser_ID] <String>]
+ [[-WebPassword_ID] <String>] [[-Reason] <String>] [-WhatIf] [-Confirm] [<CommonParameters>]
 ```
 
 ## DESCRIPTION
@@ -200,13 +201,13 @@ If the record relates to an Active Directory account, then you must specify the 
 
 ```yaml
 Type: String
-Parameter Sets: Heartbeat, Reset, ResetSchedule
+Parameter Sets: (All)
 Aliases:
 
 Required: False
 Position: 4
 Default value: None
-Accept pipeline input: True (ByPropertyName)
+Accept pipeline input: False
 Accept wildcard characters: False
 ```
 
@@ -554,13 +555,13 @@ If the record relates to account on a Host, then you must specify the Host Name 
 
 ```yaml
 Type: String
-Parameter Sets: Heartbeat, Reset, ResetSchedule
+Parameter Sets: (All)
 Aliases:
 
 Required: False
 Position: 3
 Default value: None
-Accept pipeline input: True (ByPropertyName)
+Accept pipeline input: False
 Accept wildcard characters: False
 ```
 

--- a/en-us/passwordstate-management-help.xml
+++ b/en-us/passwordstate-management-help.xml
@@ -4996,6 +4996,12 @@ The following example shows, in PowerShell, how to create a a new Password List,
             <command:parameterValue required="false" command:variableLength="false">A</command:parameterValue>
             <command:parameterValue required="false" command:variableLength="false">M</command:parameterValue>
             <command:parameterValue required="false" command:variableLength="false">V</command:parameterValue>
+            <command:parameterValue required="false" command:variableLength="false">A</command:parameterValue>
+            <command:parameterValue required="false" command:variableLength="false">M</command:parameterValue>
+            <command:parameterValue required="false" command:variableLength="false">V</command:parameterValue>
+            <command:parameterValue required="false" command:variableLength="false">A</command:parameterValue>
+            <command:parameterValue required="false" command:variableLength="false">M</command:parameterValue>
+            <command:parameterValue required="false" command:variableLength="false">V</command:parameterValue>
           </command:parameterValueGroup>
           <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
           <dev:type>
@@ -5274,6 +5280,12 @@ To copy permissions to the Password List from an existing Password List Template
 </maml:para>
           </maml:Description>
           <command:parameterValueGroup>
+            <command:parameterValue required="false" command:variableLength="false">A</command:parameterValue>
+            <command:parameterValue required="false" command:variableLength="false">M</command:parameterValue>
+            <command:parameterValue required="false" command:variableLength="false">V</command:parameterValue>
+            <command:parameterValue required="false" command:variableLength="false">A</command:parameterValue>
+            <command:parameterValue required="false" command:variableLength="false">M</command:parameterValue>
+            <command:parameterValue required="false" command:variableLength="false">V</command:parameterValue>
             <command:parameterValue required="false" command:variableLength="false">A</command:parameterValue>
             <command:parameterValue required="false" command:variableLength="false">M</command:parameterValue>
             <command:parameterValue required="false" command:variableLength="false">V</command:parameterValue>
@@ -6840,465 +6852,6 @@ A for Administrator, M for Modify or V for View permissions.</maml:para>
           </dev:type>
           <dev:defaultValue>0</dev:defaultValue>
         </command:parameter>
-        <command:parameter required="true" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="1" aliases="none">
-          <maml:name>Title</maml:name>
-          <maml:Description>
-            <maml:para>Name of the entry to be created.
-A title to describe the nature of the Password object.</maml:para>
-          </maml:Description>
-          <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
-          <dev:type>
-            <maml:name>String</maml:name>
-            <maml:uri />
-          </dev:type>
-          <dev:defaultValue>None</dev:defaultValue>
-        </command:parameter>
-        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="10" aliases="none">
-          <maml:name>GeneratePassword</maml:name>
-          <maml:Description>
-            <maml:para>A switch parameter to generate the password based of the PasswordList Policy.
-A newly generated random password will be created based on the Password Generator options associated with the Password List. If the Password List is set to use the user's Password Generator options, the Default Password Generator options will be used instead.</maml:para>
-          </maml:Description>
-          <dev:type>
-            <maml:name>SwitchParameter</maml:name>
-            <maml:uri />
-          </dev:type>
-          <dev:defaultValue>False</dev:defaultValue>
-        </command:parameter>
-        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="10" aliases="none">
-          <maml:name>GenericField1</maml:name>
-          <maml:Description>
-            <maml:para>A generic string field which can be renamed to a different value when being displayed in the PasswordState web interface. Note : Generic Fields can be configured as different Field Types, so ensure you pass a valid value for text fields, Select Lists, Radio Buttons or Date Fields.</maml:para>
-          </maml:Description>
-          <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
-          <dev:type>
-            <maml:name>String</maml:name>
-            <maml:uri />
-          </dev:type>
-          <dev:defaultValue>None</dev:defaultValue>
-        </command:parameter>
-        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="11" aliases="none">
-          <maml:name>GenericField2</maml:name>
-          <maml:Description>
-            <maml:para>A generic string field which can be renamed to a different value when being displayed in the PasswordState web interface. Note : Generic Fields can be configured as different Field Types, so ensure you pass a valid value for text fields, Select Lists, Radio Buttons or Date Fields.</maml:para>
-          </maml:Description>
-          <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
-          <dev:type>
-            <maml:name>String</maml:name>
-            <maml:uri />
-          </dev:type>
-          <dev:defaultValue>None</dev:defaultValue>
-        </command:parameter>
-        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="12" aliases="none">
-          <maml:name>GenericField3</maml:name>
-          <maml:Description>
-            <maml:para>A generic string field which can be renamed to a different value when being displayed in the PasswordState web interface. Note : Generic Fields can be configured as different Field Types, so ensure you pass a valid value for text fields, Select Lists, Radio Buttons or Date Fields.</maml:para>
-          </maml:Description>
-          <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
-          <dev:type>
-            <maml:name>String</maml:name>
-            <maml:uri />
-          </dev:type>
-          <dev:defaultValue>None</dev:defaultValue>
-        </command:parameter>
-        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="13" aliases="none">
-          <maml:name>GenericField4</maml:name>
-          <maml:Description>
-            <maml:para>A generic string field which can be renamed to a different value when being displayed in the PasswordState web interface. Note : Generic Fields can be configured as different Field Types, so ensure you pass a valid value for text fields, Select Lists, Radio Buttons or Date Fields.</maml:para>
-          </maml:Description>
-          <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
-          <dev:type>
-            <maml:name>String</maml:name>
-            <maml:uri />
-          </dev:type>
-          <dev:defaultValue>None</dev:defaultValue>
-        </command:parameter>
-        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="14" aliases="none">
-          <maml:name>GenericField5</maml:name>
-          <maml:Description>
-            <maml:para>A generic string field which can be renamed to a different value when being displayed in the PasswordState web interface. Note : Generic Fields can be configured as different Field Types, so ensure you pass a valid value for text fields, Select Lists, Radio Buttons or Date Fields.</maml:para>
-          </maml:Description>
-          <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
-          <dev:type>
-            <maml:name>String</maml:name>
-            <maml:uri />
-          </dev:type>
-          <dev:defaultValue>None</dev:defaultValue>
-        </command:parameter>
-        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="15" aliases="none">
-          <maml:name>GenericField6</maml:name>
-          <maml:Description>
-            <maml:para>A generic string field which can be renamed to a different value when being displayed in the PasswordState web interface. Note : Generic Fields can be configured as different Field Types, so ensure you pass a valid value for text fields, Select Lists, Radio Buttons or Date Fields.</maml:para>
-          </maml:Description>
-          <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
-          <dev:type>
-            <maml:name>String</maml:name>
-            <maml:uri />
-          </dev:type>
-          <dev:defaultValue>None</dev:defaultValue>
-        </command:parameter>
-        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="16" aliases="none">
-          <maml:name>GenericField7</maml:name>
-          <maml:Description>
-            <maml:para>A generic string field which can be renamed to a different value when being displayed in the PasswordState web interface. Note : Generic Fields can be configured as different Field Types, so ensure you pass a valid value for text fields, Select Lists, Radio Buttons or Date Fields.</maml:para>
-          </maml:Description>
-          <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
-          <dev:type>
-            <maml:name>String</maml:name>
-            <maml:uri />
-          </dev:type>
-          <dev:defaultValue>None</dev:defaultValue>
-        </command:parameter>
-        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="17" aliases="none">
-          <maml:name>GenericField8</maml:name>
-          <maml:Description>
-            <maml:para>A generic string field which can be renamed to a different value when being displayed in the PasswordState web interface. Note : Generic Fields can be configured as different Field Types, so ensure you pass a valid value for text fields, Select Lists, Radio Buttons or Date Fields.</maml:para>
-          </maml:Description>
-          <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
-          <dev:type>
-            <maml:name>String</maml:name>
-            <maml:uri />
-          </dev:type>
-          <dev:defaultValue>None</dev:defaultValue>
-        </command:parameter>
-        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="18" aliases="none">
-          <maml:name>GenericField9</maml:name>
-          <maml:Description>
-            <maml:para>A generic string field which can be renamed to a different value when being displayed in the PasswordState web interface. Note : Generic Fields can be configured as different Field Types, so ensure you pass a valid value for text fields, Select Lists, Radio Buttons or Date Fields.</maml:para>
-          </maml:Description>
-          <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
-          <dev:type>
-            <maml:name>String</maml:name>
-            <maml:uri />
-          </dev:type>
-          <dev:defaultValue>None</dev:defaultValue>
-        </command:parameter>
-        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="19" aliases="none">
-          <maml:name>GenericField10</maml:name>
-          <maml:Description>
-            <maml:para>A generic string field which can be renamed to a different value when being displayed in the PasswordState web interface. Note : Generic Fields can be configured as different Field Types, so ensure you pass a valid value for text fields, Select Lists, Radio Buttons or Date Fields.</maml:para>
-          </maml:Description>
-          <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
-          <dev:type>
-            <maml:name>String</maml:name>
-            <maml:uri />
-          </dev:type>
-          <dev:defaultValue>None</dev:defaultValue>
-        </command:parameter>
-        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="2" aliases="none">
-          <maml:name>Username</maml:name>
-          <maml:Description>
-            <maml:para>The username to be added to the entry (Optional).
-Some systems require a username and password to authenticate. This field represents the UserName to do so.</maml:para>
-          </maml:Description>
-          <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
-          <dev:type>
-            <maml:name>String</maml:name>
-            <maml:uri />
-          </dev:type>
-          <dev:defaultValue>None</dev:defaultValue>
-        </command:parameter>
-        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="20" aliases="none">
-          <maml:name>GenerateGenFieldPassword</maml:name>
-          <maml:Description>
-            <maml:para>If set to true, any ' Generic Fields ' which you have set to be of type 'Password ' will have a newly generated random password assigned to it. If the Password List or Generic Field is set to use the user's Password Generator options, the Default Password Generator options will be used instead.</maml:para>
-          </maml:Description>
-          <dev:type>
-            <maml:name>SwitchParameter</maml:name>
-            <maml:uri />
-          </dev:type>
-          <dev:defaultValue>False</dev:defaultValue>
-        </command:parameter>
-        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="21" aliases="none">
-          <maml:name>AddDaysToExpiryDate</maml:name>
-          <maml:Description>
-            <maml:para>Once the password has been changed due to a scheduled reset, you can add an additional (x) number of days to the ExpiryDate field so another reset will occur again in 30, 60, 90 days, etc. This is the option on the Reset Options tab for the record.</maml:para>
-          </maml:Description>
-          <command:parameterValue required="true" variableLength="false">Int32</command:parameterValue>
-          <dev:type>
-            <maml:name>Int32</maml:name>
-            <maml:uri />
-          </dev:type>
-          <dev:defaultValue>None</dev:defaultValue>
-        </command:parameter>
-        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="22" aliases="none">
-          <maml:name>ScriptID</maml:name>
-          <maml:Description>
-            <maml:para>Most accounts require a Password Reset Script to be assigned to them, with the only exception being Active Directory Accounts - not to specify this field for AD Accounts. To look up the values of the ScriptID's, this can be done by using the ' Toggle ID Column Visibility ' button on the Password Reset Scripts screens in PasswordState.</maml:para>
-          </maml:Description>
-          <command:parameterValue required="true" variableLength="false">Int32</command:parameterValue>
-          <dev:type>
-            <maml:name>Int32</maml:name>
-            <maml:uri />
-          </dev:type>
-          <dev:defaultValue>None</dev:defaultValue>
-        </command:parameter>
-        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="23" aliases="none">
-          <maml:name>PrivilegedAccountID</maml:name>
-          <maml:Description>
-            <maml:para>Some Password Reset Scripts also require a `Privileged Account Credential` to be associated with the Password record, to initiate connection and perform the reset. Requirements for Privileged Accounts are documented in the User Manual, under the KB Article section. To look up the value of PrivilegedAccountID's, this can be done on the screen `Administration -&gt; PasswordState Administration -&gt; Privileged Account Credentials`.</maml:para>
-          </maml:Description>
-          <command:parameterValue required="true" variableLength="false">Int32</command:parameterValue>
-          <dev:type>
-            <maml:name>Int32</maml:name>
-            <maml:uri />
-          </dev:type>
-          <dev:defaultValue>None</dev:defaultValue>
-        </command:parameter>
-        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="24" aliases="none">
-          <maml:name>ExpiryDate</maml:name>
-          <maml:Description>
-            <maml:para>The date in which the password value should be reset for this Password object. The date will be displayed in the format specified for the `System Setting option 'Default Locale'`, through the PasswordState web site interface.</maml:para>
-          </maml:Description>
-          <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
-          <dev:type>
-            <maml:name>String</maml:name>
-            <maml:uri />
-          </dev:type>
-          <dev:defaultValue>None</dev:defaultValue>
-        </command:parameter>
-        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="25" aliases="none">
-          <maml:name>AllowExport</maml:name>
-          <maml:Description>
-            <maml:para>Indicates whether this Password object will be exported when the entire Password List contents are exported.
-Only working if "Allow Password List to be Exported" is set on the password list.</maml:para>
-          </maml:Description>
-          <dev:type>
-            <maml:name>SwitchParameter</maml:name>
-            <maml:uri />
-          </dev:type>
-          <dev:defaultValue>False</dev:defaultValue>
-        </command:parameter>
-        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="25" aliases="none">
-          <maml:name>WebPassword_ID</maml:name>
-          <maml:Description>
-            <maml:para>This field is only used in conjunction with the Browser Extensions, and represents the Password field for login pages i.e. the tag name of the Input HTML field.</maml:para>
-          </maml:Description>
-          <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
-          <dev:type>
-            <maml:name>String</maml:name>
-            <maml:uri />
-          </dev:type>
-          <dev:defaultValue>None</dev:defaultValue>
-        </command:parameter>
-        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="25" aliases="none">
-          <maml:name>WebUser_ID</maml:name>
-          <maml:Description>
-            <maml:para>This field is only used in conjunction with the Browser Extensions, and represents the Username field for login pages i.e. the tag name of the Input HTML field.</maml:para>
-          </maml:Description>
-          <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
-          <dev:type>
-            <maml:name>String</maml:name>
-            <maml:uri />
-          </dev:type>
-          <dev:defaultValue>None</dev:defaultValue>
-        </command:parameter>
-        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="26" aliases="none">
-          <maml:name>SkipExistenceCheck</maml:name>
-          <maml:Description>
-            <maml:para>If applied, the script will skip the check if the password entry is already existing. For the check the script uses the Title and Username field. Sometimes it is possible that the Username and Title field should have the same values, then please apply -SkipExistenceCheck.</maml:para>
-          </maml:Description>
-          <dev:type>
-            <maml:name>SwitchParameter</maml:name>
-            <maml:uri />
-          </dev:type>
-          <dev:defaultValue>False</dev:defaultValue>
-        </command:parameter>
-        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="27" aliases="none">
-          <maml:name>Reason</maml:name>
-          <maml:Description>
-            <maml:para>A reason which can be logged for auditing of why a password was updated.</maml:para>
-          </maml:Description>
-          <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
-          <dev:type>
-            <maml:name>String</maml:name>
-            <maml:uri />
-          </dev:type>
-          <dev:defaultValue>None</dev:defaultValue>
-        </command:parameter>
-        <command:parameter required="true" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="3" aliases="none">
-          <maml:name>HeartbeatEnabled</maml:name>
-          <maml:Description>
-            <maml:para>If you want to enable the record to perform regular account heartbeat status update apply this switch.</maml:para>
-          </maml:Description>
-          <dev:type>
-            <maml:name>SwitchParameter</maml:name>
-            <maml:uri />
-          </dev:type>
-          <dev:defaultValue>False</dev:defaultValue>
-        </command:parameter>
-        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="3" aliases="none">
-          <maml:name>HostName</maml:name>
-          <maml:Description>
-            <maml:para>If the record relates to account on a Host, then you must specify the Host Name here, as it is stored on the Hosts screen in PasswordState.</maml:para>
-          </maml:Description>
-          <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
-          <dev:type>
-            <maml:name>String</maml:name>
-            <maml:uri />
-          </dev:type>
-          <dev:defaultValue>None</dev:defaultValue>
-        </command:parameter>
-        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="4" aliases="none">
-          <maml:name>ADDomainNetBIOS</maml:name>
-          <maml:Description>
-            <maml:para>If the record relates to an Active Directory account, then you must specify the Active Directory NetBIOS value here, as it is stored on the `Administration -&gt; PasswordState Administration -&gt; Active Directory Domains` screen in PasswordState.</maml:para>
-          </maml:Description>
-          <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
-          <dev:type>
-            <maml:name>String</maml:name>
-            <maml:uri />
-          </dev:type>
-          <dev:defaultValue>None</dev:defaultValue>
-        </command:parameter>
-        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="4" aliases="none">
-          <maml:name>Description</maml:name>
-          <maml:Description>
-            <maml:para>Custom description to be added to the password.
-Can be used as a longer verbose description of the nature of the Password object</maml:para>
-          </maml:Description>
-          <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
-          <dev:type>
-            <maml:name>String</maml:name>
-            <maml:uri />
-          </dev:type>
-          <dev:defaultValue>None</dev:defaultValue>
-        </command:parameter>
-        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="5" aliases="none">
-          <maml:name>HeartbeatSchedule</maml:name>
-          <maml:Description>
-            <maml:para>This field allows you to set the schedule for the account heartbeat status update. Specify values in the format of 23:10, or 04:00, etc. (Range: 00:00-23:59)</maml:para>
-          </maml:Description>
-          <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
-          <dev:type>
-            <maml:name>String</maml:name>
-            <maml:uri />
-          </dev:type>
-          <dev:defaultValue>None</dev:defaultValue>
-        </command:parameter>
-        <command:parameter required="true" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="5" aliases="none">
-          <maml:name>ValidationScriptID</maml:name>
-          <maml:Description>
-            <maml:para>When enabling Account Heartbeat, you must associate the correct Password Validation Script to the record (all account types require a Validation Script to be selected). To look up the values of the ValidationScriptID's, this can be done by using the ' Toggle ID Column Visibility ' button on the Password Validation Scripts screens in PasswordState.</maml:para>
-          </maml:Description>
-          <command:parameterValue required="true" variableLength="false">Int32</command:parameterValue>
-          <dev:type>
-            <maml:name>Int32</maml:name>
-            <maml:uri />
-          </dev:type>
-          <dev:defaultValue>None</dev:defaultValue>
-        </command:parameter>
-        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="6" aliases="none">
-          <maml:name>Notes</maml:name>
-          <maml:Description>
-            <maml:para>A generic Notes field where additional descriptive text can be added.</maml:para>
-          </maml:Description>
-          <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
-          <dev:type>
-            <maml:name>String</maml:name>
-            <maml:uri />
-          </dev:type>
-          <dev:defaultValue>None</dev:defaultValue>
-        </command:parameter>
-        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="7" aliases="none">
-          <maml:name>Url</maml:name>
-          <maml:Description>
-            <maml:para>URL parameter where you can specify the URL for HTTP, HTTPS, FTP, SFTP, etc. to be added to the entry if relevant.
-</maml:para>
-          </maml:Description>
-          <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
-          <dev:type>
-            <maml:name>String</maml:name>
-            <maml:uri />
-          </dev:type>
-          <dev:defaultValue>None</dev:defaultValue>
-        </command:parameter>
-        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="8" aliases="none">
-          <maml:name>AccountType</maml:name>
-          <maml:Description>
-            <maml:para>The name of the Account Type if one has been chosen for the Password record.
-You can either specify the AccountType or AccountTypeID if needed when adding password records. Account Types and their ID values can be seen on the screen `Administration -&gt; Passwordstate Administration -&gt; Images and Account Types`, and click on the ' Toggle ID Column Visibility ' button to determine the appropriate value.</maml:para>
-          </maml:Description>
-          <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
-          <dev:type>
-            <maml:name>String</maml:name>
-            <maml:uri />
-          </dev:type>
-          <dev:defaultValue>None</dev:defaultValue>
-        </command:parameter>
-        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="8" aliases="none">
-          <maml:name>ValidateWithPrivAccount</maml:name>
-          <maml:Description>
-            <maml:para>This field is only used for Linux accounts , and when set to True, the Privileged Account Credential will be used for Authentication when performing Account Heartbeats - useful for accounts like root which generally are not allowed to be used for SSH.</maml:para>
-          </maml:Description>
-          <dev:type>
-            <maml:name>SwitchParameter</maml:name>
-            <maml:uri />
-          </dev:type>
-          <dev:defaultValue>False</dev:defaultValue>
-        </command:parameter>
-        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="9" aliases="none">
-          <maml:name>AccountTypeID</maml:name>
-          <maml:Description>
-            <maml:para>The ID value representing the Account Type image (derived from the AccountTypes table). An AccountTypeID of 0 (zero) means there is no associated Account Type image for this Password.
-You can either specify the AccountType or AccountTypeID if needed when adding password records. Account Types and their ID values can be seen on the screen `Administration -&gt; Passwordstate Administration -&gt; Images and Account Types`, and click on the ' Toggle ID Column Visibility ' button to determine the appropriate value.</maml:para>
-          </maml:Description>
-          <command:parameterValue required="true" variableLength="false">Int32</command:parameterValue>
-          <dev:type>
-            <maml:name>Int32</maml:name>
-            <maml:uri />
-          </dev:type>
-          <dev:defaultValue>None</dev:defaultValue>
-        </command:parameter>
-        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="9" aliases="none">
-          <maml:name>Password</maml:name>
-          <maml:Description>
-            <maml:para>The password to be added to the entry (stored as encrypted binary field in database).</maml:para>
-          </maml:Description>
-          <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
-          <dev:type>
-            <maml:name>String</maml:name>
-            <maml:uri />
-          </dev:type>
-          <dev:defaultValue>None</dev:defaultValue>
-        </command:parameter>
-        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="cf">
-          <maml:name>Confirm</maml:name>
-          <maml:Description>
-            <maml:para>Prompts you for confirmation before running the cmdlet.</maml:para>
-          </maml:Description>
-          <dev:type>
-            <maml:name>SwitchParameter</maml:name>
-            <maml:uri />
-          </dev:type>
-          <dev:defaultValue>False</dev:defaultValue>
-        </command:parameter>
-        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="wi">
-          <maml:name>WhatIf</maml:name>
-          <maml:Description>
-            <maml:para>Shows what would happen if the cmdlet runs. The cmdlet is not run.</maml:para>
-          </maml:Description>
-          <dev:type>
-            <maml:name>SwitchParameter</maml:name>
-            <maml:uri />
-          </dev:type>
-          <dev:defaultValue>False</dev:defaultValue>
-        </command:parameter>
-      </command:syntaxItem>
-      <command:syntaxItem>
-        <maml:name>New-PasswordStatePassword</maml:name>
-        <command:parameter required="true" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="0" aliases="none">
-          <maml:name>PasswordListID</maml:name>
-          <maml:Description>
-            <maml:para>The unique ID of the password list which to place the entry in.</maml:para>
-          </maml:Description>
-          <command:parameterValue required="true" variableLength="false">Int32</command:parameterValue>
-          <dev:type>
-            <maml:name>Int32</maml:name>
-            <maml:uri />
-          </dev:type>
-          <dev:defaultValue>0</dev:defaultValue>
-        </command:parameter>
         <command:parameter required="true" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="0" aliases="none">
           <maml:name>PasswordResetEnabled</maml:name>
           <maml:Description>
@@ -7620,7 +7173,7 @@ Only working if "Allow Password List to be Exported" is set on the password list
           </dev:type>
           <dev:defaultValue>False</dev:defaultValue>
         </command:parameter>
-        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="3" aliases="none">
+        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="3" aliases="none">
           <maml:name>HostName</maml:name>
           <maml:Description>
             <maml:para>If the record relates to account on a Host, then you must specify the Host Name here, as it is stored on the Hosts screen in PasswordState.</maml:para>
@@ -7632,7 +7185,7 @@ Only working if "Allow Password List to be Exported" is set on the password list
           </dev:type>
           <dev:defaultValue>None</dev:defaultValue>
         </command:parameter>
-        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="4" aliases="none">
+        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="4" aliases="none">
           <maml:name>ADDomainNetBIOS</maml:name>
           <maml:Description>
             <maml:para>If the record relates to an Active Directory account, then you must specify the Active Directory NetBIOS value here, as it is stored on the `Administration -&gt; PasswordState Administration -&gt; Active Directory Domains` screen in PasswordState.</maml:para>
@@ -8102,7 +7655,7 @@ Only working if "Allow Password List to be Exported" is set on the password list
           </dev:type>
           <dev:defaultValue>False</dev:defaultValue>
         </command:parameter>
-        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="3" aliases="none">
+        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="3" aliases="none">
           <maml:name>HostName</maml:name>
           <maml:Description>
             <maml:para>If the record relates to account on a Host, then you must specify the Host Name here, as it is stored on the Hosts screen in PasswordState.</maml:para>
@@ -8114,7 +7667,7 @@ Only working if "Allow Password List to be Exported" is set on the password list
           </dev:type>
           <dev:defaultValue>None</dev:defaultValue>
         </command:parameter>
-        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="4" aliases="none">
+        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="4" aliases="none">
           <maml:name>ADDomainNetBIOS</maml:name>
           <maml:Description>
             <maml:para>If the record relates to an Active Directory account, then you must specify the Active Directory NetBIOS value here, as it is stored on the `Administration -&gt; PasswordState Administration -&gt; Active Directory Domains` screen in PasswordState.</maml:para>
@@ -8550,6 +8103,30 @@ Only working if "Allow Password List to be Exported" is set on the password list
           </dev:type>
           <dev:defaultValue>None</dev:defaultValue>
         </command:parameter>
+        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="3" aliases="none">
+          <maml:name>HostName</maml:name>
+          <maml:Description>
+            <maml:para>If the record relates to account on a Host, then you must specify the Host Name here, as it is stored on the Hosts screen in PasswordState.</maml:para>
+          </maml:Description>
+          <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+          <dev:type>
+            <maml:name>String</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="4" aliases="none">
+          <maml:name>ADDomainNetBIOS</maml:name>
+          <maml:Description>
+            <maml:para>If the record relates to an Active Directory account, then you must specify the Active Directory NetBIOS value here, as it is stored on the `Administration -&gt; PasswordState Administration -&gt; Active Directory Domains` screen in PasswordState.</maml:para>
+          </maml:Description>
+          <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+          <dev:type>
+            <maml:name>String</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
         <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="4" aliases="none">
           <maml:name>Description</maml:name>
           <maml:Description>
@@ -8612,6 +8189,465 @@ You can either specify the AccountType or AccountTypeID if needed when adding pa
             <maml:uri />
           </dev:type>
           <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="9" aliases="none">
+          <maml:name>AccountTypeID</maml:name>
+          <maml:Description>
+            <maml:para>The ID value representing the Account Type image (derived from the AccountTypes table). An AccountTypeID of 0 (zero) means there is no associated Account Type image for this Password.
+You can either specify the AccountType or AccountTypeID if needed when adding password records. Account Types and their ID values can be seen on the screen `Administration -&gt; Passwordstate Administration -&gt; Images and Account Types`, and click on the ' Toggle ID Column Visibility ' button to determine the appropriate value.</maml:para>
+          </maml:Description>
+          <command:parameterValue required="true" variableLength="false">Int32</command:parameterValue>
+          <dev:type>
+            <maml:name>Int32</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="9" aliases="none">
+          <maml:name>Password</maml:name>
+          <maml:Description>
+            <maml:para>The password to be added to the entry (stored as encrypted binary field in database).</maml:para>
+          </maml:Description>
+          <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+          <dev:type>
+            <maml:name>String</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="cf">
+          <maml:name>Confirm</maml:name>
+          <maml:Description>
+            <maml:para>Prompts you for confirmation before running the cmdlet.</maml:para>
+          </maml:Description>
+          <dev:type>
+            <maml:name>SwitchParameter</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>False</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="wi">
+          <maml:name>WhatIf</maml:name>
+          <maml:Description>
+            <maml:para>Shows what would happen if the cmdlet runs. The cmdlet is not run.</maml:para>
+          </maml:Description>
+          <dev:type>
+            <maml:name>SwitchParameter</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>False</dev:defaultValue>
+        </command:parameter>
+      </command:syntaxItem>
+      <command:syntaxItem>
+        <maml:name>New-PasswordStatePassword</maml:name>
+        <command:parameter required="true" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="0" aliases="none">
+          <maml:name>PasswordListID</maml:name>
+          <maml:Description>
+            <maml:para>The unique ID of the password list which to place the entry in.</maml:para>
+          </maml:Description>
+          <command:parameterValue required="true" variableLength="false">Int32</command:parameterValue>
+          <dev:type>
+            <maml:name>Int32</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>0</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="true" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="1" aliases="none">
+          <maml:name>Title</maml:name>
+          <maml:Description>
+            <maml:para>Name of the entry to be created.
+A title to describe the nature of the Password object.</maml:para>
+          </maml:Description>
+          <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+          <dev:type>
+            <maml:name>String</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="10" aliases="none">
+          <maml:name>GeneratePassword</maml:name>
+          <maml:Description>
+            <maml:para>A switch parameter to generate the password based of the PasswordList Policy.
+A newly generated random password will be created based on the Password Generator options associated with the Password List. If the Password List is set to use the user's Password Generator options, the Default Password Generator options will be used instead.</maml:para>
+          </maml:Description>
+          <dev:type>
+            <maml:name>SwitchParameter</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>False</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="10" aliases="none">
+          <maml:name>GenericField1</maml:name>
+          <maml:Description>
+            <maml:para>A generic string field which can be renamed to a different value when being displayed in the PasswordState web interface. Note : Generic Fields can be configured as different Field Types, so ensure you pass a valid value for text fields, Select Lists, Radio Buttons or Date Fields.</maml:para>
+          </maml:Description>
+          <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+          <dev:type>
+            <maml:name>String</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="11" aliases="none">
+          <maml:name>GenericField2</maml:name>
+          <maml:Description>
+            <maml:para>A generic string field which can be renamed to a different value when being displayed in the PasswordState web interface. Note : Generic Fields can be configured as different Field Types, so ensure you pass a valid value for text fields, Select Lists, Radio Buttons or Date Fields.</maml:para>
+          </maml:Description>
+          <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+          <dev:type>
+            <maml:name>String</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="12" aliases="none">
+          <maml:name>GenericField3</maml:name>
+          <maml:Description>
+            <maml:para>A generic string field which can be renamed to a different value when being displayed in the PasswordState web interface. Note : Generic Fields can be configured as different Field Types, so ensure you pass a valid value for text fields, Select Lists, Radio Buttons or Date Fields.</maml:para>
+          </maml:Description>
+          <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+          <dev:type>
+            <maml:name>String</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="13" aliases="none">
+          <maml:name>GenericField4</maml:name>
+          <maml:Description>
+            <maml:para>A generic string field which can be renamed to a different value when being displayed in the PasswordState web interface. Note : Generic Fields can be configured as different Field Types, so ensure you pass a valid value for text fields, Select Lists, Radio Buttons or Date Fields.</maml:para>
+          </maml:Description>
+          <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+          <dev:type>
+            <maml:name>String</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="14" aliases="none">
+          <maml:name>GenericField5</maml:name>
+          <maml:Description>
+            <maml:para>A generic string field which can be renamed to a different value when being displayed in the PasswordState web interface. Note : Generic Fields can be configured as different Field Types, so ensure you pass a valid value for text fields, Select Lists, Radio Buttons or Date Fields.</maml:para>
+          </maml:Description>
+          <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+          <dev:type>
+            <maml:name>String</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="15" aliases="none">
+          <maml:name>GenericField6</maml:name>
+          <maml:Description>
+            <maml:para>A generic string field which can be renamed to a different value when being displayed in the PasswordState web interface. Note : Generic Fields can be configured as different Field Types, so ensure you pass a valid value for text fields, Select Lists, Radio Buttons or Date Fields.</maml:para>
+          </maml:Description>
+          <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+          <dev:type>
+            <maml:name>String</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="16" aliases="none">
+          <maml:name>GenericField7</maml:name>
+          <maml:Description>
+            <maml:para>A generic string field which can be renamed to a different value when being displayed in the PasswordState web interface. Note : Generic Fields can be configured as different Field Types, so ensure you pass a valid value for text fields, Select Lists, Radio Buttons or Date Fields.</maml:para>
+          </maml:Description>
+          <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+          <dev:type>
+            <maml:name>String</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="17" aliases="none">
+          <maml:name>GenericField8</maml:name>
+          <maml:Description>
+            <maml:para>A generic string field which can be renamed to a different value when being displayed in the PasswordState web interface. Note : Generic Fields can be configured as different Field Types, so ensure you pass a valid value for text fields, Select Lists, Radio Buttons or Date Fields.</maml:para>
+          </maml:Description>
+          <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+          <dev:type>
+            <maml:name>String</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="18" aliases="none">
+          <maml:name>GenericField9</maml:name>
+          <maml:Description>
+            <maml:para>A generic string field which can be renamed to a different value when being displayed in the PasswordState web interface. Note : Generic Fields can be configured as different Field Types, so ensure you pass a valid value for text fields, Select Lists, Radio Buttons or Date Fields.</maml:para>
+          </maml:Description>
+          <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+          <dev:type>
+            <maml:name>String</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="19" aliases="none">
+          <maml:name>GenericField10</maml:name>
+          <maml:Description>
+            <maml:para>A generic string field which can be renamed to a different value when being displayed in the PasswordState web interface. Note : Generic Fields can be configured as different Field Types, so ensure you pass a valid value for text fields, Select Lists, Radio Buttons or Date Fields.</maml:para>
+          </maml:Description>
+          <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+          <dev:type>
+            <maml:name>String</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="2" aliases="none">
+          <maml:name>Username</maml:name>
+          <maml:Description>
+            <maml:para>The username to be added to the entry (Optional).
+Some systems require a username and password to authenticate. This field represents the UserName to do so.</maml:para>
+          </maml:Description>
+          <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+          <dev:type>
+            <maml:name>String</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="20" aliases="none">
+          <maml:name>GenerateGenFieldPassword</maml:name>
+          <maml:Description>
+            <maml:para>If set to true, any ' Generic Fields ' which you have set to be of type 'Password ' will have a newly generated random password assigned to it. If the Password List or Generic Field is set to use the user's Password Generator options, the Default Password Generator options will be used instead.</maml:para>
+          </maml:Description>
+          <dev:type>
+            <maml:name>SwitchParameter</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>False</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="21" aliases="none">
+          <maml:name>AddDaysToExpiryDate</maml:name>
+          <maml:Description>
+            <maml:para>Once the password has been changed due to a scheduled reset, you can add an additional (x) number of days to the ExpiryDate field so another reset will occur again in 30, 60, 90 days, etc. This is the option on the Reset Options tab for the record.</maml:para>
+          </maml:Description>
+          <command:parameterValue required="true" variableLength="false">Int32</command:parameterValue>
+          <dev:type>
+            <maml:name>Int32</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="22" aliases="none">
+          <maml:name>ScriptID</maml:name>
+          <maml:Description>
+            <maml:para>Most accounts require a Password Reset Script to be assigned to them, with the only exception being Active Directory Accounts - not to specify this field for AD Accounts. To look up the values of the ScriptID's, this can be done by using the ' Toggle ID Column Visibility ' button on the Password Reset Scripts screens in PasswordState.</maml:para>
+          </maml:Description>
+          <command:parameterValue required="true" variableLength="false">Int32</command:parameterValue>
+          <dev:type>
+            <maml:name>Int32</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="23" aliases="none">
+          <maml:name>PrivilegedAccountID</maml:name>
+          <maml:Description>
+            <maml:para>Some Password Reset Scripts also require a `Privileged Account Credential` to be associated with the Password record, to initiate connection and perform the reset. Requirements for Privileged Accounts are documented in the User Manual, under the KB Article section. To look up the value of PrivilegedAccountID's, this can be done on the screen `Administration -&gt; PasswordState Administration -&gt; Privileged Account Credentials`.</maml:para>
+          </maml:Description>
+          <command:parameterValue required="true" variableLength="false">Int32</command:parameterValue>
+          <dev:type>
+            <maml:name>Int32</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="24" aliases="none">
+          <maml:name>ExpiryDate</maml:name>
+          <maml:Description>
+            <maml:para>The date in which the password value should be reset for this Password object. The date will be displayed in the format specified for the `System Setting option 'Default Locale'`, through the PasswordState web site interface.</maml:para>
+          </maml:Description>
+          <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+          <dev:type>
+            <maml:name>String</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="25" aliases="none">
+          <maml:name>AllowExport</maml:name>
+          <maml:Description>
+            <maml:para>Indicates whether this Password object will be exported when the entire Password List contents are exported.
+Only working if "Allow Password List to be Exported" is set on the password list.</maml:para>
+          </maml:Description>
+          <dev:type>
+            <maml:name>SwitchParameter</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>False</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="25" aliases="none">
+          <maml:name>WebPassword_ID</maml:name>
+          <maml:Description>
+            <maml:para>This field is only used in conjunction with the Browser Extensions, and represents the Password field for login pages i.e. the tag name of the Input HTML field.</maml:para>
+          </maml:Description>
+          <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+          <dev:type>
+            <maml:name>String</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="25" aliases="none">
+          <maml:name>WebUser_ID</maml:name>
+          <maml:Description>
+            <maml:para>This field is only used in conjunction with the Browser Extensions, and represents the Username field for login pages i.e. the tag name of the Input HTML field.</maml:para>
+          </maml:Description>
+          <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+          <dev:type>
+            <maml:name>String</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="26" aliases="none">
+          <maml:name>SkipExistenceCheck</maml:name>
+          <maml:Description>
+            <maml:para>If applied, the script will skip the check if the password entry is already existing. For the check the script uses the Title and Username field. Sometimes it is possible that the Username and Title field should have the same values, then please apply -SkipExistenceCheck.</maml:para>
+          </maml:Description>
+          <dev:type>
+            <maml:name>SwitchParameter</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>False</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="27" aliases="none">
+          <maml:name>Reason</maml:name>
+          <maml:Description>
+            <maml:para>A reason which can be logged for auditing of why a password was updated.</maml:para>
+          </maml:Description>
+          <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+          <dev:type>
+            <maml:name>String</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="true" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="3" aliases="none">
+          <maml:name>HeartbeatEnabled</maml:name>
+          <maml:Description>
+            <maml:para>If you want to enable the record to perform regular account heartbeat status update apply this switch.</maml:para>
+          </maml:Description>
+          <dev:type>
+            <maml:name>SwitchParameter</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>False</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="3" aliases="none">
+          <maml:name>HostName</maml:name>
+          <maml:Description>
+            <maml:para>If the record relates to account on a Host, then you must specify the Host Name here, as it is stored on the Hosts screen in PasswordState.</maml:para>
+          </maml:Description>
+          <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+          <dev:type>
+            <maml:name>String</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="4" aliases="none">
+          <maml:name>ADDomainNetBIOS</maml:name>
+          <maml:Description>
+            <maml:para>If the record relates to an Active Directory account, then you must specify the Active Directory NetBIOS value here, as it is stored on the `Administration -&gt; PasswordState Administration -&gt; Active Directory Domains` screen in PasswordState.</maml:para>
+          </maml:Description>
+          <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+          <dev:type>
+            <maml:name>String</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="4" aliases="none">
+          <maml:name>Description</maml:name>
+          <maml:Description>
+            <maml:para>Custom description to be added to the password.
+Can be used as a longer verbose description of the nature of the Password object</maml:para>
+          </maml:Description>
+          <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+          <dev:type>
+            <maml:name>String</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="5" aliases="none">
+          <maml:name>HeartbeatSchedule</maml:name>
+          <maml:Description>
+            <maml:para>This field allows you to set the schedule for the account heartbeat status update. Specify values in the format of 23:10, or 04:00, etc. (Range: 00:00-23:59)</maml:para>
+          </maml:Description>
+          <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+          <dev:type>
+            <maml:name>String</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="true" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="5" aliases="none">
+          <maml:name>ValidationScriptID</maml:name>
+          <maml:Description>
+            <maml:para>When enabling Account Heartbeat, you must associate the correct Password Validation Script to the record (all account types require a Validation Script to be selected). To look up the values of the ValidationScriptID's, this can be done by using the ' Toggle ID Column Visibility ' button on the Password Validation Scripts screens in PasswordState.</maml:para>
+          </maml:Description>
+          <command:parameterValue required="true" variableLength="false">Int32</command:parameterValue>
+          <dev:type>
+            <maml:name>Int32</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="6" aliases="none">
+          <maml:name>Notes</maml:name>
+          <maml:Description>
+            <maml:para>A generic Notes field where additional descriptive text can be added.</maml:para>
+          </maml:Description>
+          <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+          <dev:type>
+            <maml:name>String</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="7" aliases="none">
+          <maml:name>Url</maml:name>
+          <maml:Description>
+            <maml:para>URL parameter where you can specify the URL for HTTP, HTTPS, FTP, SFTP, etc. to be added to the entry if relevant.
+</maml:para>
+          </maml:Description>
+          <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+          <dev:type>
+            <maml:name>String</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="8" aliases="none">
+          <maml:name>AccountType</maml:name>
+          <maml:Description>
+            <maml:para>The name of the Account Type if one has been chosen for the Password record.
+You can either specify the AccountType or AccountTypeID if needed when adding password records. Account Types and their ID values can be seen on the screen `Administration -&gt; Passwordstate Administration -&gt; Images and Account Types`, and click on the ' Toggle ID Column Visibility ' button to determine the appropriate value.</maml:para>
+          </maml:Description>
+          <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+          <dev:type>
+            <maml:name>String</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="8" aliases="none">
+          <maml:name>ValidateWithPrivAccount</maml:name>
+          <maml:Description>
+            <maml:para>This field is only used for Linux accounts , and when set to True, the Privileged Account Credential will be used for Authentication when performing Account Heartbeats - useful for accounts like root which generally are not allowed to be used for SSH.</maml:para>
+          </maml:Description>
+          <dev:type>
+            <maml:name>SwitchParameter</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>False</dev:defaultValue>
         </command:parameter>
         <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="9" aliases="none">
           <maml:name>AccountTypeID</maml:name>
@@ -8951,6 +8987,30 @@ Only working if "Allow Password List to be Exported" is set on the password list
           </dev:type>
           <dev:defaultValue>None</dev:defaultValue>
         </command:parameter>
+        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="3" aliases="none">
+          <maml:name>HostName</maml:name>
+          <maml:Description>
+            <maml:para>If the record relates to account on a Host, then you must specify the Host Name here, as it is stored on the Hosts screen in PasswordState.</maml:para>
+          </maml:Description>
+          <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+          <dev:type>
+            <maml:name>String</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="4" aliases="none">
+          <maml:name>ADDomainNetBIOS</maml:name>
+          <maml:Description>
+            <maml:para>If the record relates to an Active Directory account, then you must specify the Active Directory NetBIOS value here, as it is stored on the `Administration -&gt; PasswordState Administration -&gt; Active Directory Domains` screen in PasswordState.</maml:para>
+          </maml:Description>
+          <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+          <dev:type>
+            <maml:name>String</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
         <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="4" aliases="none">
           <maml:name>Description</maml:name>
           <maml:Description>
@@ -9316,6 +9376,30 @@ Only working if "Allow Password List to be Exported" is set on the password list
           </dev:type>
           <dev:defaultValue>None</dev:defaultValue>
         </command:parameter>
+        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="3" aliases="none">
+          <maml:name>HostName</maml:name>
+          <maml:Description>
+            <maml:para>If the record relates to account on a Host, then you must specify the Host Name here, as it is stored on the Hosts screen in PasswordState.</maml:para>
+          </maml:Description>
+          <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+          <dev:type>
+            <maml:name>String</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="4" aliases="none">
+          <maml:name>ADDomainNetBIOS</maml:name>
+          <maml:Description>
+            <maml:para>If the record relates to an Active Directory account, then you must specify the Active Directory NetBIOS value here, as it is stored on the `Administration -&gt; PasswordState Administration -&gt; Active Directory Domains` screen in PasswordState.</maml:para>
+          </maml:Description>
+          <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+          <dev:type>
+            <maml:name>String</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
         <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="4" aliases="none">
           <maml:name>Description</maml:name>
           <maml:Description>
@@ -9455,7 +9539,7 @@ You can either specify the AccountType or AccountTypeID if needed when adding pa
         </dev:type>
         <dev:defaultValue>None</dev:defaultValue>
       </command:parameter>
-      <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="4" aliases="none">
+      <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="4" aliases="none">
         <maml:name>ADDomainNetBIOS</maml:name>
         <maml:Description>
           <maml:para>If the record relates to an Active Directory account, then you must specify the Active Directory NetBIOS value here, as it is stored on the `Administration -&gt; PasswordState Administration -&gt; Active Directory Domains` screen in PasswordState.</maml:para>
@@ -9686,7 +9770,7 @@ A newly generated random password will be created based on the Password Generato
         </dev:type>
         <dev:defaultValue>None</dev:defaultValue>
       </command:parameter>
-      <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="3" aliases="none">
+      <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="3" aliases="none">
         <maml:name>HostName</maml:name>
         <maml:Description>
           <maml:para>If the record relates to account on a Host, then you must specify the Host Name here, as it is stored on the Hosts screen in PasswordState.</maml:para>
@@ -13798,464 +13882,6 @@ If the password record being updated is 'Managed', in that it is enabled to perf
           </dev:type>
           <dev:defaultValue>0</dev:defaultValue>
         </command:parameter>
-        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="1" aliases="none">
-          <maml:name>Title</maml:name>
-          <maml:Description>
-            <maml:para>Name of the entry to be updated.
-A title to describe the nature of the Password object.</maml:para>
-          </maml:Description>
-          <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
-          <dev:type>
-            <maml:name>String</maml:name>
-            <maml:uri />
-          </dev:type>
-          <dev:defaultValue>None</dev:defaultValue>
-        </command:parameter>
-        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="10" aliases="none">
-          <maml:name>GeneratePassword</maml:name>
-          <maml:Description>
-            <maml:para>A switch parameter to generate the password based of the PasswordList Policy.
-A newly generated random password will be created based on the Password Generator options associated with the Password List. If the Password List is set to use the user's Password Generator options, the Default Password Generator options will be used instead.</maml:para>
-          </maml:Description>
-          <dev:type>
-            <maml:name>SwitchParameter</maml:name>
-            <maml:uri />
-          </dev:type>
-          <dev:defaultValue>False</dev:defaultValue>
-        </command:parameter>
-        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="10" aliases="none">
-          <maml:name>GenericField1</maml:name>
-          <maml:Description>
-            <maml:para>An optional parameter to set the generic field value.
-A generic field is a string field which can be renamed to a different value when being displayed in the PasswordState web interface. Note : Generic Fields can be configured as different Field Types, so ensure you pass a valid value for text fields, Select Lists, Radio Buttons or Date Fields.</maml:para>
-          </maml:Description>
-          <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
-          <dev:type>
-            <maml:name>String</maml:name>
-            <maml:uri />
-          </dev:type>
-          <dev:defaultValue>None</dev:defaultValue>
-        </command:parameter>
-        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="11" aliases="none">
-          <maml:name>GenericField2</maml:name>
-          <maml:Description>
-            <maml:para>An optional parameter to set the generic field value.
-A generic field is a string field which can be renamed to a different value when being displayed in the PasswordState web interface. Note : Generic Fields can be configured as different Field Types, so ensure you pass a valid value for text fields, Select Lists, Radio Buttons or Date Fields.</maml:para>
-          </maml:Description>
-          <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
-          <dev:type>
-            <maml:name>String</maml:name>
-            <maml:uri />
-          </dev:type>
-          <dev:defaultValue>None</dev:defaultValue>
-        </command:parameter>
-        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="12" aliases="none">
-          <maml:name>GenericField3</maml:name>
-          <maml:Description>
-            <maml:para>An optional parameter to set the generic field value.
-A generic field is a string field which can be renamed to a different value when being displayed in the PasswordState web interface. Note : Generic Fields can be configured as different Field Types, so ensure you pass a valid value for text fields, Select Lists, Radio Buttons or Date Fields.</maml:para>
-          </maml:Description>
-          <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
-          <dev:type>
-            <maml:name>String</maml:name>
-            <maml:uri />
-          </dev:type>
-          <dev:defaultValue>None</dev:defaultValue>
-        </command:parameter>
-        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="13" aliases="none">
-          <maml:name>GenericField4</maml:name>
-          <maml:Description>
-            <maml:para>An optional parameter to set the generic field value.
-A generic field is a string field which can be renamed to a different value when being displayed in the PasswordState web interface. Note : Generic Fields can be configured as different Field Types, so ensure you pass a valid value for text fields, Select Lists, Radio Buttons or Date Fields.</maml:para>
-          </maml:Description>
-          <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
-          <dev:type>
-            <maml:name>String</maml:name>
-            <maml:uri />
-          </dev:type>
-          <dev:defaultValue>None</dev:defaultValue>
-        </command:parameter>
-        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="14" aliases="none">
-          <maml:name>GenericField5</maml:name>
-          <maml:Description>
-            <maml:para>An optional parameter to set the generic field value.
-A generic field is a string field which can be renamed to a different value when being displayed in the PasswordState web interface. Note : Generic Fields can be configured as different Field Types, so ensure you pass a valid value for text fields, Select Lists, Radio Buttons or Date Fields.</maml:para>
-          </maml:Description>
-          <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
-          <dev:type>
-            <maml:name>String</maml:name>
-            <maml:uri />
-          </dev:type>
-          <dev:defaultValue>None</dev:defaultValue>
-        </command:parameter>
-        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="15" aliases="none">
-          <maml:name>GenericField6</maml:name>
-          <maml:Description>
-            <maml:para>An optional parameter to set the generic field value.
-A generic field is a string field which can be renamed to a different value when being displayed in the PasswordState web interface. Note : Generic Fields can be configured as different Field Types, so ensure you pass a valid value for text fields, Select Lists, Radio Buttons or Date Fields.</maml:para>
-          </maml:Description>
-          <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
-          <dev:type>
-            <maml:name>String</maml:name>
-            <maml:uri />
-          </dev:type>
-          <dev:defaultValue>None</dev:defaultValue>
-        </command:parameter>
-        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="16" aliases="none">
-          <maml:name>GenericField7</maml:name>
-          <maml:Description>
-            <maml:para>An optional parameter to set the generic field value.
-A generic field is a string field which can be renamed to a different value when being displayed in the PasswordState web interface. Note : Generic Fields can be configured as different Field Types, so ensure you pass a valid value for text fields, Select Lists, Radio Buttons or Date Fields.</maml:para>
-          </maml:Description>
-          <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
-          <dev:type>
-            <maml:name>String</maml:name>
-            <maml:uri />
-          </dev:type>
-          <dev:defaultValue>None</dev:defaultValue>
-        </command:parameter>
-        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="17" aliases="none">
-          <maml:name>GenericField8</maml:name>
-          <maml:Description>
-            <maml:para>An optional parameter to set the generic field value.
-A generic field is a string field which can be renamed to a different value when being displayed in the PasswordState web interface. Note : Generic Fields can be configured as different Field Types, so ensure you pass a valid value for text fields, Select Lists, Radio Buttons or Date Fields.</maml:para>
-          </maml:Description>
-          <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
-          <dev:type>
-            <maml:name>String</maml:name>
-            <maml:uri />
-          </dev:type>
-          <dev:defaultValue>None</dev:defaultValue>
-        </command:parameter>
-        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="18" aliases="none">
-          <maml:name>GenericField9</maml:name>
-          <maml:Description>
-            <maml:para>An optional parameter to set the generic field value.
-A generic field is a string field which can be renamed to a different value when being displayed in the PasswordState web interface. Note : Generic Fields can be configured as different Field Types, so ensure you pass a valid value for text fields, Select Lists, Radio Buttons or Date Fields.</maml:para>
-          </maml:Description>
-          <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
-          <dev:type>
-            <maml:name>String</maml:name>
-            <maml:uri />
-          </dev:type>
-          <dev:defaultValue>None</dev:defaultValue>
-        </command:parameter>
-        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="19" aliases="none">
-          <maml:name>GenericField10</maml:name>
-          <maml:Description>
-            <maml:para>An optional parameter to set the generic field value.
-A generic field is a string field which can be renamed to a different value when being displayed in the PasswordState web interface. Note : Generic Fields can be configured as different Field Types, so ensure you pass a valid value for text fields, Select Lists, Radio Buttons or Date Fields.</maml:para>
-          </maml:Description>
-          <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
-          <dev:type>
-            <maml:name>String</maml:name>
-            <maml:uri />
-          </dev:type>
-          <dev:defaultValue>None</dev:defaultValue>
-        </command:parameter>
-        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="2" aliases="none">
-          <maml:name>Username</maml:name>
-          <maml:Description>
-            <maml:para>The username to be updated (optional).
-Some systems require a username and password to authenticate. This field represents the UserName to do so.</maml:para>
-          </maml:Description>
-          <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
-          <dev:type>
-            <maml:name>String</maml:name>
-            <maml:uri />
-          </dev:type>
-          <dev:defaultValue>None</dev:defaultValue>
-        </command:parameter>
-        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="20" aliases="none">
-          <maml:name>GenerateGenFieldPassword</maml:name>
-          <maml:Description>
-            <maml:para>If set to true, any ' Generic Fields ' which you have set to be of type 'Password ' will have a newly generated random password assigned to it. If the Password List or Generic Field is set to use the user's Password Generator options, the Default Password Generator options will be used instead.</maml:para>
-          </maml:Description>
-          <dev:type>
-            <maml:name>SwitchParameter</maml:name>
-            <maml:uri />
-          </dev:type>
-          <dev:defaultValue>False</dev:defaultValue>
-        </command:parameter>
-        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="21" aliases="none">
-          <maml:name>AddDaysToExpiryDate</maml:name>
-          <maml:Description>
-            <maml:para>Once the password has been changed due to a scheduled reset, you can add an additional (x) number of days to the ExpiryDate field so another reset will occur again in 30, 60, 90 days, etc. This is the option on the Reset Options tab for the record.</maml:para>
-          </maml:Description>
-          <command:parameterValue required="true" variableLength="false">Int32</command:parameterValue>
-          <dev:type>
-            <maml:name>Int32</maml:name>
-            <maml:uri />
-          </dev:type>
-          <dev:defaultValue>None</dev:defaultValue>
-        </command:parameter>
-        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="22" aliases="none">
-          <maml:name>ScriptID</maml:name>
-          <maml:Description>
-            <maml:para>Most accounts require a Password Reset Script to be assigned to them, with the only exception being Active Directory Accounts - not to specify this field for AD Accounts. To look up the values of the ScriptID's, this can be done by using the ' Toggle ID Column Visibility ' button on the Password Reset Scripts screens in PasswordState.</maml:para>
-          </maml:Description>
-          <command:parameterValue required="true" variableLength="false">Int32</command:parameterValue>
-          <dev:type>
-            <maml:name>Int32</maml:name>
-            <maml:uri />
-          </dev:type>
-          <dev:defaultValue>None</dev:defaultValue>
-        </command:parameter>
-        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="23" aliases="none">
-          <maml:name>PrivilegedAccountID</maml:name>
-          <maml:Description>
-            <maml:para>Some Password Reset Scripts also require a `Privileged Account Credential` to be associated with the Password record, to initiate connection and perform the reset. Requirements for Privileged Accounts are documented in the User Manual, under the KB Article section. To look up the value of PrivilegedAccountID's, this can be done on the screen `Administration -&gt; PasswordState Administration -&gt; Privileged Account Credentials`.</maml:para>
-          </maml:Description>
-          <command:parameterValue required="true" variableLength="false">Int32</command:parameterValue>
-          <dev:type>
-            <maml:name>Int32</maml:name>
-            <maml:uri />
-          </dev:type>
-          <dev:defaultValue>None</dev:defaultValue>
-        </command:parameter>
-        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="24" aliases="none">
-          <maml:name>ExpiryDate</maml:name>
-          <maml:Description>
-            <maml:para>The date in which the password value should be reset for this Password object. The date will be displayed in the format specified for the `System Setting option 'Default Locale'`, through the PasswordState web site interface.</maml:para>
-          </maml:Description>
-          <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
-          <dev:type>
-            <maml:name>String</maml:name>
-            <maml:uri />
-          </dev:type>
-          <dev:defaultValue>None</dev:defaultValue>
-        </command:parameter>
-        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="25" aliases="none">
-          <maml:name>AllowExport</maml:name>
-          <maml:Description>
-            <maml:para>Indicates whether this Password object will be exported when the entire Password List contents are exported.
-Only working if "`Allow Password List to be Exported`" is set on the password list.</maml:para>
-          </maml:Description>
-          <dev:type>
-            <maml:name>SwitchParameter</maml:name>
-            <maml:uri />
-          </dev:type>
-          <dev:defaultValue>False</dev:defaultValue>
-        </command:parameter>
-        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="25" aliases="none">
-          <maml:name>WebPassword_ID</maml:name>
-          <maml:Description>
-            <maml:para>This field is only used in conjunction with the Browser Extensions, and represents the Password field for login pages i.e. the tag name of the Input HTML field.</maml:para>
-          </maml:Description>
-          <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
-          <dev:type>
-            <maml:name>String</maml:name>
-            <maml:uri />
-          </dev:type>
-          <dev:defaultValue>None</dev:defaultValue>
-        </command:parameter>
-        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="25" aliases="none">
-          <maml:name>WebUser_ID</maml:name>
-          <maml:Description>
-            <maml:para>This field is only used in conjunction with the Browser Extensions, and represents the Username field for login pages i.e. the tag name of the Input HTML field.</maml:para>
-          </maml:Description>
-          <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
-          <dev:type>
-            <maml:name>String</maml:name>
-            <maml:uri />
-          </dev:type>
-          <dev:defaultValue>None</dev:defaultValue>
-        </command:parameter>
-        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="26" aliases="none">
-          <maml:name>Reason</maml:name>
-          <maml:Description>
-            <maml:para>A reason which can be logged for auditing of why a password was updated.</maml:para>
-          </maml:Description>
-          <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
-          <dev:type>
-            <maml:name>String</maml:name>
-            <maml:uri />
-          </dev:type>
-          <dev:defaultValue>None</dev:defaultValue>
-        </command:parameter>
-        <command:parameter required="true" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="3" aliases="none">
-          <maml:name>HeartbeatEnabled</maml:name>
-          <maml:Description>
-            <maml:para>If you want to enable the record to perform regular account heartbeat status update apply this switch.</maml:para>
-          </maml:Description>
-          <dev:type>
-            <maml:name>SwitchParameter</maml:name>
-            <maml:uri />
-          </dev:type>
-          <dev:defaultValue>False</dev:defaultValue>
-        </command:parameter>
-        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="3" aliases="none">
-          <maml:name>HostName</maml:name>
-          <maml:Description>
-            <maml:para>If the record relates to account on a Host, then you must specify the Host Name here, as it is stored on the Hosts screen in PasswordState.</maml:para>
-          </maml:Description>
-          <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
-          <dev:type>
-            <maml:name>String</maml:name>
-            <maml:uri />
-          </dev:type>
-          <dev:defaultValue>None</dev:defaultValue>
-        </command:parameter>
-        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="4" aliases="none">
-          <maml:name>ADDomainNetBIOS</maml:name>
-          <maml:Description>
-            <maml:para>If the record relates to an Active Directory account, then you must specify the Active Directory NetBIOS value here, as it is stored on the `Administration -&gt; PasswordState Administration -&gt; Active Directory Domains` screen in PasswordState.</maml:para>
-          </maml:Description>
-          <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
-          <dev:type>
-            <maml:name>String</maml:name>
-            <maml:uri />
-          </dev:type>
-          <dev:defaultValue>None</dev:defaultValue>
-        </command:parameter>
-        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="4" aliases="none">
-          <maml:name>Description</maml:name>
-          <maml:Description>
-            <maml:para>Custom description to be added to the password.
-Can be used as a longer verbose description of the nature of the Password object</maml:para>
-          </maml:Description>
-          <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
-          <dev:type>
-            <maml:name>String</maml:name>
-            <maml:uri />
-          </dev:type>
-          <dev:defaultValue>None</dev:defaultValue>
-        </command:parameter>
-        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="5" aliases="none">
-          <maml:name>HeartbeatSchedule</maml:name>
-          <maml:Description>
-            <maml:para>This field allows you to set the schedule for the account heartbeat status update. Specify values in the format of 23:10, or 04:00, etc. (Range: 00:00-23:59)</maml:para>
-          </maml:Description>
-          <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
-          <dev:type>
-            <maml:name>String</maml:name>
-            <maml:uri />
-          </dev:type>
-          <dev:defaultValue>None</dev:defaultValue>
-        </command:parameter>
-        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="5" aliases="none">
-          <maml:name>ValidationScriptID</maml:name>
-          <maml:Description>
-            <maml:para>When enabling Account Heartbeat, you must associate the correct Password Validation Script to the record (all account types require a Validation Script to be selected). To look up the values of the ValidationScriptID's, this can be done by using the ' Toggle ID Column Visibility ' button on the Password Validation Scripts screens in PasswordState.</maml:para>
-          </maml:Description>
-          <command:parameterValue required="true" variableLength="false">Int32</command:parameterValue>
-          <dev:type>
-            <maml:name>Int32</maml:name>
-            <maml:uri />
-          </dev:type>
-          <dev:defaultValue>None</dev:defaultValue>
-        </command:parameter>
-        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="6" aliases="none">
-          <maml:name>Notes</maml:name>
-          <maml:Description>
-            <maml:para>A generic Notes field where additional descriptive text can be added.</maml:para>
-          </maml:Description>
-          <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
-          <dev:type>
-            <maml:name>String</maml:name>
-            <maml:uri />
-          </dev:type>
-          <dev:defaultValue>None</dev:defaultValue>
-        </command:parameter>
-        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="7" aliases="none">
-          <maml:name>Url</maml:name>
-          <maml:Description>
-            <maml:para>URL parameter where you can specify the URL for HTTP, HTTPS, FTP, SFTP, etc. to be updated if relevant.
-</maml:para>
-          </maml:Description>
-          <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
-          <dev:type>
-            <maml:name>String</maml:name>
-            <maml:uri />
-          </dev:type>
-          <dev:defaultValue>None</dev:defaultValue>
-        </command:parameter>
-        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="8" aliases="none">
-          <maml:name>AccountType</maml:name>
-          <maml:Description>
-            <maml:para>The name of the Account Type if one has been chosen for the Password record.
-You can either specify the AccountType or AccountTypeID if needed when changing password records. Account Types and their ID values can be seen on the screen `Administration -&gt; Passwordstate Administration -&gt; Images and Account Types`, and click on the ' Toggle ID Column Visibility ' button to determine the appropriate value.</maml:para>
-          </maml:Description>
-          <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
-          <dev:type>
-            <maml:name>String</maml:name>
-            <maml:uri />
-          </dev:type>
-          <dev:defaultValue>None</dev:defaultValue>
-        </command:parameter>
-        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="8" aliases="none">
-          <maml:name>ValidateWithPrivAccount</maml:name>
-          <maml:Description>
-            <maml:para>This field is only used for Linux accounts , and when set to True, the Privileged Account Credential will be used for Authentication when performing Account Heartbeats - useful for accounts like root which generally are not allowed to be used for SSH.</maml:para>
-          </maml:Description>
-          <dev:type>
-            <maml:name>SwitchParameter</maml:name>
-            <maml:uri />
-          </dev:type>
-          <dev:defaultValue>False</dev:defaultValue>
-        </command:parameter>
-        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="9" aliases="none">
-          <maml:name>AccountTypeID</maml:name>
-          <maml:Description>
-            <maml:para>The ID value representing the Account Type image (derived from the AccountTypes table). An AccountTypeID of 0 (zero) means there is no associated Account Type image for this Password.
-You can either specify the AccountType or AccountTypeID if needed when changing password records. Account Types and their ID values can be seen on the screen `Administration -&gt; Passwordstate Administration -&gt; Images and Account Types`, and click on the ' Toggle ID Column Visibility ' button to determine the appropriate value.</maml:para>
-          </maml:Description>
-          <command:parameterValue required="true" variableLength="false">Int32</command:parameterValue>
-          <dev:type>
-            <maml:name>Int32</maml:name>
-            <maml:uri />
-          </dev:type>
-          <dev:defaultValue>None</dev:defaultValue>
-        </command:parameter>
-        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="9" aliases="none">
-          <maml:name>Password</maml:name>
-          <maml:Description>
-            <maml:para>The new password to be added to the entry (stored as encrypted binary field in database).</maml:para>
-          </maml:Description>
-          <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
-          <dev:type>
-            <maml:name>String</maml:name>
-            <maml:uri />
-          </dev:type>
-          <dev:defaultValue>None</dev:defaultValue>
-        </command:parameter>
-        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="cf">
-          <maml:name>Confirm</maml:name>
-          <maml:Description>
-            <maml:para>Prompts you for confirmation before running the cmdlet.</maml:para>
-          </maml:Description>
-          <dev:type>
-            <maml:name>SwitchParameter</maml:name>
-            <maml:uri />
-          </dev:type>
-          <dev:defaultValue>False</dev:defaultValue>
-        </command:parameter>
-        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="wi">
-          <maml:name>WhatIf</maml:name>
-          <maml:Description>
-            <maml:para>Shows what would happen if the cmdlet runs. The cmdlet is not run.</maml:para>
-          </maml:Description>
-          <dev:type>
-            <maml:name>SwitchParameter</maml:name>
-            <maml:uri />
-          </dev:type>
-          <dev:defaultValue>False</dev:defaultValue>
-        </command:parameter>
-      </command:syntaxItem>
-      <command:syntaxItem>
-        <maml:name>Set-PasswordStatePassword</maml:name>
-        <command:parameter required="true" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="0" aliases="none">
-          <maml:name>PasswordID</maml:name>
-          <maml:Description>
-            <maml:para>The ID of the password to be updated.</maml:para>
-          </maml:Description>
-          <command:parameterValue required="true" variableLength="false">Int32</command:parameterValue>
-          <dev:type>
-            <maml:name>Int32</maml:name>
-            <maml:uri />
-          </dev:type>
-          <dev:defaultValue>0</dev:defaultValue>
-        </command:parameter>
         <command:parameter required="true" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="0" aliases="none">
           <maml:name>PasswordResetEnabled</maml:name>
           <maml:Description>
@@ -14576,7 +14202,7 @@ Only working if "`Allow Password List to be Exported`" is set on the password li
           </dev:type>
           <dev:defaultValue>False</dev:defaultValue>
         </command:parameter>
-        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="3" aliases="none">
+        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="3" aliases="none">
           <maml:name>HostName</maml:name>
           <maml:Description>
             <maml:para>If the record relates to account on a Host, then you must specify the Host Name here, as it is stored on the Hosts screen in PasswordState.</maml:para>
@@ -14588,7 +14214,7 @@ Only working if "`Allow Password List to be Exported`" is set on the password li
           </dev:type>
           <dev:defaultValue>None</dev:defaultValue>
         </command:parameter>
-        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="4" aliases="none">
+        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="4" aliases="none">
           <maml:name>ADDomainNetBIOS</maml:name>
           <maml:Description>
             <maml:para>If the record relates to an Active Directory account, then you must specify the Active Directory NetBIOS value here, as it is stored on the `Administration -&gt; PasswordState Administration -&gt; Active Directory Domains` screen in PasswordState.</maml:para>
@@ -15057,7 +14683,7 @@ Only working if "`Allow Password List to be Exported`" is set on the password li
           </dev:type>
           <dev:defaultValue>False</dev:defaultValue>
         </command:parameter>
-        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="3" aliases="none">
+        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="3" aliases="none">
           <maml:name>HostName</maml:name>
           <maml:Description>
             <maml:para>If the record relates to account on a Host, then you must specify the Host Name here, as it is stored on the Hosts screen in PasswordState.</maml:para>
@@ -15069,7 +14695,7 @@ Only working if "`Allow Password List to be Exported`" is set on the password li
           </dev:type>
           <dev:defaultValue>None</dev:defaultValue>
         </command:parameter>
-        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="4" aliases="none">
+        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="4" aliases="none">
           <maml:name>ADDomainNetBIOS</maml:name>
           <maml:Description>
             <maml:para>If the record relates to an Active Directory account, then you must specify the Active Directory NetBIOS value here, as it is stored on the `Administration -&gt; PasswordState Administration -&gt; Active Directory Domains` screen in PasswordState.</maml:para>
@@ -15504,6 +15130,30 @@ Only working if "`Allow Password List to be Exported`" is set on the password li
           </dev:type>
           <dev:defaultValue>None</dev:defaultValue>
         </command:parameter>
+        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="3" aliases="none">
+          <maml:name>HostName</maml:name>
+          <maml:Description>
+            <maml:para>If the record relates to account on a Host, then you must specify the Host Name here, as it is stored on the Hosts screen in PasswordState.</maml:para>
+          </maml:Description>
+          <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+          <dev:type>
+            <maml:name>String</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="4" aliases="none">
+          <maml:name>ADDomainNetBIOS</maml:name>
+          <maml:Description>
+            <maml:para>If the record relates to an Active Directory account, then you must specify the Active Directory NetBIOS value here, as it is stored on the `Administration -&gt; PasswordState Administration -&gt; Active Directory Domains` screen in PasswordState.</maml:para>
+          </maml:Description>
+          <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+          <dev:type>
+            <maml:name>String</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
         <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="4" aliases="none">
           <maml:name>Description</maml:name>
           <maml:Description>
@@ -15566,6 +15216,464 @@ You can either specify the AccountType or AccountTypeID if needed when changing 
             <maml:uri />
           </dev:type>
           <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="9" aliases="none">
+          <maml:name>AccountTypeID</maml:name>
+          <maml:Description>
+            <maml:para>The ID value representing the Account Type image (derived from the AccountTypes table). An AccountTypeID of 0 (zero) means there is no associated Account Type image for this Password.
+You can either specify the AccountType or AccountTypeID if needed when changing password records. Account Types and their ID values can be seen on the screen `Administration -&gt; Passwordstate Administration -&gt; Images and Account Types`, and click on the ' Toggle ID Column Visibility ' button to determine the appropriate value.</maml:para>
+          </maml:Description>
+          <command:parameterValue required="true" variableLength="false">Int32</command:parameterValue>
+          <dev:type>
+            <maml:name>Int32</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="9" aliases="none">
+          <maml:name>Password</maml:name>
+          <maml:Description>
+            <maml:para>The new password to be added to the entry (stored as encrypted binary field in database).</maml:para>
+          </maml:Description>
+          <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+          <dev:type>
+            <maml:name>String</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="cf">
+          <maml:name>Confirm</maml:name>
+          <maml:Description>
+            <maml:para>Prompts you for confirmation before running the cmdlet.</maml:para>
+          </maml:Description>
+          <dev:type>
+            <maml:name>SwitchParameter</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>False</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="wi">
+          <maml:name>WhatIf</maml:name>
+          <maml:Description>
+            <maml:para>Shows what would happen if the cmdlet runs. The cmdlet is not run.</maml:para>
+          </maml:Description>
+          <dev:type>
+            <maml:name>SwitchParameter</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>False</dev:defaultValue>
+        </command:parameter>
+      </command:syntaxItem>
+      <command:syntaxItem>
+        <maml:name>Set-PasswordStatePassword</maml:name>
+        <command:parameter required="true" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="0" aliases="none">
+          <maml:name>PasswordID</maml:name>
+          <maml:Description>
+            <maml:para>The ID of the password to be updated.</maml:para>
+          </maml:Description>
+          <command:parameterValue required="true" variableLength="false">Int32</command:parameterValue>
+          <dev:type>
+            <maml:name>Int32</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>0</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="1" aliases="none">
+          <maml:name>Title</maml:name>
+          <maml:Description>
+            <maml:para>Name of the entry to be updated.
+A title to describe the nature of the Password object.</maml:para>
+          </maml:Description>
+          <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+          <dev:type>
+            <maml:name>String</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="10" aliases="none">
+          <maml:name>GeneratePassword</maml:name>
+          <maml:Description>
+            <maml:para>A switch parameter to generate the password based of the PasswordList Policy.
+A newly generated random password will be created based on the Password Generator options associated with the Password List. If the Password List is set to use the user's Password Generator options, the Default Password Generator options will be used instead.</maml:para>
+          </maml:Description>
+          <dev:type>
+            <maml:name>SwitchParameter</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>False</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="10" aliases="none">
+          <maml:name>GenericField1</maml:name>
+          <maml:Description>
+            <maml:para>An optional parameter to set the generic field value.
+A generic field is a string field which can be renamed to a different value when being displayed in the PasswordState web interface. Note : Generic Fields can be configured as different Field Types, so ensure you pass a valid value for text fields, Select Lists, Radio Buttons or Date Fields.</maml:para>
+          </maml:Description>
+          <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+          <dev:type>
+            <maml:name>String</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="11" aliases="none">
+          <maml:name>GenericField2</maml:name>
+          <maml:Description>
+            <maml:para>An optional parameter to set the generic field value.
+A generic field is a string field which can be renamed to a different value when being displayed in the PasswordState web interface. Note : Generic Fields can be configured as different Field Types, so ensure you pass a valid value for text fields, Select Lists, Radio Buttons or Date Fields.</maml:para>
+          </maml:Description>
+          <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+          <dev:type>
+            <maml:name>String</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="12" aliases="none">
+          <maml:name>GenericField3</maml:name>
+          <maml:Description>
+            <maml:para>An optional parameter to set the generic field value.
+A generic field is a string field which can be renamed to a different value when being displayed in the PasswordState web interface. Note : Generic Fields can be configured as different Field Types, so ensure you pass a valid value for text fields, Select Lists, Radio Buttons or Date Fields.</maml:para>
+          </maml:Description>
+          <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+          <dev:type>
+            <maml:name>String</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="13" aliases="none">
+          <maml:name>GenericField4</maml:name>
+          <maml:Description>
+            <maml:para>An optional parameter to set the generic field value.
+A generic field is a string field which can be renamed to a different value when being displayed in the PasswordState web interface. Note : Generic Fields can be configured as different Field Types, so ensure you pass a valid value for text fields, Select Lists, Radio Buttons or Date Fields.</maml:para>
+          </maml:Description>
+          <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+          <dev:type>
+            <maml:name>String</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="14" aliases="none">
+          <maml:name>GenericField5</maml:name>
+          <maml:Description>
+            <maml:para>An optional parameter to set the generic field value.
+A generic field is a string field which can be renamed to a different value when being displayed in the PasswordState web interface. Note : Generic Fields can be configured as different Field Types, so ensure you pass a valid value for text fields, Select Lists, Radio Buttons or Date Fields.</maml:para>
+          </maml:Description>
+          <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+          <dev:type>
+            <maml:name>String</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="15" aliases="none">
+          <maml:name>GenericField6</maml:name>
+          <maml:Description>
+            <maml:para>An optional parameter to set the generic field value.
+A generic field is a string field which can be renamed to a different value when being displayed in the PasswordState web interface. Note : Generic Fields can be configured as different Field Types, so ensure you pass a valid value for text fields, Select Lists, Radio Buttons or Date Fields.</maml:para>
+          </maml:Description>
+          <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+          <dev:type>
+            <maml:name>String</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="16" aliases="none">
+          <maml:name>GenericField7</maml:name>
+          <maml:Description>
+            <maml:para>An optional parameter to set the generic field value.
+A generic field is a string field which can be renamed to a different value when being displayed in the PasswordState web interface. Note : Generic Fields can be configured as different Field Types, so ensure you pass a valid value for text fields, Select Lists, Radio Buttons or Date Fields.</maml:para>
+          </maml:Description>
+          <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+          <dev:type>
+            <maml:name>String</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="17" aliases="none">
+          <maml:name>GenericField8</maml:name>
+          <maml:Description>
+            <maml:para>An optional parameter to set the generic field value.
+A generic field is a string field which can be renamed to a different value when being displayed in the PasswordState web interface. Note : Generic Fields can be configured as different Field Types, so ensure you pass a valid value for text fields, Select Lists, Radio Buttons or Date Fields.</maml:para>
+          </maml:Description>
+          <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+          <dev:type>
+            <maml:name>String</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="18" aliases="none">
+          <maml:name>GenericField9</maml:name>
+          <maml:Description>
+            <maml:para>An optional parameter to set the generic field value.
+A generic field is a string field which can be renamed to a different value when being displayed in the PasswordState web interface. Note : Generic Fields can be configured as different Field Types, so ensure you pass a valid value for text fields, Select Lists, Radio Buttons or Date Fields.</maml:para>
+          </maml:Description>
+          <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+          <dev:type>
+            <maml:name>String</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="19" aliases="none">
+          <maml:name>GenericField10</maml:name>
+          <maml:Description>
+            <maml:para>An optional parameter to set the generic field value.
+A generic field is a string field which can be renamed to a different value when being displayed in the PasswordState web interface. Note : Generic Fields can be configured as different Field Types, so ensure you pass a valid value for text fields, Select Lists, Radio Buttons or Date Fields.</maml:para>
+          </maml:Description>
+          <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+          <dev:type>
+            <maml:name>String</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="2" aliases="none">
+          <maml:name>Username</maml:name>
+          <maml:Description>
+            <maml:para>The username to be updated (optional).
+Some systems require a username and password to authenticate. This field represents the UserName to do so.</maml:para>
+          </maml:Description>
+          <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+          <dev:type>
+            <maml:name>String</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="20" aliases="none">
+          <maml:name>GenerateGenFieldPassword</maml:name>
+          <maml:Description>
+            <maml:para>If set to true, any ' Generic Fields ' which you have set to be of type 'Password ' will have a newly generated random password assigned to it. If the Password List or Generic Field is set to use the user's Password Generator options, the Default Password Generator options will be used instead.</maml:para>
+          </maml:Description>
+          <dev:type>
+            <maml:name>SwitchParameter</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>False</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="21" aliases="none">
+          <maml:name>AddDaysToExpiryDate</maml:name>
+          <maml:Description>
+            <maml:para>Once the password has been changed due to a scheduled reset, you can add an additional (x) number of days to the ExpiryDate field so another reset will occur again in 30, 60, 90 days, etc. This is the option on the Reset Options tab for the record.</maml:para>
+          </maml:Description>
+          <command:parameterValue required="true" variableLength="false">Int32</command:parameterValue>
+          <dev:type>
+            <maml:name>Int32</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="22" aliases="none">
+          <maml:name>ScriptID</maml:name>
+          <maml:Description>
+            <maml:para>Most accounts require a Password Reset Script to be assigned to them, with the only exception being Active Directory Accounts - not to specify this field for AD Accounts. To look up the values of the ScriptID's, this can be done by using the ' Toggle ID Column Visibility ' button on the Password Reset Scripts screens in PasswordState.</maml:para>
+          </maml:Description>
+          <command:parameterValue required="true" variableLength="false">Int32</command:parameterValue>
+          <dev:type>
+            <maml:name>Int32</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="23" aliases="none">
+          <maml:name>PrivilegedAccountID</maml:name>
+          <maml:Description>
+            <maml:para>Some Password Reset Scripts also require a `Privileged Account Credential` to be associated with the Password record, to initiate connection and perform the reset. Requirements for Privileged Accounts are documented in the User Manual, under the KB Article section. To look up the value of PrivilegedAccountID's, this can be done on the screen `Administration -&gt; PasswordState Administration -&gt; Privileged Account Credentials`.</maml:para>
+          </maml:Description>
+          <command:parameterValue required="true" variableLength="false">Int32</command:parameterValue>
+          <dev:type>
+            <maml:name>Int32</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="24" aliases="none">
+          <maml:name>ExpiryDate</maml:name>
+          <maml:Description>
+            <maml:para>The date in which the password value should be reset for this Password object. The date will be displayed in the format specified for the `System Setting option 'Default Locale'`, through the PasswordState web site interface.</maml:para>
+          </maml:Description>
+          <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+          <dev:type>
+            <maml:name>String</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="25" aliases="none">
+          <maml:name>AllowExport</maml:name>
+          <maml:Description>
+            <maml:para>Indicates whether this Password object will be exported when the entire Password List contents are exported.
+Only working if "`Allow Password List to be Exported`" is set on the password list.</maml:para>
+          </maml:Description>
+          <dev:type>
+            <maml:name>SwitchParameter</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>False</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="25" aliases="none">
+          <maml:name>WebPassword_ID</maml:name>
+          <maml:Description>
+            <maml:para>This field is only used in conjunction with the Browser Extensions, and represents the Password field for login pages i.e. the tag name of the Input HTML field.</maml:para>
+          </maml:Description>
+          <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+          <dev:type>
+            <maml:name>String</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="25" aliases="none">
+          <maml:name>WebUser_ID</maml:name>
+          <maml:Description>
+            <maml:para>This field is only used in conjunction with the Browser Extensions, and represents the Username field for login pages i.e. the tag name of the Input HTML field.</maml:para>
+          </maml:Description>
+          <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+          <dev:type>
+            <maml:name>String</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="26" aliases="none">
+          <maml:name>Reason</maml:name>
+          <maml:Description>
+            <maml:para>A reason which can be logged for auditing of why a password was updated.</maml:para>
+          </maml:Description>
+          <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+          <dev:type>
+            <maml:name>String</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="true" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="3" aliases="none">
+          <maml:name>HeartbeatEnabled</maml:name>
+          <maml:Description>
+            <maml:para>If you want to enable the record to perform regular account heartbeat status update apply this switch.</maml:para>
+          </maml:Description>
+          <dev:type>
+            <maml:name>SwitchParameter</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>False</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="3" aliases="none">
+          <maml:name>HostName</maml:name>
+          <maml:Description>
+            <maml:para>If the record relates to account on a Host, then you must specify the Host Name here, as it is stored on the Hosts screen in PasswordState.</maml:para>
+          </maml:Description>
+          <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+          <dev:type>
+            <maml:name>String</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="4" aliases="none">
+          <maml:name>ADDomainNetBIOS</maml:name>
+          <maml:Description>
+            <maml:para>If the record relates to an Active Directory account, then you must specify the Active Directory NetBIOS value here, as it is stored on the `Administration -&gt; PasswordState Administration -&gt; Active Directory Domains` screen in PasswordState.</maml:para>
+          </maml:Description>
+          <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+          <dev:type>
+            <maml:name>String</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="4" aliases="none">
+          <maml:name>Description</maml:name>
+          <maml:Description>
+            <maml:para>Custom description to be added to the password.
+Can be used as a longer verbose description of the nature of the Password object</maml:para>
+          </maml:Description>
+          <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+          <dev:type>
+            <maml:name>String</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="5" aliases="none">
+          <maml:name>HeartbeatSchedule</maml:name>
+          <maml:Description>
+            <maml:para>This field allows you to set the schedule for the account heartbeat status update. Specify values in the format of 23:10, or 04:00, etc. (Range: 00:00-23:59)</maml:para>
+          </maml:Description>
+          <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+          <dev:type>
+            <maml:name>String</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="5" aliases="none">
+          <maml:name>ValidationScriptID</maml:name>
+          <maml:Description>
+            <maml:para>When enabling Account Heartbeat, you must associate the correct Password Validation Script to the record (all account types require a Validation Script to be selected). To look up the values of the ValidationScriptID's, this can be done by using the ' Toggle ID Column Visibility ' button on the Password Validation Scripts screens in PasswordState.</maml:para>
+          </maml:Description>
+          <command:parameterValue required="true" variableLength="false">Int32</command:parameterValue>
+          <dev:type>
+            <maml:name>Int32</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="6" aliases="none">
+          <maml:name>Notes</maml:name>
+          <maml:Description>
+            <maml:para>A generic Notes field where additional descriptive text can be added.</maml:para>
+          </maml:Description>
+          <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+          <dev:type>
+            <maml:name>String</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="7" aliases="none">
+          <maml:name>Url</maml:name>
+          <maml:Description>
+            <maml:para>URL parameter where you can specify the URL for HTTP, HTTPS, FTP, SFTP, etc. to be updated if relevant.
+</maml:para>
+          </maml:Description>
+          <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+          <dev:type>
+            <maml:name>String</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="8" aliases="none">
+          <maml:name>AccountType</maml:name>
+          <maml:Description>
+            <maml:para>The name of the Account Type if one has been chosen for the Password record.
+You can either specify the AccountType or AccountTypeID if needed when changing password records. Account Types and their ID values can be seen on the screen `Administration -&gt; Passwordstate Administration -&gt; Images and Account Types`, and click on the ' Toggle ID Column Visibility ' button to determine the appropriate value.</maml:para>
+          </maml:Description>
+          <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+          <dev:type>
+            <maml:name>String</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="8" aliases="none">
+          <maml:name>ValidateWithPrivAccount</maml:name>
+          <maml:Description>
+            <maml:para>This field is only used for Linux accounts , and when set to True, the Privileged Account Credential will be used for Authentication when performing Account Heartbeats - useful for accounts like root which generally are not allowed to be used for SSH.</maml:para>
+          </maml:Description>
+          <dev:type>
+            <maml:name>SwitchParameter</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>False</dev:defaultValue>
         </command:parameter>
         <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="9" aliases="none">
           <maml:name>AccountTypeID</maml:name>
@@ -15915,6 +16023,30 @@ Only working if "`Allow Password List to be Exported`" is set on the password li
           </dev:type>
           <dev:defaultValue>None</dev:defaultValue>
         </command:parameter>
+        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="3" aliases="none">
+          <maml:name>HostName</maml:name>
+          <maml:Description>
+            <maml:para>If the record relates to account on a Host, then you must specify the Host Name here, as it is stored on the Hosts screen in PasswordState.</maml:para>
+          </maml:Description>
+          <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+          <dev:type>
+            <maml:name>String</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="4" aliases="none">
+          <maml:name>ADDomainNetBIOS</maml:name>
+          <maml:Description>
+            <maml:para>If the record relates to an Active Directory account, then you must specify the Active Directory NetBIOS value here, as it is stored on the `Administration -&gt; PasswordState Administration -&gt; Active Directory Domains` screen in PasswordState.</maml:para>
+          </maml:Description>
+          <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+          <dev:type>
+            <maml:name>String</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
         <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="4" aliases="none">
           <maml:name>Description</maml:name>
           <maml:Description>
@@ -16290,6 +16422,30 @@ Only working if "`Allow Password List to be Exported`" is set on the password li
           </dev:type>
           <dev:defaultValue>None</dev:defaultValue>
         </command:parameter>
+        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="3" aliases="none">
+          <maml:name>HostName</maml:name>
+          <maml:Description>
+            <maml:para>If the record relates to account on a Host, then you must specify the Host Name here, as it is stored on the Hosts screen in PasswordState.</maml:para>
+          </maml:Description>
+          <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+          <dev:type>
+            <maml:name>String</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="4" aliases="none">
+          <maml:name>ADDomainNetBIOS</maml:name>
+          <maml:Description>
+            <maml:para>If the record relates to an Active Directory account, then you must specify the Active Directory NetBIOS value here, as it is stored on the `Administration -&gt; PasswordState Administration -&gt; Active Directory Domains` screen in PasswordState.</maml:para>
+          </maml:Description>
+          <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+          <dev:type>
+            <maml:name>String</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
         <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="4" aliases="none">
           <maml:name>Description</maml:name>
           <maml:Description>
@@ -16429,7 +16585,7 @@ You can either specify the AccountType or AccountTypeID if needed when changing 
         </dev:type>
         <dev:defaultValue>None</dev:defaultValue>
       </command:parameter>
-      <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="4" aliases="none">
+      <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="4" aliases="none">
         <maml:name>ADDomainNetBIOS</maml:name>
         <maml:Description>
           <maml:para>If the record relates to an Active Directory account, then you must specify the Active Directory NetBIOS value here, as it is stored on the `Administration -&gt; PasswordState Administration -&gt; Active Directory Domains` screen in PasswordState.</maml:para>
@@ -16670,7 +16826,7 @@ A generic field is a string field which can be renamed to a different value when
         </dev:type>
         <dev:defaultValue>None</dev:defaultValue>
       </command:parameter>
-      <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="3" aliases="none">
+      <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="3" aliases="none">
         <maml:name>HostName</maml:name>
         <maml:Description>
           <maml:para>If the record relates to account on a Host, then you must specify the Host Name here, as it is stored on the Hosts screen in PasswordState.</maml:para>

--- a/functions/Set-PasswordStatePassword.ps1
+++ b/functions/Set-PasswordStatePassword.ps1
@@ -26,7 +26,7 @@
                 return $true
             })]
         [string]$Password,
-        [parameter(ValueFromPipelineByPropertyName, Mandatory = $false, Position = 4)][ValidateLength(1, 255)][string]$Description,
+        [parameter(ValueFromPipelineByPropertyName, Mandatory = $false, Position = 4)][ValidateLength(0, 255)][string]$Description,
         [parameter(ValueFromPipelineByPropertyName, Mandatory = $true, ParameterSetName = "GeneratePassword", Position = 0)]
         [parameter(ValueFromPipelineByPropertyName, Mandatory = $false, ParameterSetName = "ResetSchedule", Position = 10)]
         [parameter(ValueFromPipelineByPropertyName, Mandatory = $false, ParameterSetName = "Reset", Position = 10)]
@@ -34,8 +34,8 @@
         [parameter(ValueFromPipelineByPropertyName, Mandatory = $false, ParameterSetName = "HeartbeatSchedule", Position = 10)]
         [switch]$GeneratePassword,
         [parameter(ValueFromPipelineByPropertyName, Mandatory = $false, Position = 6)][string]$Notes,
-        [parameter(ValueFromPipelineByPropertyName, Mandatory = $false, Position = 7)][ValidateLength(1, 255)][string]$Url,
-        [parameter(ValueFromPipelineByPropertyName, Mandatory = $false, Position = 8)][ValidateLength(1, 50)][string]$AccountType,
+        [parameter(ValueFromPipelineByPropertyName, Mandatory = $false, Position = 7)][ValidateLength(0, 255)][string]$Url,
+        [parameter(ValueFromPipelineByPropertyName, Mandatory = $false, Position = 8)][ValidateLength(0, 50)][string]$AccountType,
         [parameter(ValueFromPipelineByPropertyName, Mandatory = $false, Position = 9)][AllowNull()][Nullable[System.Int32]]$AccountTypeID = $null,
         [Parameter(ValueFromPipelineByPropertyName, Mandatory = $false, Position = 10)][string]$GenericField1 = $null,
         [Parameter(ValueFromPipelineByPropertyName, Mandatory = $false, Position = 11)][string]$GenericField2 = $null,
@@ -109,7 +109,10 @@
                 {
                     [boolean]($StrDate -as [DateTime])
                 }
-                if (!(isDate $_))
+                if ([string]::IsNullOrEmpty($_)){
+                    $true
+                }
+                elseif (!(isDate $_))
                 {
                     throw "Given ExpiryDate '$_' is not a valid Date format. Also, please specify the ExpiryDate in the date format that you have chosen in 'System Settings - miscellaneous - Default Locale' (Default: 'YYYY-MM-DD')."
                 }
@@ -118,10 +121,10 @@
                     $true
                 }
             })]
-        [string]$ExpiryDate,
+            [string]$ExpiryDate,
         [parameter(ValueFromPipelineByPropertyName, Mandatory = $false, Position = 25)][switch]$AllowExport,
-        [parameter(ValueFromPipelineByPropertyName, Mandatory = $false, Position = 25)][ValidateLength(1, 200)][string]$WebUser_ID,
-        [parameter(ValueFromPipelineByPropertyName, Mandatory = $false, Position = 25)][ValidateLength(1, 200)][string]$WebPassword_ID,
+        [parameter(ValueFromPipelineByPropertyName, Mandatory = $false, Position = 25)][ValidateLength(0, 200)][string]$WebUser_ID,
+        [parameter(ValueFromPipelineByPropertyName, Mandatory = $false, Position = 25)][ValidateLength(0, 200)][string]$WebPassword_ID,
         [parameter(ValueFromPipelineByPropertyName, Mandatory = $false, Position = 26)][string]$Reason
     )
 


### PR DESCRIPTION
Currently getting a passwordstate entry and passing across the pipeline to Set-PasswordstatePassword fails due to the validation on the Set-PasswordstatePassword function not allowing null/empty values for many entries or below 1 on length.

This fix allows the following scenario:

```powershell
Get-PasswordstatePassword github | Set-PasswordstatePassword -Password "T0pSecret"
```

Fixes #127 