### PR TITLE
Fix for converting result to pscredential object when using setplaint…

### DIFF
--- a/internal/functions/PasswordStateClass.ps1
+++ b/internal/functions/PasswordStateClass.ps1
@@ -50,17 +50,19 @@ class PasswordResult {
             }
             $user += "$($this.Username)"
         }
-        $result = [String]::IsNullOrEmpty($this.Password.Password)
-        If ($this.Password.GetType().Name -ne 'String' -and $result -eq $false) {
-            $output = [PSCredential]::new($user, $this.Password.Password)
-            return $output
+        $result = if ($null -eq $this.Password -or "" -eq $this.Password){
+            $true
         }
         if ($result -eq $true) {
             return $null
         }
+        If ($this.Password.GetType().Name -ne 'String' -and $result -eq $false) {
+            $output = [PSCredential]::new($user, $this.Password.Password)
+            return $output
+        }
         Else {
             $this.Password = [EncryptedPassword]$this.Password
-            $output = [PSCredential]::new($user, $this.Password.Password)
+            $output = [PSCredential]::new($user,$(ConvertTo-SecureString "$($this.Password.Password)" -AsPlainText -Force))
             return $output
         }
     }

--- a/internal/functions/PasswordStateClass.ps1
+++ b/internal/functions/PasswordStateClass.ps1
@@ -62,7 +62,7 @@ class PasswordResult {
         }
         Else {
             $this.Password = [EncryptedPassword]$this.Password
-            $output = [PSCredential]::new($user,$(ConvertTo-SecureString "$($this.Password.Password)" -AsPlainText -Force))
+            $output = [PSCredential]::new($user,$(ConvertTo-SecureString "$($this.Password)" -AsPlainText -Force))
             return $output
         }
     }


### PR DESCRIPTION
When using the method .ToPSCredential() on a password result object with a plaintext password the credential wouldn't be created and would be returned as null. Now correctly converts to a pscredential.