### PR TITLE
ToPSCredential Fix

### DIFF
--- a/internal/functions/PasswordStateClass.ps1
+++ b/internal/functions/PasswordStateClass.ps1
@@ -1,5 +1,6 @@
 ﻿[Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSAvoidUsingConvertToSecureStringWithPlainText', '', Justification = 'Script is converting to secure string.')]
 [Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSAvoidUsingPlainTextForPassword', '', Justification = 'Script is converting to secure string.')]
+Param()
 # Create Class
 Class EncryptedPassword {
     EncryptedPassword ($Password) {

--- a/internal/functions/PasswordStateClass.ps1
+++ b/internal/functions/PasswordStateClass.ps1
@@ -1,6 +1,5 @@
 ﻿[Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSAvoidUsingConvertToSecureStringWithPlainText', '', Justification = 'Script is converting to secure string.')]
 [Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSAvoidUsingPlainTextForPassword', '', Justification = 'Script is converting to secure string.')]
-Param()
 # Create Class
 Class EncryptedPassword {
     EncryptedPassword ($Password) {
@@ -51,21 +50,20 @@ class PasswordResult {
             }
             $user += "$($this.Username)"
         }
-        $result = if ($null -eq $this.Password -or "" -eq $this.Password){
-            $true
-        }
-        if ($result -eq $true) {
-            return $null
-        }
-        If ($this.Password.GetType().Name -ne 'String' -and $result -eq $false) {
+       
+        If ($this.Password.GetType().Name -ne 'String') {
             $output = [PSCredential]::new($user, $this.Password.Password)
             return $output
         }
-        Else {
-            $this.Password = [EncryptedPassword]$this.Password
-            $output = [PSCredential]::new($user,$(ConvertTo-SecureString "$($this.Password)" -AsPlainText -Force))
+
+        Else{
+            if($this.Password.Length -lt 1){
+                return $null
+            }
+            $output = [PSCredential]::new($user, $(ConvertTo-SecureString -String $this.Password -AsPlainText -Force))
             return $output
         }
+
     }
     [String]$Description
     [String]$Domain

--- a/internal/functions/PasswordStateClass.ps1
+++ b/internal/functions/PasswordStateClass.ps1
@@ -50,17 +50,19 @@ class PasswordResult {
             }
             $user += "$($this.Username)"
         }
-        $result = [String]::IsNullOrEmpty($this.Password.Password)
-        If ($this.Password.GetType().Name -ne 'String' -and $result -eq $false) {
-            $output = [PSCredential]::new($user, $this.Password.Password)
-            return $output
+        $result = if ($null -eq $this.Password -or "" -eq $this.Password){
+            $true
         }
         if ($result -eq $true) {
             return $null
         }
+        If ($this.Password.GetType().Name -ne 'String' -and $result -eq $false) {
+            $output = [PSCredential]::new($user, $this.Password.Password)
+            return $output
+        }
         Else {
             $this.Password = [EncryptedPassword]$this.Password
-            $output = [PSCredential]::new($user, $this.Password.Password)
+            $output = [PSCredential]::new($user,$(ConvertTo-SecureString "$($this.Password.Password)" -AsPlainText -Force))
             return $output
         }
     }

--- a/internal/functions/PasswordStateClass.ps1
+++ b/internal/functions/PasswordStateClass.ps1
@@ -1,6 +1,8 @@
 ﻿[Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSAvoidUsingConvertToSecureStringWithPlainText', '', Justification = 'Script is converting to secure string.')]
 [Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSAvoidUsingPlainTextForPassword', '', Justification = 'Script is converting to secure string.')]
 # Create Class
+param()
+
 Class EncryptedPassword {
     EncryptedPassword ($Password) {
         $result = [string]::IsNullOrEmpty($Password)

--- a/internal/functions/PasswordStateClass.ps1
+++ b/internal/functions/PasswordStateClass.ps1
@@ -62,7 +62,7 @@ class PasswordResult {
         }
         Else {
             $this.Password = [EncryptedPassword]$this.Password
-            $output = [PSCredential]::new($user,$(ConvertTo-SecureString "$($this.Password.Password)" -AsPlainText -Force))
+            $output = [PSCredential]::new($user,$(ConvertTo-SecureString "$($this.Password)" -AsPlainText -Force))
             return $output
         }
     }


### PR DESCRIPTION
Resolves issue #130 with converting encrypted passwords to a pscredential type introduced in 4.4.29.