### PR TITLE
Changed Encoding for the HTTP POST/PUT/DELETE Actions to UTF-8

### DIFF
--- a/internal/functions/New-PasswordStateResource.ps1
+++ b/internal/functions/New-PasswordStateResource.ps1
@@ -57,7 +57,7 @@ function New-PasswordStateResource {
             "URI"             = "$($PasswordStateEnvironment.baseuri)$uri"
             "Method"          = $method.ToUpper()
             "ContentType"     = $ContentType
-            "Body"            = $body
+            "Body"            = [System.Text.Encoding]::UTF8.GetBytes($body)
         }
         if ($body) {
             Write-PSFMessage -Level Verbose -Message "Using body $($body)"

--- a/internal/functions/Remove-PasswordStateResource.ps1
+++ b/internal/functions/Remove-PasswordStateResource.ps1
@@ -58,7 +58,7 @@ function Remove-PasswordStateResource {
             "URI"             = "$($passwordstateenvironment.baseuri)$uri"
             "Method"          = $method.ToUpper()
             "ContentType"     = $ContentType
-            "Body"            = $body
+            "Body"            = [System.Text.Encoding]::UTF8.GetBytes($body)
         }
         if ($body) {
             Write-PSFMessage -Level Verbose -Message "Using body $($body)"

--- a/internal/functions/Set-PasswordStateResource.ps1
+++ b/internal/functions/Set-PasswordStateResource.ps1
@@ -56,7 +56,7 @@ function Set-PasswordStateResource {
             "URI"             = "$($passwordstateenvironment.baseuri)$uri"
             "Method"          = $method.ToUpper()
             "ContentType"     = $ContentType
-            "Body"            = $body
+            "Body"            = [System.Text.Encoding]::UTF8.GetBytes($body)
         }
         if ($body) {
             Write-PSFMessage -Level Verbose -Message "Using body $($body)"


### PR DESCRIPTION
Changed Encoding for the HTTP POST/PUT/DELETE Actions to UTF-8 to include culture dependent characters (german umlauts etc.).

For example, at the moment, if you send "René" or "Jörg" (so culture dependent umlauts) to the api using default encoding, you will get an error from the API and the api object cannot be deleted/added/changed.

René