### PR TITLE
(v9) Fix Set-PasswordStatePassword if existing password should not be changed

### DIFF
--- a/functions/Set-PasswordStatePassword.ps1
+++ b/functions/Set-PasswordStatePassword.ps1
@@ -1,5 +1,4 @@
-﻿function Set-PasswordStatePassword
-{
+﻿function Set-PasswordStatePassword {
     [Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSAvoidUsingPlainTextForPassword', '', Justification = 'API requires password be passed as plain text')]
     [Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSAvoidUsingUserNameAndPassWordParams', '', Justification = 'API requires password be passed as plain text')]
     [Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSAvoidGlobalVars', '', Justification = 'Needed for backward compatability')]
@@ -19,8 +18,7 @@
                 $regex = [Regex]::Escape($InvalidChars)
                 $regex = "[$regex]"
                 $Invalid = [Regex]::Matches($_, $regex, 'IgnoreCase') | Select-Object -ExpandProperty Value | Sort-Object -Unique
-                if ($null -ne $Invalid)
-                {
+                if ($null -ne $Invalid) {
                     throw "ERROR: The specified password contains the following illegal characters: '$Invalid'. Please do not use the characters '$InvalidChars' in your password since the api does not understand these characters."
                 }
                 return $true
@@ -58,12 +56,10 @@
         [parameter(ValueFromPipelineByPropertyName, Mandatory = $true, ParameterSetName = "ResetSchedule", Position = 2)]
         [parameter(ValueFromPipelineByPropertyName, Mandatory = $false, ParameterSetName = "Reset", Position = 2)]
         [ValidateScript( {
-                if ($_ -notmatch '^(([0-1][0-9]|[2-2][0-3]):([0-5][0-9]))$')
-                {
+                if ($_ -notmatch '^(([0-1][0-9]|[2-2][0-3]):([0-5][0-9]))$') {
                     throw "Given PasswordResetSchedule '$_' is not a valid Schedule! Please specify a correct schedule in (Date)Time Format, e.g. '23:10', '00:15', '09:00' from 00:00-23:59."
                 }
-                else
-                {
+                else {
                     $true
                 }
             })]
@@ -80,12 +76,10 @@
         [parameter(ValueFromPipelineByPropertyName, Mandatory = $false, ParameterSetName = "Reset", Position = 5)]
         [parameter(ValueFromPipelineByPropertyName, Mandatory = $false, ParameterSetName = "ResetSchedule", Position = 5)]
         [ValidateScript( {
-                if ($_ -notmatch '^(([0-1][0-9]|[2-2][0-3]):([0-5][0-9]))$')
-                {
+                if ($_ -notmatch '^(([0-1][0-9]|[2-2][0-3]):([0-5][0-9]))$') {
                     throw "Given HeartbeatSchedule '$_' is not a valid Schedule! Please specify a correct schedule in (Date)Time Format, e.g. '23:10', '00:15', '09:00' from 00:00-23:59."
                 }
-                else
-                {
+                else {
                     $true
                 }
             })]
@@ -105,109 +99,90 @@
         [parameter(ValueFromPipelineByPropertyName, Mandatory = $false, Position = 24)]
         [ValidateScript( {
                 # The dates for the ExpiryDate needs to be culture aware, so we cannot validate a specific date format.
-                function isDate([string]$StrDate)
-                {
+                function isDate([string]$StrDate) {
                     [boolean]($StrDate -as [DateTime])
                 }
-                if ([string]::IsNullOrEmpty($_)){
+                if ([string]::IsNullOrEmpty($_)) {
                     $true
                 }
-                elseif (!(isDate $_))
-                {
+                elseif (!(isDate $_)) {
                     throw "Given ExpiryDate '$_' is not a valid Date format. Also, please specify the ExpiryDate in the date format that you have chosen in 'System Settings - miscellaneous - Default Locale' (Default: 'YYYY-MM-DD')."
                 }
-                else
-                {
+                else {
                     $true
                 }
             })]
-            [string]$ExpiryDate,
+        [string]$ExpiryDate,
         [parameter(ValueFromPipelineByPropertyName, Mandatory = $false, Position = 25)][switch]$AllowExport,
         [parameter(ValueFromPipelineByPropertyName, Mandatory = $false, Position = 25)][ValidateLength(0, 200)][string]$WebUser_ID,
         [parameter(ValueFromPipelineByPropertyName, Mandatory = $false, Position = 25)][ValidateLength(0, 200)][string]$WebPassword_ID,
         [parameter(ValueFromPipelineByPropertyName, Mandatory = $false, Position = 26)][string]$Reason
     )
 
-    begin
-    {
+    begin {
         # Import PasswordState Environment for validation of PasswordsInPlainText setting
         $PWSProfile = Get-PasswordStateEnvironment
         # Add a reason to the audit log if specified
-        If ($Reason)
-        {
+        If ($Reason) {
             $headerreason = @{"Reason" = "$reason" }
             $parms = @{ExtraParams = @{"Headers" = $headerreason } }
         }
         else { $parms = @{ } }
     }
 
-    process
-    {
-        if ($PasswordID)
-        {
-            try
-            {
+    process {
+        if ($PasswordID) {
+            try {
                 $result = Get-PasswordStatePassword -PasswordID $PasswordID -ErrorAction Stop
             }
-            catch
-            {
+            catch {
                 throw "Given PasswordID '$PasswordID' not found"
             }
             Write-PSFMessage -Level Verbose -Message "Password with PasswordID '$PasswordID' found. Updating password '$($result.title)'..."
         }
-        else
-        {
+        else {
             throw "Please apply '-PasswordID'! PasswordID is needed to update passwords."
         }
-        if ($PSCmdlet.ShouldProcess("PasswordID:$($result.PasswordID) Title:$($result.Title)"))
-        {
+        if ($PSCmdlet.ShouldProcess("PasswordID:$($result.PasswordID) Title:$($result.Title)")) {
             # Loop through each of the bound parameters and set the updated value on the object.
-            foreach ($i in $PSBoundParameters.Keys)
-            {
+            foreach ($i in $PSBoundParameters.Keys) {
                 # Replace Result property with that of the bound parameter
                 $NotProcess = "PreventAuditing", "Reason", "verbose", "erroraction", "debug", "whatif", "confirm"
-                if ($NotProcess -notcontains $i)
-                {
-                    if ($i -eq "Password" -and $PSBoundParameters.$($i) -eq "EncryptedPassword")
-                    {
+                if ($NotProcess -notcontains $i) {
+                    if ($i -eq "Password" -and $PSBoundParameters.$($i) -eq "EncryptedPassword") {
                         $result.DecryptPassword()
                     }
-                    else
-                    {
+                    else {
                         # if existing result object does contain a specified property replace it with the specified property value
-                        if (Get-Member -InputObject $result -MemberType Property -Name $i)
-                        {
+                        if (Get-Member -InputObject $result -MemberType Property -Name $i) {
                             $result.$($i) = $PSBoundParameters.$($i)
                         }
                         # if existing result object does NOT contain a specified property, create a new member and add the new value
-                        else
-                        {
+                        else {
                             # if specified property type is a switch parameter, we need to specified the value of sub property IsPresent
-                            if ($PSBoundParameters.$($i).GetType().Name -eq "SwitchParameter")
-                            {
-                                try
-                                {
+                            if ($PSBoundParameters.$($i).GetType().Name -eq "SwitchParameter") {
+                                try {
                                     $result | Add-Member -MemberType NoteProperty -Name $i -Value $PSBoundParameters.$($i).IsPresent -ErrorAction Stop
                                 }
-                                catch
-                                {
-                                    throw $_.Exception
+                                catch {
+                                    throw $_.Exception.Message
                                 }
                             }
-                            else
-                            {
-                                try
-                                {
+                            else {
+                                try {
                                     $result | Add-Member -MemberType NoteProperty -Name $i -Value $PSBoundParameters.$($i) -ErrorAction Stop
                                 }
-                                catch
-                                {
-                                    throw $_.Exception
+                                catch {
+                                    throw $_.Exception.Message
                                 }
                             }
                         }
                     }
                 }
+            }
+            # Change in v9: If password of existing object should not be changed (-Password or -GeneratePassword not given), we need to remove it from the result that should be send to the api as change request
+            if ($PSBoundParameters.Keys -notcontains "Password") {
+                $result = $result | Select-Object -Property * -ExcludeProperty Password
             }
             # Store in a new variable and remove all null values as password state doesn't like nulls.
             $body = $result
@@ -216,10 +191,8 @@
             # Get all properties from the object.
             $properties = ($body | Get-Member -Force | Where-Object { $_.MemberType -eq "Property" -or $_.MemberType -eq "NoteProperty" }).Name
             # Get only those properties which aren't empty and add them to our selection array.
-            foreach ($item in $properties)
-            {
-                if ($body.$($item) -notlike $null)
-                {
+            foreach ($item in $properties) {
+                if ($body.$($item) -notlike $null) {
                     $selections += $item
                 }
             }
@@ -228,53 +201,41 @@
             # Write back to password state.
             $uri = "/api/passwords"
             $body = "$($body | ConvertTo-Json)"
-            try
-            {
+            try {
                 $output = Set-PasswordStateResource -uri $uri -body $body @parms -ErrorAction Stop
             }
-            catch
-            {
-                throw $_.Exception
+            catch {
+                throw $_.Exception.Message
             }
-            if ($output)
-            {
-                if ((Get-Member -InputObject $output -MemberType NoteProperty -Name Status) -and (Get-Member -InputObject $output -MemberType NoteProperty -Name CurrentPassword) -and (Get-Member -InputObject $output -MemberType NoteProperty -Name NewPassword))
-                {
-                    try
-                    {
+            if ($output) {
+                if ((Get-Member -InputObject $output -MemberType NoteProperty -Name Status) -and (Get-Member -InputObject $output -MemberType NoteProperty -Name CurrentPassword) -and (Get-Member -InputObject $output -MemberType NoteProperty -Name NewPassword)) {
+                    try {
                         [PasswordResetResult]$output = $output
                     }
-                    catch
-                    {
+                    catch {
                         throw $_.Exception
                     }
-                    if (!$PWSProfile.PasswordsInPlainText)
-                    {
+                    if (!$PWSProfile.PasswordsInPlainText) {
                         $output.CurrentPassword = [EncryptedPassword]$output.CurrentPassword
                         $output.NewPassword = [EncryptedPassword]$output.NewPassword
                     }
                     return
                 }
-                try
-                {
+                try {
                     [PasswordResult]$output = $output
                 }
-                catch
-                {
+                catch {
                     throw $_.Exception
                 }
-                if (!$PWSProfile.PasswordsInPlainText)
-                {
+                if (!$PWSProfile.PasswordsInPlainText) {
                     $output.Password = [EncryptedPassword]$output.Password
                 }
             }
         }
     }
 
-    end
-    {
-        if ($output)
-        {
+    end {
+        if ($output) {
             return $output
         }
     }


### PR DESCRIPTION
Hi @dnewsholme 

Change in v9: If password of existing object should not be changed ( `-Password` or `-GeneratePassword` not given), we need to remove it from the result that should be send to the api as change request.

This should not break any compatibility with v8.

**Example:**

In the current implementation the Password property will be applied to any POST Request, but only the length of the password will be send to the api. PasswordState v8 does not care as long as no password was specified. v9 will not accept this request (Internal Server Error 500), we need to remove this property from the body before sending it to the api. (Fix: (Line 183-186))

`Set-PasswordStatePassword -PasswordId 123 -GenericField1 "test" -Verbose`

```json
...
"Password": {
    "Password": {
      "Length": 14
    }
  },
...
```

Reference #132: Fix Set-PasswordStatePassword if existing password should not be changed.

(Please ignore the formatting changes).

Thanks,
René