### PR TITLE
Fix reason not being passed when calling Set-PasswordstatePassword

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -22,4 +22,6 @@ RUN apt-get -y install git procps lsb-release
 
 SHELL [ "pwsh", "-command" ]
 RUN Set-PSRepository -Name PSGallery -InstallationPolicy Trusted
+COPY certs/*.pem /etc/ssl/certs/
+RUN update-ca-certificates
 RUN pwsh -noprofile -noninteractive -c 'Install-Module PowershellGet -Scope AllUsers -Force; Install-Module Pester -Scope AllUsers -Verbose; Install-Module PSFramework -Scope AllUsers'

--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ testResults.xml
 cov.xml
 .vscode
 passwordstate.code-workspace
+.devcontainer\certs\*.pem

--- a/.gitignore
+++ b/.gitignore
@@ -5,4 +5,4 @@ testResults.xml
 cov.xml
 .vscode
 passwordstate.code-workspace
-.devcontainer\certs\*.pem
+/.devcontainer/certs/*.pem

--- a/functions/Set-PasswordStatePassword.ps1
+++ b/functions/Set-PasswordStatePassword.ps1
@@ -133,7 +133,7 @@
     process {
         if ($PasswordID) {
             try {
-                $result = Get-PasswordStatePassword -PasswordID $PasswordID -ErrorAction Stop
+                $result = Get-PasswordStatePassword -PasswordID $PasswordID @headerreason -ErrorAction Stop
             }
             catch {
                 throw "Given PasswordID '$PasswordID' not found"

--- a/internal/functions/Get-PasswordStateResource.ps1
+++ b/internal/functions/Get-PasswordStateResource.ps1
@@ -69,7 +69,7 @@ function Get-PasswordStateResource {
             $params += @{"headers" = $headers }
             $skipheaders = $true
         }
-        if ($extraparams -and $null -ne $extraparams.Headers) {
+        if ($extraparams -and $null -ne $extraparams.Headers -and $skipheaders -ne $true) {
             Write-Verbose "[$(Get-Date -format G)] Adding extra parameter $($extraparams.keys) $($extraparams.values)"
             $params += $extraparams
         }

--- a/internal/functions/Remove-PasswordStateResource.ps1
+++ b/internal/functions/Remove-PasswordStateResource.ps1
@@ -72,7 +72,7 @@ function Remove-PasswordStateResource {
             $params += @{"headers" = $headers }
             $skipheaders = $true
         }
-        if ($extraparams -and $null -eq $extraparams.Headers) {
+        if ($extraparams -and $null -eq $extraparams.Headers -and $skipheaders -ne $true) {
             Write-Verbose "[$(Get-Date -format G)] Adding extra parameter $($extraparams.keys) $($extraparams.values)"
             $params += $extraparams
         }

--- a/internal/functions/Set-PasswordStateResource.ps1
+++ b/internal/functions/Set-PasswordStateResource.ps1
@@ -70,7 +70,7 @@ function Set-PasswordStateResource {
             $params += @{"headers" = $headers }
             $skipheaders = $true
         }
-        if ($extraparams -and $null -eq $extraparams.Headers) {
+        if ($extraparams -and $null -eq $extraparams.Headers -and $skipheaders -ne $true) {
             Write-Verbose "[$(Get-Date -format G)] Adding extra parameter $($extraparams.keys) $($extraparams.values)"
             $params += $extraparams
         }


### PR DESCRIPTION
Fixes #144 

Reason was not being passed to Get-PasswordstatePassword call inside Set-PasswordstatePassword

This adds the parameter to the call if a reason was specified.