### PR TITLE
Fix New-PasswordStateList. Remove TLS 1.2 force and fix error handlin…

### DIFF
--- a/functions/New-PasswordStateList.ps1
+++ b/functions/New-PasswordStateList.ps1
@@ -66,6 +66,9 @@
             throw "The following properties are not implemented yet to the PasswordState (Win)API, please remove these parameters: 'AllowExport', 'PreventBadPasswordUse', 'PasswordResetEnabled', 'PasswordGeneratorID', 'PasswordStrengthPolicyID'. `
             If you would like to change these properties, please copy the settings from an existing password list (-CopySettingsFromPasswordListID) or create a password list template and copy the settings from the template (-CopySettingsFromTemplateID)"
         }
+        if (-not($PSBoundParameters.Keys | Where-Object {$_ -like "*Permission*"})){
+            throw "Permissions must be granted for a password list to be able to create it"
+        }
     }
     process {
         # Build the Custom object to convert to json and send to the api.

--- a/functions/Test-PasswordPwned.ps1
+++ b/functions/Test-PasswordPwned.ps1
@@ -5,7 +5,6 @@
         [parameter(ValueFromPipeline, Mandatory = $true, Position = 0)][Alias("Password")][String]$Value
     )
     begin {
-        [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12
         class pwnpasswd {
             [string]$password
             [string]$hash

--- a/internal/functions/New-PasswordStateResource.ps1
+++ b/internal/functions/New-PasswordStateResource.ps1
@@ -100,9 +100,7 @@ function New-PasswordStateResource {
                 }
             }
             catch [System.Net.WebException] {
-                Write-PSFMessage -Level Verbose -Message "The request to Passwordstate timed out after $($PasswordStateEnvironment.TimeoutSeconds)"
-                Write-Error -Exception $_.Exception -Message "The request to Passwordstate timed out after $($PasswordStateEnvironment.TimeoutSeconds)"
-                throw "Passwordstate did not respond within the allotted time of $($PasswordStateEnvironment.TimeoutSeconds) seconds"
+                throw $_.Exception
             }
 
         }

--- a/internal/functions/Remove-PasswordStateResource.ps1
+++ b/internal/functions/Remove-PasswordStateResource.ps1
@@ -32,9 +32,6 @@ function Remove-PasswordStateResource {
     )
 
     begin {
-        # Force TLS 1.2
-        $SecurityProtocol = [System.Net.ServicePointManager]::SecurityProtocol
-        [System.Net.ServicePointManager]::SecurityProtocol = [System.Net.SecurityProtocolType]::Tls12
         # Import the environment
         $passwordstateenvironment = $(Get-PasswordStateEnvironment)
         # If the apikey is windowsauth then rebuild the uri string to match the windows auth apis, otherwise just build the api headers.

--- a/internal/functions/Set-PasswordStateResource.ps1
+++ b/internal/functions/Set-PasswordStateResource.ps1
@@ -32,9 +32,6 @@ function Set-PasswordStateResource {
     )
 
     begin {
-        # Force TLS 1.2
-        $SecurityProtocol = [System.Net.ServicePointManager]::SecurityProtocol
-        [System.Net.ServicePointManager]::SecurityProtocol = [System.Net.SecurityProtocolType]::Tls12
         $passwordstateenvironment = $(Get-PasswordStateEnvironment)
         # If the apikey is windowsauth then rebuild the uri string to match the windows auth apis, otherwise just build the api headers.
         Switch ($passwordstateenvironment.AuthType) {


### PR DESCRIPTION
- Fixes errors from when New-PasswordStateList is called without permissions parameters. #150 
- Fixes forcing TLS versions #151 
- Fixes Error handling from New-PasswordstateResource #147 