### PR TITLE
Get-PasswordstatePassword broken after upgrade to 9653 

### DIFF
--- a/docs/Get-PasswordStatePassword.md
+++ b/docs/Get-PasswordStatePassword.md
@@ -27,13 +27,13 @@ Get-PasswordStatePassword [-PasswordID] <Int32> [[-Reason] <String>] [-PreventAu
 ### Specific
 ```
 Get-PasswordStatePassword [[-Title] <String>] [[-UserName] <String>] [[-HostName] <String>]
- [[-ADDomainNetBIOS] <String>] [[-AccountType] <String>] [[-Description] <String>] [[-Notes] <String>] [[-URL] <String>]
- [[-SiteID] <String>] [[-SiteLocation] <String>] [[-GenericField1] <String>] [[-GenericField2] <String>]
- [[-GenericField3] <String>] [[-GenericField4] <String>] [[-GenericField5] <String>]
- [[-GenericField6] <String>] [[-GenericField7] <String>] [[-GenericField8] <String>]
- [[-GenericField9] <String>] [[-GenericField10] <String>] [[-AccountTypeID] <String>] [-PasswordResetEnabled]
- [[-ExpiryDate] <String>] [[-ExpiryDateRange] <String>] [[-AndOr] <String>] [[-PasswordListID] <Int32>]
- [[-Reason] <String>] [-PreventAuditing] [<CommonParameters>]
+ [[-AccountType] <String>] [[-Description] <String>] [[-Notes] <String>] [[-URL] <String>] [[-SiteID] <String>]
+ [[-SiteLocation] <String>] [[-GenericField1] <String>] [[-GenericField2] <String>] [[-GenericField3] <String>]
+ [[-GenericField4] <String>] [[-GenericField5] <String>] [[-GenericField6] <String>]
+ [[-GenericField7] <String>] [[-GenericField8] <String>] [[-GenericField9] <String>]
+ [[-GenericField10] <String>] [[-AccountTypeID] <String>] [-PasswordResetEnabled] [[-ExpiryDate] <String>]
+ [[-ExpiryDateRange] <String>] [[-AndOr] <String>] [[-PasswordListID] <Int32>] [[-Reason] <String>]
+ [-PreventAuditing] [[-ADDomainNetBIOS] <String>] [<CommonParameters>]
 ```
 
 ## DESCRIPTION
@@ -251,7 +251,7 @@ If you want to search for a record that relates to an Active Directory account, 
 ```yaml
 Type: String
 Parameter Sets: Specific
-Aliases:
+Aliases: Domain
 
 Required: False
 Position: 28

--- a/docs/Get-PasswordStatePassword.md
+++ b/docs/Get-PasswordStatePassword.md
@@ -33,7 +33,11 @@ Get-PasswordStatePassword [[-Title] <String>] [[-UserName] <String>] [[-HostName
  [[-GenericField7] <String>] [[-GenericField8] <String>] [[-GenericField9] <String>]
  [[-GenericField10] <String>] [[-AccountTypeID] <String>] [-PasswordResetEnabled] [[-ExpiryDate] <String>]
  [[-ExpiryDateRange] <String>] [[-AndOr] <String>] [[-PasswordListID] <Int32>] [[-Reason] <String>]
- [-PreventAuditing] [[-ADDomainNetBIOS] <String>] [<CommonParameters>]
+ [-PreventAuditing] [[-ADDomainNetBIOS] <String>] [-WebGenericField1_ID <String>]
+ [-WebGenericField2_ID <String>] [-WebGenericField3_ID <String>] [-WebGenericField4_ID <String>]
+ [-WebGenericField5_ID <String>] [-WebGenericField6_ID <String>] [-WebGenericField7_ID <String>]
+ [-WebGenericField8_ID <String>] [-WebGenericField9_ID <String>] [-WebGenericField10_ID <String>]
+ [-WebUser_ID <String>] [-WebPassword_ID <String>] [-WebOTP_ID <String>] [<CommonParameters>]
 ```
 
 ## DESCRIPTION
@@ -714,6 +718,201 @@ Aliases:
 
 Required: False
 Position: 1
+Default value: None
+Accept pipeline input: True (ByPropertyName)
+Accept wildcard characters: False
+```
+
+### -WebGenericField1_ID
+This field is only used in conjunction with the Browser Extensions, and represents any generic fields, in additional to Username and Password, they you may need to use for a web site
+
+```yaml
+Type: String
+Parameter Sets: Specific
+Aliases:
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: True (ByPropertyName)
+Accept wildcard characters: False
+```
+
+### -WebGenericField10_ID
+This field is only used in conjunction with the Browser Extensions, and represents any generic fields, in additional to Username and Password, they you may need to use for a web site
+
+```yaml
+Type: String
+Parameter Sets: Specific
+Aliases:
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: True (ByPropertyName)
+Accept wildcard characters: False
+```
+
+### -WebGenericField2_ID
+This field is only used in conjunction with the Browser Extensions, and represents any generic fields, in additional to Username and Password, they you may need to use for a web site
+
+```yaml
+Type: String
+Parameter Sets: Specific
+Aliases:
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: True (ByPropertyName)
+Accept wildcard characters: False
+```
+
+### -WebGenericField3_ID
+This field is only used in conjunction with the Browser Extensions, and represents any generic fields, in additional to Username and Password, they you may need to use for a web site
+
+```yaml
+Type: String
+Parameter Sets: Specific
+Aliases:
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: True (ByPropertyName)
+Accept wildcard characters: False
+```
+
+### -WebGenericField4_ID
+This field is only used in conjunction with the Browser Extensions, and represents any generic fields, in additional to Username and Password, they you may need to use for a web site
+
+```yaml
+Type: String
+Parameter Sets: Specific
+Aliases:
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: True (ByPropertyName)
+Accept wildcard characters: False
+```
+
+### -WebGenericField5_ID
+This field is only used in conjunction with the Browser Extensions, and represents any generic fields, in additional to Username and Password, they you may need to use for a web site
+
+```yaml
+Type: String
+Parameter Sets: Specific
+Aliases:
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: True (ByPropertyName)
+Accept wildcard characters: False
+```
+
+### -WebGenericField6_ID
+This field is only used in conjunction with the Browser Extensions, and represents any generic fields, in additional to Username and Password, they you may need to use for a web site
+
+```yaml
+Type: String
+Parameter Sets: Specific
+Aliases:
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: True (ByPropertyName)
+Accept wildcard characters: False
+```
+
+### -WebGenericField7_ID
+This field is only used in conjunction with the Browser Extensions, and represents any generic fields, in additional to Username and Password, they you may need to use for a web site
+
+```yaml
+Type: String
+Parameter Sets: Specific
+Aliases:
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: True (ByPropertyName)
+Accept wildcard characters: False
+```
+
+### -WebGenericField8_ID
+This field is only used in conjunction with the Browser Extensions, and represents any generic fields, in additional to Username and Password, they you may need to use for a web site
+
+```yaml
+Type: String
+Parameter Sets: Specific
+Aliases:
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: True (ByPropertyName)
+Accept wildcard characters: False
+```
+
+### -WebGenericField9_ID
+This field is only used in conjunction with the Browser Extensions, and represents any generic fields, in additional to Username and Password, they you may need to use for a web site
+
+```yaml
+Type: String
+Parameter Sets: Specific
+Aliases:
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: True (ByPropertyName)
+Accept wildcard characters: False
+```
+
+### -WebOTP_ID
+This field is only used in conjunction with the Browser Extensions, and represents the OTP field for login pages i.e. the tag name of the Input HTML field.
+
+```yaml
+Type: String
+Parameter Sets: Specific
+Aliases:
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: True (ByPropertyName)
+Accept wildcard characters: False
+```
+
+### -WebPassword_ID
+This field is only used in conjunction with the Browser Extensions, and represents the Password field for login pages i.e. the tag name of the Input HTML field.
+
+```yaml
+Type: String
+Parameter Sets: Specific
+Aliases:
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: True (ByPropertyName)
+Accept wildcard characters: False
+```
+
+### -WebUser_ID
+This field is only used in conjunction with the Browser Extensions, and represents the Username field for login pages i.e. the tag name of the Input HTML field.
+
+```yaml
+Type: String
+Parameter Sets: Specific
+Aliases:
+
+Required: False
+Position: Named
 Default value: None
 Accept pipeline input: True (ByPropertyName)
 Accept wildcard characters: False

--- a/en-us/passwordstate-management-help.xml
+++ b/en-us/passwordstate-management-help.xml
@@ -1385,6 +1385,162 @@ If you do not specify this parameter, it will report data based on all Site Loca
           </dev:type>
           <dev:defaultValue>None</dev:defaultValue>
         </command:parameter>
+        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="named" aliases="none">
+          <maml:name>WebGenericField1_ID</maml:name>
+          <maml:Description>
+            <maml:para>This field is only used in conjunction with the Browser Extensions, and represents any generic fields, in additional to Username and Password, they you may need to use for a web site</maml:para>
+          </maml:Description>
+          <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+          <dev:type>
+            <maml:name>String</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="named" aliases="none">
+          <maml:name>WebGenericField10_ID</maml:name>
+          <maml:Description>
+            <maml:para>This field is only used in conjunction with the Browser Extensions, and represents any generic fields, in additional to Username and Password, they you may need to use for a web site</maml:para>
+          </maml:Description>
+          <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+          <dev:type>
+            <maml:name>String</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="named" aliases="none">
+          <maml:name>WebGenericField2_ID</maml:name>
+          <maml:Description>
+            <maml:para>This field is only used in conjunction with the Browser Extensions, and represents any generic fields, in additional to Username and Password, they you may need to use for a web site</maml:para>
+          </maml:Description>
+          <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+          <dev:type>
+            <maml:name>String</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="named" aliases="none">
+          <maml:name>WebGenericField3_ID</maml:name>
+          <maml:Description>
+            <maml:para>This field is only used in conjunction with the Browser Extensions, and represents any generic fields, in additional to Username and Password, they you may need to use for a web site</maml:para>
+          </maml:Description>
+          <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+          <dev:type>
+            <maml:name>String</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="named" aliases="none">
+          <maml:name>WebGenericField4_ID</maml:name>
+          <maml:Description>
+            <maml:para>This field is only used in conjunction with the Browser Extensions, and represents any generic fields, in additional to Username and Password, they you may need to use for a web site</maml:para>
+          </maml:Description>
+          <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+          <dev:type>
+            <maml:name>String</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="named" aliases="none">
+          <maml:name>WebGenericField5_ID</maml:name>
+          <maml:Description>
+            <maml:para>This field is only used in conjunction with the Browser Extensions, and represents any generic fields, in additional to Username and Password, they you may need to use for a web site</maml:para>
+          </maml:Description>
+          <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+          <dev:type>
+            <maml:name>String</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="named" aliases="none">
+          <maml:name>WebGenericField6_ID</maml:name>
+          <maml:Description>
+            <maml:para>This field is only used in conjunction with the Browser Extensions, and represents any generic fields, in additional to Username and Password, they you may need to use for a web site</maml:para>
+          </maml:Description>
+          <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+          <dev:type>
+            <maml:name>String</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="named" aliases="none">
+          <maml:name>WebGenericField7_ID</maml:name>
+          <maml:Description>
+            <maml:para>This field is only used in conjunction with the Browser Extensions, and represents any generic fields, in additional to Username and Password, they you may need to use for a web site</maml:para>
+          </maml:Description>
+          <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+          <dev:type>
+            <maml:name>String</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="named" aliases="none">
+          <maml:name>WebGenericField8_ID</maml:name>
+          <maml:Description>
+            <maml:para>This field is only used in conjunction with the Browser Extensions, and represents any generic fields, in additional to Username and Password, they you may need to use for a web site</maml:para>
+          </maml:Description>
+          <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+          <dev:type>
+            <maml:name>String</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="named" aliases="none">
+          <maml:name>WebGenericField9_ID</maml:name>
+          <maml:Description>
+            <maml:para>This field is only used in conjunction with the Browser Extensions, and represents any generic fields, in additional to Username and Password, they you may need to use for a web site</maml:para>
+          </maml:Description>
+          <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+          <dev:type>
+            <maml:name>String</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="named" aliases="none">
+          <maml:name>WebOTP_ID</maml:name>
+          <maml:Description>
+            <maml:para>This field is only used in conjunction with the Browser Extensions, and represents the OTP field for login pages i.e. the tag name of the Input HTML field.</maml:para>
+          </maml:Description>
+          <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+          <dev:type>
+            <maml:name>String</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="named" aliases="none">
+          <maml:name>WebPassword_ID</maml:name>
+          <maml:Description>
+            <maml:para>This field is only used in conjunction with the Browser Extensions, and represents the Password field for login pages i.e. the tag name of the Input HTML field.</maml:para>
+          </maml:Description>
+          <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+          <dev:type>
+            <maml:name>String</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="named" aliases="none">
+          <maml:name>WebUser_ID</maml:name>
+          <maml:Description>
+            <maml:para>This field is only used in conjunction with the Browser Extensions, and represents the Username field for login pages i.e. the tag name of the Input HTML field.</maml:para>
+          </maml:Description>
+          <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+          <dev:type>
+            <maml:name>String</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
       </command:syntaxItem>
       <command:syntaxItem>
         <maml:name>Get-PasswordStatePassword</maml:name>
@@ -1855,6 +2011,162 @@ URL parameter can be the URL for HTTP, HTTPS, FTP, SFTP, etc. found in the passw
           <maml:para>An optional parameter to filter searches to those with a certain username as multiple titles may have the same value.
 Some systems require a username and password to authenticate. This field represents the UserName to do so.
 </maml:para>
+        </maml:Description>
+        <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+        <dev:type>
+          <maml:name>String</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="named" aliases="none">
+        <maml:name>WebGenericField1_ID</maml:name>
+        <maml:Description>
+          <maml:para>This field is only used in conjunction with the Browser Extensions, and represents any generic fields, in additional to Username and Password, they you may need to use for a web site</maml:para>
+        </maml:Description>
+        <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+        <dev:type>
+          <maml:name>String</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="named" aliases="none">
+        <maml:name>WebGenericField10_ID</maml:name>
+        <maml:Description>
+          <maml:para>This field is only used in conjunction with the Browser Extensions, and represents any generic fields, in additional to Username and Password, they you may need to use for a web site</maml:para>
+        </maml:Description>
+        <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+        <dev:type>
+          <maml:name>String</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="named" aliases="none">
+        <maml:name>WebGenericField2_ID</maml:name>
+        <maml:Description>
+          <maml:para>This field is only used in conjunction with the Browser Extensions, and represents any generic fields, in additional to Username and Password, they you may need to use for a web site</maml:para>
+        </maml:Description>
+        <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+        <dev:type>
+          <maml:name>String</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="named" aliases="none">
+        <maml:name>WebGenericField3_ID</maml:name>
+        <maml:Description>
+          <maml:para>This field is only used in conjunction with the Browser Extensions, and represents any generic fields, in additional to Username and Password, they you may need to use for a web site</maml:para>
+        </maml:Description>
+        <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+        <dev:type>
+          <maml:name>String</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="named" aliases="none">
+        <maml:name>WebGenericField4_ID</maml:name>
+        <maml:Description>
+          <maml:para>This field is only used in conjunction with the Browser Extensions, and represents any generic fields, in additional to Username and Password, they you may need to use for a web site</maml:para>
+        </maml:Description>
+        <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+        <dev:type>
+          <maml:name>String</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="named" aliases="none">
+        <maml:name>WebGenericField5_ID</maml:name>
+        <maml:Description>
+          <maml:para>This field is only used in conjunction with the Browser Extensions, and represents any generic fields, in additional to Username and Password, they you may need to use for a web site</maml:para>
+        </maml:Description>
+        <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+        <dev:type>
+          <maml:name>String</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="named" aliases="none">
+        <maml:name>WebGenericField6_ID</maml:name>
+        <maml:Description>
+          <maml:para>This field is only used in conjunction with the Browser Extensions, and represents any generic fields, in additional to Username and Password, they you may need to use for a web site</maml:para>
+        </maml:Description>
+        <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+        <dev:type>
+          <maml:name>String</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="named" aliases="none">
+        <maml:name>WebGenericField7_ID</maml:name>
+        <maml:Description>
+          <maml:para>This field is only used in conjunction with the Browser Extensions, and represents any generic fields, in additional to Username and Password, they you may need to use for a web site</maml:para>
+        </maml:Description>
+        <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+        <dev:type>
+          <maml:name>String</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="named" aliases="none">
+        <maml:name>WebGenericField8_ID</maml:name>
+        <maml:Description>
+          <maml:para>This field is only used in conjunction with the Browser Extensions, and represents any generic fields, in additional to Username and Password, they you may need to use for a web site</maml:para>
+        </maml:Description>
+        <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+        <dev:type>
+          <maml:name>String</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="named" aliases="none">
+        <maml:name>WebGenericField9_ID</maml:name>
+        <maml:Description>
+          <maml:para>This field is only used in conjunction with the Browser Extensions, and represents any generic fields, in additional to Username and Password, they you may need to use for a web site</maml:para>
+        </maml:Description>
+        <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+        <dev:type>
+          <maml:name>String</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="named" aliases="none">
+        <maml:name>WebOTP_ID</maml:name>
+        <maml:Description>
+          <maml:para>This field is only used in conjunction with the Browser Extensions, and represents the OTP field for login pages i.e. the tag name of the Input HTML field.</maml:para>
+        </maml:Description>
+        <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+        <dev:type>
+          <maml:name>String</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="named" aliases="none">
+        <maml:name>WebPassword_ID</maml:name>
+        <maml:Description>
+          <maml:para>This field is only used in conjunction with the Browser Extensions, and represents the Password field for login pages i.e. the tag name of the Input HTML field.</maml:para>
+        </maml:Description>
+        <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+        <dev:type>
+          <maml:name>String</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="named" aliases="none">
+        <maml:name>WebUser_ID</maml:name>
+        <maml:Description>
+          <maml:para>This field is only used in conjunction with the Browser Extensions, and represents the Username field for login pages i.e. the tag name of the Input HTML field.</maml:para>
         </maml:Description>
         <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
         <dev:type>

--- a/en-us/passwordstate-management-help.xml
+++ b/en-us/passwordstate-management-help.xml
@@ -1296,7 +1296,7 @@ The `ExpiryDate` is a date in which the password value should be reset for the P
           </dev:type>
           <dev:defaultValue>False</dev:defaultValue>
         </command:parameter>
-        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="28" aliases="none">
+        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="28" aliases="Domain">
           <maml:name>ADDomainNetBIOS</maml:name>
           <maml:Description>
             <maml:para>If you want to search for a record that relates to an Active Directory account, then you can specify the Active Directory NetBIOS value here, as it is stored on the `Administration -&gt; PasswordState Administration -&gt; Active Directory Domains` screen in PasswordState or found in a password record if set.</maml:para>
@@ -1502,7 +1502,7 @@ Account Types and their ID values can be seen on the screen `Administration -&gt
         </dev:type>
         <dev:defaultValue>None</dev:defaultValue>
       </command:parameter>
-      <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="28" aliases="none">
+      <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="28" aliases="Domain">
         <maml:name>ADDomainNetBIOS</maml:name>
         <maml:Description>
           <maml:para>If you want to search for a record that relates to an Active Directory account, then you can specify the Active Directory NetBIOS value here, as it is stored on the `Administration -&gt; PasswordState Administration -&gt; Active Directory Domains` screen in PasswordState or found in a password record if set.</maml:para>

--- a/functions/Get-PasswordStatePassword.ps1
+++ b/functions/Get-PasswordStatePassword.ps1
@@ -58,7 +58,20 @@
         [Parameter(ParameterSetName = 'General', ValueFromPipelineByPropertyName, Position = 1)][Parameter(ParameterSetName = 'Specific', ValueFromPipelineByPropertyName, Position = 25)][Nullable[System.Int32]]$PasswordListID,
         [parameter(ValueFromPipelineByPropertyName, Position = 26)][string]$Reason,
         [parameter(ValueFromPipelineByPropertyName, Position = 27)][switch]$PreventAuditing,
-        [Parameter(ParameterSetName = 'Specific', ValueFromPipelineByPropertyName, Position = 28)][ValidateLength(1, 50)][Alias('Domain')][string]$ADDomainNetBIOS
+        [Parameter(ParameterSetName = 'Specific', ValueFromPipelineByPropertyName, Position = 28)][ValidateLength(1, 50)][Alias('Domain')][string]$ADDomainNetBIOS,
+        [Parameter(ParameterSetName = 'Specific', ValueFromPipelineByPropertyName, Position = 29)][ValidateLength(1, 200)][string]$WebGenericField1_ID,
+        [Parameter(ParameterSetName = 'Specific', ValueFromPipelineByPropertyName, Position = 30)][ValidateLength(1, 200)][string]$WebGenericField2_ID,
+        [Parameter(ParameterSetName = 'Specific', ValueFromPipelineByPropertyName, Position = 31)][ValidateLength(1, 200)][string]$WebGenericField3_ID,
+        [Parameter(ParameterSetName = 'Specific', ValueFromPipelineByPropertyName, Position = 32)][ValidateLength(1, 200)][string]$WebGenericField4_ID,
+        [Parameter(ParameterSetName = 'Specific', ValueFromPipelineByPropertyName, Position = 33)][ValidateLength(1, 200)][string]$WebGenericField5_ID,
+        [Parameter(ParameterSetName = 'Specific', ValueFromPipelineByPropertyName, Position = 34)][ValidateLength(1, 200)][string]$WebGenericField6_ID,
+        [Parameter(ParameterSetName = 'Specific', ValueFromPipelineByPropertyName, Position = 35)][ValidateLength(1, 200)][string]$WebGenericField7_ID,
+        [Parameter(ParameterSetName = 'Specific', ValueFromPipelineByPropertyName, Position = 36)][ValidateLength(1, 200)][string]$WebGenericField8_ID,
+        [Parameter(ParameterSetName = 'Specific', ValueFromPipelineByPropertyName, Position = 37)][ValidateLength(1, 200)][string]$WebGenericField9_ID,
+        [Parameter(ParameterSetName = 'Specific', ValueFromPipelineByPropertyName, Position = 38)][ValidateLength(1, 200)][string]$WebGenericField10_ID,
+        [Parameter(ParameterSetName = 'Specific', ValueFromPipelineByPropertyName, Position = 39)][ValidateLength(1, 200)][string]$WebUser_ID,
+        [Parameter(ParameterSetName = 'Specific', ValueFromPipelineByPropertyName, Position = 40)][ValidateLength(1, 200)][string]$WebPassword_ID,
+        [Parameter(ParameterSetName = 'Specific', ValueFromPipelineByPropertyName, Position = 41)][ValidateLength(1, 200)][string]$WebOTP_ID
     )
 
     Begin {
@@ -66,8 +79,8 @@
         $PWSProfile = Get-PasswordStateEnvironment
         # Add a reason to the audit log if specified
         If ($Reason) {
-            $headerreason = @{"Reason" = "$Reason" }
-            $parms = @{ExtraParams = @{"Headers" = $headerreason } }
+            $headerreason = @{'Reason' = "$Reason" }
+            $parms = @{ExtraParams = @{'Headers' = $headerreason } }
         }
         else { $parms = @{ } }
     }
@@ -88,7 +101,7 @@
                     }
                     # Return all Passwords that the user/APIKey has access to
                     else {
-                        $uri = "/api/passwords/?QueryAll"
+                        $uri = '/api/passwords/?QueryAll'
                     }
                 }
                 Else {
@@ -127,13 +140,26 @@
                 If ($GenericField8) { $BuildURL += "GenericField8=$([System.Web.HttpUtility]::UrlEncode($GenericField8))&" }
                 If ($GenericField9) { $BuildURL += "GenericField9=$([System.Web.HttpUtility]::UrlEncode($GenericField9))&" }
                 If ($GenericField10) { $BuildURL += "GenericField10=$([System.Web.HttpUtility]::UrlEncode($GenericField10))&" }
+                If ($WebGenericField1_ID) { $BuildURL += "WebGenericField1_ID=$([System.Web.HttpUtility]::UrlEncode($WebGenericField1_ID))&" }
+                If ($WebGenericField2_ID) { $BuildURL += "WebGenericField2_ID=$([System.Web.HttpUtility]::UrlEncode($WebGenericField2_ID))&" }
+                If ($WebGenericField3_ID) { $BuildURL += "WebGenericField3_ID=$([System.Web.HttpUtility]::UrlEncode($WebGenericField3_ID))&" }
+                If ($WebGenericField4_ID) { $BuildURL += "WebGenericField4_ID=$([System.Web.HttpUtility]::UrlEncode($WebGenericField4_ID))&" }
+                If ($WebGenericField5_ID) { $BuildURL += "WebGenericField5_ID=$([System.Web.HttpUtility]::UrlEncode($WebGenericField5_ID))&" }
+                If ($WebGenericField6_ID) { $BuildURL += "WebGenericField6_ID=$([System.Web.HttpUtility]::UrlEncode($WebGenericField6_ID))&" }
+                If ($WebGenericField7_ID) { $BuildURL += "WebGenericField7_ID=$([System.Web.HttpUtility]::UrlEncode($WebGenericField7_ID))&" }
+                If ($WebGenericField8_ID) { $BuildURL += "WebGenericField8_ID=$([System.Web.HttpUtility]::UrlEncode($WebGenericField8_ID))&" }
+                If ($WebGenericField9_ID) { $BuildURL += "WebGenericField9_ID=$([System.Web.HttpUtility]::UrlEncode($WebGenericField9_ID))&" }
+                If ($WebGenericField10_ID) { $BuildURL += "WebGenericField10_ID=$([System.Web.HttpUtility]::UrlEncode($WebGenericField10_ID))&" }
+                If ($WebUser_ID) { $BuildURL += "WebUser_ID=$([System.Web.HttpUtility]::UrlEncode($WebUser_ID))&" }
+                If ($WebPassword_ID) { $BuildURL += "WebPassword_ID=$([System.Web.HttpUtility]::UrlEncode($WebPassword_ID))&" }
+                If ($WebOTP_ID) { $BuildURL += "WebOTP_ID=$([System.Web.HttpUtility]::UrlEncode($WebOTP_ID))&" }
                 If ($AccountTypeID) { $BuildURL += "AccountTypeID=$([System.Web.HttpUtility]::UrlEncode($AccountTypeID))&" }
                 If ($PasswordResetEnabled.IsPresent) { $BuildURL += "PasswordResetEnabled=$([System.Web.HttpUtility]::UrlEncode('true'))&" }
                 If ($ExpiryDateRange) { $BuildURL += "ExpiryDateRange=$([System.Web.HttpUtility]::UrlEncode($ExpiryDateRange))&" }
                 If ($ExpiryDate) { $BuildURL += "ExpiryDate=$([System.Web.HttpUtility]::UrlEncode($ExpiryDate))&" }
                 If ($AndOr) { $BuildURL += "AndOr=$([System.Web.HttpUtility]::UrlEncode($AndOr))&" }
 
-                $BuildURL = $BuildURL -Replace ".$"
+                $BuildURL = $BuildURL -Replace '.$'
 
                 if ($PasswordListID) {
                     $uri = "/api/searchpasswords/$($PasswordListID)$($BuildURL)"
@@ -145,7 +171,7 @@
         }
         Switch ($PreventAuditing) {
             $True {
-                $uri += "&PreventAuditing=true"
+                $uri += '&PreventAuditing=true'
             }
             Default {
 

--- a/internal/functions/PasswordStateClass.ps1
+++ b/internal/functions/PasswordStateClass.ps1
@@ -88,7 +88,20 @@ class PasswordResult {
     [string]$ExpiryDate
     [System.Boolean]$AllowExport
     [string]$AccountType
-    [System.Array]$OTP
+    [string]$OTP
+    [String]$WebUser_ID
+    [String]$WebPassword_ID
+    [String]$WebOTP_ID
+    [String]$WebGenericField1_ID
+    [String]$WebGenericField2_ID
+    [String]$WebGenericField3_ID
+    [String]$WebGenericField4_ID
+    [String]$WebGenericField5_ID
+    [String]$WebGenericField6_ID
+    [String]$WebGenericField7_ID
+    [String]$WebGenericField8_ID
+    [String]$WebGenericField9_ID
+    [String]$WebGenericField10_ID
     # Constructor used to initiate the default property set.
     PasswordResult() {
         [string[]]$DefaultProperties = 'PasswordID', 'Title', 'Username', 'Password', 'Description', 'Domain'

--- a/tests/functions/Get-PasswordStatePassword.Tests.ps1
+++ b/tests/functions/Get-PasswordStatePassword.Tests.ps1
@@ -17,42 +17,55 @@ Describe 'Get-PasswordStatePassword' {
         $APIKey = 'SuperSecretKey'
         $ProfilePath = 'TestDrive:'
         $TestCredential = [pscredential]::new('myuser', (ConvertTo-SecureString -AsPlainText -Force -String $APIKey))
-        $Paramattributetype='System.Management.Automation.ParameterAttribute'
+        $Paramattributetype = 'System.Management.Automation.ParameterAttribute'
         . "$($PSScriptRoot)\json\enum-jsonfiles.ps1"
     }
-    Context 'Parameter Validation' -Foreach @(
-        @{parametername = 'Search'; mandatory = 'False'; ParameterSetName = "General" }
-        @{parametername = 'Title'; mandatory = 'False'; ParameterSetName = "Specific" }
-        @{parametername = 'UserName'; mandatory = 'False'; ParameterSetName = "Specific" }
-        @{parametername = 'HostName'; mandatory = 'False'; ParameterSetName = "Specific" }
-        @{parametername = 'ADDomainNetBios'; mandatory = 'False'; ParameterSetName = "Specific" }
-        @{parametername = 'AccountType'; mandatory = 'False'; ParameterSetName = "Specific" }
-        @{parametername = 'Description'; mandatory = 'False'; ParameterSetName = "Specific" }
-        @{parametername = 'Notes'; mandatory = 'False'; ParameterSetName = "Specific" }
-        @{parametername = 'URL'; mandatory = 'False'; ParameterSetName = "Specific" }
-        @{parametername = 'SiteID'; mandatory = 'False'; ParameterSetName = "Specific" }
-        @{parametername = 'SiteLocation'; mandatory = 'False'; ParameterSetName = "Specific" }
-        @{parametername = 'GenericField1'; mandatory = 'False'; ParameterSetName = "Specific" }
-        @{parametername = 'GenericField2'; mandatory = 'False'; ParameterSetName = "Specific" }
-        @{parametername = 'GenericField3'; mandatory = 'False'; ParameterSetName = "Specific" }
-        @{parametername = 'GenericField4'; mandatory = 'False'; ParameterSetName = "Specific" }
-        @{parametername = 'GenericField5'; mandatory = 'False'; ParameterSetName = "Specific" }
-        @{parametername = 'GenericField6'; mandatory = 'False'; ParameterSetName = "Specific" }
-        @{parametername = 'GenericField7'; mandatory = 'False'; ParameterSetName = "Specific" }
-        @{parametername = 'GenericField8'; mandatory = 'False'; ParameterSetName = "Specific" }
-        @{parametername = 'GenericField9'; mandatory = 'False'; ParameterSetName = "Specific" }
-        @{parametername = 'GenericField10'; mandatory = 'False'; ParameterSetName = "Specific" }
-        @{parametername = 'Reason'; mandatory = 'False'; ParameterSetName = "__AllParameterSets" }
-        @{parametername = 'PreventAuditing'; mandatory = 'False'; ParameterSetName = "__AllParameterSets" }
+    Context 'Parameter Validation' -ForEach @(
+        @{parametername = 'Search'; mandatory = 'False'; ParameterSetName = 'General' }
+        @{parametername = 'Title'; mandatory = 'False'; ParameterSetName = 'Specific' }
+        @{parametername = 'UserName'; mandatory = 'False'; ParameterSetName = 'Specific' }
+        @{parametername = 'HostName'; mandatory = 'False'; ParameterSetName = 'Specific' }
+        @{parametername = 'ADDomainNetBios'; mandatory = 'False'; ParameterSetName = 'Specific' }
+        @{parametername = 'AccountType'; mandatory = 'False'; ParameterSetName = 'Specific' }
+        @{parametername = 'Description'; mandatory = 'False'; ParameterSetName = 'Specific' }
+        @{parametername = 'Notes'; mandatory = 'False'; ParameterSetName = 'Specific' }
+        @{parametername = 'URL'; mandatory = 'False'; ParameterSetName = 'Specific' }
+        @{parametername = 'SiteID'; mandatory = 'False'; ParameterSetName = 'Specific' }
+        @{parametername = 'SiteLocation'; mandatory = 'False'; ParameterSetName = 'Specific' }
+        @{parametername = 'GenericField1'; mandatory = 'False'; ParameterSetName = 'Specific' }
+        @{parametername = 'GenericField2'; mandatory = 'False'; ParameterSetName = 'Specific' }
+        @{parametername = 'GenericField3'; mandatory = 'False'; ParameterSetName = 'Specific' }
+        @{parametername = 'GenericField4'; mandatory = 'False'; ParameterSetName = 'Specific' }
+        @{parametername = 'GenericField5'; mandatory = 'False'; ParameterSetName = 'Specific' }
+        @{parametername = 'GenericField6'; mandatory = 'False'; ParameterSetName = 'Specific' }
+        @{parametername = 'GenericField7'; mandatory = 'False'; ParameterSetName = 'Specific' }
+        @{parametername = 'GenericField8'; mandatory = 'False'; ParameterSetName = 'Specific' }
+        @{parametername = 'GenericField9'; mandatory = 'False'; ParameterSetName = 'Specific' }
+        @{parametername = 'GenericField10'; mandatory = 'False'; ParameterSetName = 'Specific' }
+        @{parametername = 'WebUser_ID'; mandatory = 'False'; ParameterSetName = 'Specific' }
+        @{parametername = 'WebPassword_ID'; mandatory = 'False'; ParameterSetName = 'Specific' }
+        @{parametername = 'WebOTP_ID'; mandatory = 'False'; ParameterSetName = 'Specific' }
+        @{parametername = 'WebGenericField1_ID'; mandatory = 'False'; ParameterSetName = 'Specific' }
+        @{parametername = 'WebGenericField2_ID'; mandatory = 'False'; ParameterSetName = 'Specific' }
+        @{parametername = 'WebGenericField3_ID'; mandatory = 'False'; ParameterSetName = 'Specific' }
+        @{parametername = 'WebGenericField4_ID'; mandatory = 'False'; ParameterSetName = 'Specific' }
+        @{parametername = 'WebGenericField5_ID'; mandatory = 'False'; ParameterSetName = 'Specific' }
+        @{parametername = 'WebGenericField6_ID'; mandatory = 'False'; ParameterSetName = 'Specific' }
+        @{parametername = 'WebGenericField7_ID'; mandatory = 'False'; ParameterSetName = 'Specific' }
+        @{parametername = 'WebGenericField8_ID'; mandatory = 'False'; ParameterSetName = 'Specific' }
+        @{parametername = 'WebGenericField9_ID'; mandatory = 'False'; ParameterSetName = 'Specific' }
+        @{parametername = 'WebGenericField10_ID'; mandatory = 'False'; ParameterSetName = 'Specific' }
+        @{parametername = 'Reason'; mandatory = 'False'; ParameterSetName = '__AllParameterSets' }
+        @{parametername = 'PreventAuditing'; mandatory = 'False'; ParameterSetName = '__AllParameterSets' }
     ) {
         It 'should verify if parameter "<parametername>" is present' {
             (Get-Command -Name $FunctionName).Parameters[$parametername] | Should -Not -BeNullOrEmpty
         }
         It 'should verify if mandatory for parameter "<parametername>" is set to "<mandatory>"' {
-            "$(((Get-Command -Name $FunctionName).Parameters[$parametername].Attributes | Where-Object { $_.GetType().fullname -eq $Paramattributetype}).Mandatory)" | Should -be $mandatory
+            "$(((Get-Command -Name $FunctionName).Parameters[$parametername].Attributes | Where-Object { $_.GetType().fullname -eq $Paramattributetype}).Mandatory)" | Should -Be $mandatory
         }
         It 'should verify if parameter "<parametername>" is part of "<parametersetname>" ParameterSetName' {
-            "$(((Get-Command -Name $FunctionName).Parameters[$parametername].Attributes | Where-Object { $_.GetType().fullname -eq $Paramattributetype}).ParameterSetName)" | Should -be $ParameterSetName
+            "$(((Get-Command -Name $FunctionName).Parameters[$parametername].Attributes | Where-Object { $_.GetType().fullname -eq $Paramattributetype}).ParameterSetName)" | Should -Be $ParameterSetName
         }
     }
     Context 'Unit tests with API key' {
@@ -62,29 +75,29 @@ Describe 'Get-PasswordStatePassword' {
             Mock -CommandName 'Get-PasswordStateResource' -ModuleName 'passwordstate-management' -MockWith { $Global:TestJSON["PasswordSearch$($ParameterName)Response"] } -ParameterFilter { $uri -and $uri -match '\/searchpasswords\/(\d+){0,1}\?\w+=[^\&]+$' } -Verifiable
         }
         AfterAll {
-            Remove-Item -Path "$([environment]::GetFolderPath("UserProfile"))\Passwordstate.json" -Force -Confirm:$false -ErrorAction SilentlyContinue
+            Remove-Item -Path "$([environment]::GetFolderPath('UserProfile'))\Passwordstate.json" -Force -Confirm:$false -ErrorAction SilentlyContinue
         }
         It 'Should return <ListCount> for parameter <parametername> without PasswordListID' -ForEach @(
-            @{parametername = 'Title'; testvalue = "Demo AD Username"; ListCount = 2; PWLID = 53 }
-            @{parametername = 'UserName'; testvalue = "username1"; ListCount = 3; PWLID = 53 }
-            @{parametername = 'HostName'; testvalue = "HostA"; ListCount = 4; PWLID = 53 }
-            @{parametername = 'Domain'; testvalue = "MYDomain"; ListCount = 5; PWLID = 53 }
-            @{parametername = 'AccountType'; testvalue = ""; ListCount = 1; PWLID = 53 } # testvalue must be empty because the actual property is AccountTypeID
-            @{parametername = 'Description'; testvalue = "Description for "; ListCount = 6; PWLID = 53 }
-            @{parametername = 'Notes'; testvalue = "Same Notes"; ListCount = 7; PWLID = 53 }
-            @{parametername = 'URL'; testvalue = "https://passworstate.local"; ListCount = 8; PWLID = 53 }
-            @{parametername = 'SiteID'; testvalue = ""; ListCount = 9; PWLID = 53 }
-            @{parametername = 'SiteLocation'; testvalue = ""; ListCount = 11; PWLID = 53 }
-            @{parametername = 'GenericField1'; testvalue = "TestField1"; ListCount = 11; PWLID = 53 }
-            @{parametername = 'GenericField2'; testvalue = "TestField2"; ListCount = 12; PWLID = 53 }
-            @{parametername = 'GenericField3'; testvalue = "TestField3"; ListCount = 13; PWLID = 53 }
-            @{parametername = 'GenericField4'; testvalue = "TestField4"; ListCount = 14; PWLID = 53 }
-            @{parametername = 'GenericField5'; testvalue = "TestField5"; ListCount = 15; PWLID = 53 }
-            @{parametername = 'GenericField6'; testvalue = "TestField6"; ListCount = 16; PWLID = 53 }
-            @{parametername = 'GenericField7'; testvalue = "TestField7"; ListCount = 17; PWLID = 53 }
-            @{parametername = 'GenericField8'; testvalue = "TestField8"; ListCount = 18; PWLID = 53 }
-            @{parametername = 'GenericField9'; testvalue = "TestField9"; ListCount = 19; PWLID = 53 }
-            @{parametername = 'GenericField10'; testvalue = "TestField10"; ListCount = 20; PWLID = 53 }
+            @{parametername = 'Title'; testvalue = 'Demo AD Username'; ListCount = 2; PWLID = 53 }
+            @{parametername = 'UserName'; testvalue = 'username1'; ListCount = 3; PWLID = 53 }
+            @{parametername = 'HostName'; testvalue = 'HostA'; ListCount = 4; PWLID = 53 }
+            @{parametername = 'Domain'; testvalue = 'MYDomain'; ListCount = 5; PWLID = 53 }
+            @{parametername = 'AccountType'; testvalue = ''; ListCount = 1; PWLID = 53 } # testvalue must be empty because the actual property is AccountTypeID
+            @{parametername = 'Description'; testvalue = 'Description for '; ListCount = 6; PWLID = 53 }
+            @{parametername = 'Notes'; testvalue = 'Same Notes'; ListCount = 7; PWLID = 53 }
+            @{parametername = 'URL'; testvalue = 'https://passworstate.local'; ListCount = 8; PWLID = 53 }
+            @{parametername = 'SiteID'; testvalue = ''; ListCount = 9; PWLID = 53 }
+            @{parametername = 'SiteLocation'; testvalue = ''; ListCount = 11; PWLID = 53 }
+            @{parametername = 'GenericField1'; testvalue = 'TestField1'; ListCount = 11; PWLID = 53 }
+            @{parametername = 'GenericField2'; testvalue = 'TestField2'; ListCount = 12; PWLID = 53 }
+            @{parametername = 'GenericField3'; testvalue = 'TestField3'; ListCount = 13; PWLID = 53 }
+            @{parametername = 'GenericField4'; testvalue = 'TestField4'; ListCount = 14; PWLID = 53 }
+            @{parametername = 'GenericField5'; testvalue = 'TestField5'; ListCount = 15; PWLID = 53 }
+            @{parametername = 'GenericField6'; testvalue = 'TestField6'; ListCount = 16; PWLID = 53 }
+            @{parametername = 'GenericField7'; testvalue = 'TestField7'; ListCount = 17; PWLID = 53 }
+            @{parametername = 'GenericField8'; testvalue = 'TestField8'; ListCount = 18; PWLID = 53 }
+            @{parametername = 'GenericField9'; testvalue = 'TestField9'; ListCount = 19; PWLID = 53 }
+            @{parametername = 'GenericField10'; testvalue = 'TestField10'; ListCount = 20; PWLID = 53 }
         ) {
             $Result = if ($parametername -ne '') {
                 ((Invoke-Expression -Command "$($FunctionName) -$($Parametername) '$($testvalue)'" ) | Measure-Object).Count
@@ -98,26 +111,26 @@ Describe 'Get-PasswordStatePassword' {
             }
         }
         It 'Should return <ListCount> for parameter <parametername> with PasswordListID <PWLID>' -ForEach @(
-            @{parametername = 'Title'; testvalue = "Demo AD Username"; ListCount = 2; PWLID = 53 }
-            @{parametername = 'UserName'; testvalue = "username1"; ListCount = 3; PWLID = 53 }
-            @{parametername = 'HostName'; testvalue = "HostA"; ListCount = 4; PWLID = 53 }
-            @{parametername = 'Domain'; testvalue = "MYDomain"; ListCount = 5; PWLID = 53 }
-            @{parametername = 'AccountType'; testvalue = ""; ListCount = 1; PWLID = 53 } # testvalue must be empty because the actual property is AccountTypeID
-            @{parametername = 'Description'; testvalue = "Description for "; ListCount = 6; PWLID = 53 }
-            @{parametername = 'Notes'; testvalue = "Same Notes"; ListCount = 7; PWLID = 53 }
-            @{parametername = 'URL'; testvalue = "https://passworstate.local"; ListCount = 8; PWLID = 53 }
-            @{parametername = 'SiteID'; testvalue = ""; ListCount = 9; PWLID = 53 }
-            @{parametername = 'SiteLocation'; testvalue = ""; ListCount = 11; PWLID = 53 }
-            @{parametername = 'GenericField1'; testvalue = "TestField1"; ListCount = 11; PWLID = 53 }
-            @{parametername = 'GenericField2'; testvalue = "TestField2"; ListCount = 12; PWLID = 53 }
-            @{parametername = 'GenericField3'; testvalue = "TestField3"; ListCount = 13; PWLID = 53 }
-            @{parametername = 'GenericField4'; testvalue = "TestField4"; ListCount = 14; PWLID = 53 }
-            @{parametername = 'GenericField5'; testvalue = "TestField5"; ListCount = 15; PWLID = 53 }
-            @{parametername = 'GenericField6'; testvalue = "TestField6"; ListCount = 16; PWLID = 53 }
-            @{parametername = 'GenericField7'; testvalue = "TestField7"; ListCount = 17; PWLID = 53 }
-            @{parametername = 'GenericField8'; testvalue = "TestField8"; ListCount = 18; PWLID = 53 }
-            @{parametername = 'GenericField9'; testvalue = "TestField9"; ListCount = 19; PWLID = 53 }
-            @{parametername = 'GenericField10'; testvalue = "TestField10"; ListCount = 20; PWLID = 53 }
+            @{parametername = 'Title'; testvalue = 'Demo AD Username'; ListCount = 2; PWLID = 53 }
+            @{parametername = 'UserName'; testvalue = 'username1'; ListCount = 3; PWLID = 53 }
+            @{parametername = 'HostName'; testvalue = 'HostA'; ListCount = 4; PWLID = 53 }
+            @{parametername = 'Domain'; testvalue = 'MYDomain'; ListCount = 5; PWLID = 53 }
+            @{parametername = 'AccountType'; testvalue = ''; ListCount = 1; PWLID = 53 } # testvalue must be empty because the actual property is AccountTypeID
+            @{parametername = 'Description'; testvalue = 'Description for '; ListCount = 6; PWLID = 53 }
+            @{parametername = 'Notes'; testvalue = 'Same Notes'; ListCount = 7; PWLID = 53 }
+            @{parametername = 'URL'; testvalue = 'https://passworstate.local'; ListCount = 8; PWLID = 53 }
+            @{parametername = 'SiteID'; testvalue = ''; ListCount = 9; PWLID = 53 }
+            @{parametername = 'SiteLocation'; testvalue = ''; ListCount = 11; PWLID = 53 }
+            @{parametername = 'GenericField1'; testvalue = 'TestField1'; ListCount = 11; PWLID = 53 }
+            @{parametername = 'GenericField2'; testvalue = 'TestField2'; ListCount = 12; PWLID = 53 }
+            @{parametername = 'GenericField3'; testvalue = 'TestField3'; ListCount = 13; PWLID = 53 }
+            @{parametername = 'GenericField4'; testvalue = 'TestField4'; ListCount = 14; PWLID = 53 }
+            @{parametername = 'GenericField5'; testvalue = 'TestField5'; ListCount = 15; PWLID = 53 }
+            @{parametername = 'GenericField6'; testvalue = 'TestField6'; ListCount = 16; PWLID = 53 }
+            @{parametername = 'GenericField7'; testvalue = 'TestField7'; ListCount = 17; PWLID = 53 }
+            @{parametername = 'GenericField8'; testvalue = 'TestField8'; ListCount = 18; PWLID = 53 }
+            @{parametername = 'GenericField9'; testvalue = 'TestField9'; ListCount = 19; PWLID = 53 }
+            @{parametername = 'GenericField10'; testvalue = 'TestField10'; ListCount = 20; PWLID = 53 }
         ) {
             $Result = if ($parametername -ne '') {
                 ((Invoke-Expression -Command "$($FunctionName) -$($Parametername) '$($testvalue)'" ) | Measure-Object).Count
@@ -131,26 +144,26 @@ Describe 'Get-PasswordStatePassword' {
             }
         }
         It 'Should return <ListCount> for parameter <parametername> without PasswordListID and PreventAudit set to True' -ForEach @(
-            @{parametername = 'Title'; testvalue = "Demo AD Username"; ListCount = 2; PWLID = 53 }
-            @{parametername = 'UserName'; testvalue = "username1"; ListCount = 3; PWLID = 53 }
-            @{parametername = 'HostName'; testvalue = "HostA"; ListCount = 4; PWLID = 53 }
-            @{parametername = 'Domain'; testvalue = "MYDomain"; ListCount = 5; PWLID = 53 }
-            @{parametername = 'AccountType'; testvalue = ""; ListCount = 1; PWLID = 53 } # testvalue must be empty because the actual property is AccountTypeID
-            @{parametername = 'Description'; testvalue = "Description for "; ListCount = 6; PWLID = 53 }
-            @{parametername = 'Notes'; testvalue = "Same Notes"; ListCount = 7; PWLID = 53 }
-            @{parametername = 'URL'; testvalue = "https://passworstate.local"; ListCount = 8; PWLID = 53 }
-            @{parametername = 'SiteID'; testvalue = ""; ListCount = 9; PWLID = 53 }
-            @{parametername = 'SiteLocation'; testvalue = ""; ListCount = 11; PWLID = 53 }
-            @{parametername = 'GenericField1'; testvalue = "TestField1"; ListCount = 11; PWLID = 53 }
-            @{parametername = 'GenericField2'; testvalue = "TestField2"; ListCount = 12; PWLID = 53 }
-            @{parametername = 'GenericField3'; testvalue = "TestField3"; ListCount = 13; PWLID = 53 }
-            @{parametername = 'GenericField4'; testvalue = "TestField4"; ListCount = 14; PWLID = 53 }
-            @{parametername = 'GenericField5'; testvalue = "TestField5"; ListCount = 15; PWLID = 53 }
-            @{parametername = 'GenericField6'; testvalue = "TestField6"; ListCount = 16; PWLID = 53 }
-            @{parametername = 'GenericField7'; testvalue = "TestField7"; ListCount = 17; PWLID = 53 }
-            @{parametername = 'GenericField8'; testvalue = "TestField8"; ListCount = 18; PWLID = 53 }
-            @{parametername = 'GenericField9'; testvalue = "TestField9"; ListCount = 19; PWLID = 53 }
-            @{parametername = 'GenericField10'; testvalue = "TestField10"; ListCount = 20; PWLID = 53 }
+            @{parametername = 'Title'; testvalue = 'Demo AD Username'; ListCount = 2; PWLID = 53 }
+            @{parametername = 'UserName'; testvalue = 'username1'; ListCount = 3; PWLID = 53 }
+            @{parametername = 'HostName'; testvalue = 'HostA'; ListCount = 4; PWLID = 53 }
+            @{parametername = 'Domain'; testvalue = 'MYDomain'; ListCount = 5; PWLID = 53 }
+            @{parametername = 'AccountType'; testvalue = ''; ListCount = 1; PWLID = 53 } # testvalue must be empty because the actual property is AccountTypeID
+            @{parametername = 'Description'; testvalue = 'Description for '; ListCount = 6; PWLID = 53 }
+            @{parametername = 'Notes'; testvalue = 'Same Notes'; ListCount = 7; PWLID = 53 }
+            @{parametername = 'URL'; testvalue = 'https://passworstate.local'; ListCount = 8; PWLID = 53 }
+            @{parametername = 'SiteID'; testvalue = ''; ListCount = 9; PWLID = 53 }
+            @{parametername = 'SiteLocation'; testvalue = ''; ListCount = 11; PWLID = 53 }
+            @{parametername = 'GenericField1'; testvalue = 'TestField1'; ListCount = 11; PWLID = 53 }
+            @{parametername = 'GenericField2'; testvalue = 'TestField2'; ListCount = 12; PWLID = 53 }
+            @{parametername = 'GenericField3'; testvalue = 'TestField3'; ListCount = 13; PWLID = 53 }
+            @{parametername = 'GenericField4'; testvalue = 'TestField4'; ListCount = 14; PWLID = 53 }
+            @{parametername = 'GenericField5'; testvalue = 'TestField5'; ListCount = 15; PWLID = 53 }
+            @{parametername = 'GenericField6'; testvalue = 'TestField6'; ListCount = 16; PWLID = 53 }
+            @{parametername = 'GenericField7'; testvalue = 'TestField7'; ListCount = 17; PWLID = 53 }
+            @{parametername = 'GenericField8'; testvalue = 'TestField8'; ListCount = 18; PWLID = 53 }
+            @{parametername = 'GenericField9'; testvalue = 'TestField9'; ListCount = 19; PWLID = 53 }
+            @{parametername = 'GenericField10'; testvalue = 'TestField10'; ListCount = 20; PWLID = 53 }
         ) {
             $Result = if ($parametername -ne '') {
                 ((Invoke-Expression -Command "$($FunctionName) -$($Parametername) '$($testvalue)' -PreventAuditing:`$True" ) | Measure-Object).Count
@@ -164,26 +177,26 @@ Describe 'Get-PasswordStatePassword' {
             }
         }
         It 'Should return <ListCount> for parameter <parametername> with PasswordListID <PWLID> and PreventAudit set to True' -ForEach @(
-            @{parametername = 'Title'; testvalue = "Demo AD Username"; ListCount = 2; PWLID = 53 }
-            @{parametername = 'UserName'; testvalue = "username1"; ListCount = 3; PWLID = 53 }
-            @{parametername = 'HostName'; testvalue = "HostA"; ListCount = 4; PWLID = 53 }
-            @{parametername = 'Domain'; testvalue = "MYDomain"; ListCount = 5; PWLID = 53 }
-            @{parametername = 'AccountType'; testvalue = ""; ListCount = 1; PWLID = 53 } # testvalue must be empty because the actual property is AccountTypeID
-            @{parametername = 'Description'; testvalue = "Description for "; ListCount = 6; PWLID = 53 }
-            @{parametername = 'Notes'; testvalue = "Same Notes"; ListCount = 7; PWLID = 53 }
-            @{parametername = 'URL'; testvalue = "https://passworstate.local"; ListCount = 8; PWLID = 53 }
-            @{parametername = 'SiteID'; testvalue = ""; ListCount = 9; PWLID = 53 }
-            @{parametername = 'SiteLocation'; testvalue = ""; ListCount = 11; PWLID = 53 }
-            @{parametername = 'GenericField1'; testvalue = "TestField1"; ListCount = 11; PWLID = 53 }
-            @{parametername = 'GenericField2'; testvalue = "TestField2"; ListCount = 12; PWLID = 53 }
-            @{parametername = 'GenericField3'; testvalue = "TestField3"; ListCount = 13; PWLID = 53 }
-            @{parametername = 'GenericField4'; testvalue = "TestField4"; ListCount = 14; PWLID = 53 }
-            @{parametername = 'GenericField5'; testvalue = "TestField5"; ListCount = 15; PWLID = 53 }
-            @{parametername = 'GenericField6'; testvalue = "TestField6"; ListCount = 16; PWLID = 53 }
-            @{parametername = 'GenericField7'; testvalue = "TestField7"; ListCount = 17; PWLID = 53 }
-            @{parametername = 'GenericField8'; testvalue = "TestField8"; ListCount = 18; PWLID = 53 }
-            @{parametername = 'GenericField9'; testvalue = "TestField9"; ListCount = 19; PWLID = 53 }
-            @{parametername = 'GenericField10'; testvalue = "TestField10"; ListCount = 20; PWLID = 53 }
+            @{parametername = 'Title'; testvalue = 'Demo AD Username'; ListCount = 2; PWLID = 53 }
+            @{parametername = 'UserName'; testvalue = 'username1'; ListCount = 3; PWLID = 53 }
+            @{parametername = 'HostName'; testvalue = 'HostA'; ListCount = 4; PWLID = 53 }
+            @{parametername = 'Domain'; testvalue = 'MYDomain'; ListCount = 5; PWLID = 53 }
+            @{parametername = 'AccountType'; testvalue = ''; ListCount = 1; PWLID = 53 } # testvalue must be empty because the actual property is AccountTypeID
+            @{parametername = 'Description'; testvalue = 'Description for '; ListCount = 6; PWLID = 53 }
+            @{parametername = 'Notes'; testvalue = 'Same Notes'; ListCount = 7; PWLID = 53 }
+            @{parametername = 'URL'; testvalue = 'https://passworstate.local'; ListCount = 8; PWLID = 53 }
+            @{parametername = 'SiteID'; testvalue = ''; ListCount = 9; PWLID = 53 }
+            @{parametername = 'SiteLocation'; testvalue = ''; ListCount = 11; PWLID = 53 }
+            @{parametername = 'GenericField1'; testvalue = 'TestField1'; ListCount = 11; PWLID = 53 }
+            @{parametername = 'GenericField2'; testvalue = 'TestField2'; ListCount = 12; PWLID = 53 }
+            @{parametername = 'GenericField3'; testvalue = 'TestField3'; ListCount = 13; PWLID = 53 }
+            @{parametername = 'GenericField4'; testvalue = 'TestField4'; ListCount = 14; PWLID = 53 }
+            @{parametername = 'GenericField5'; testvalue = 'TestField5'; ListCount = 15; PWLID = 53 }
+            @{parametername = 'GenericField6'; testvalue = 'TestField6'; ListCount = 16; PWLID = 53 }
+            @{parametername = 'GenericField7'; testvalue = 'TestField7'; ListCount = 17; PWLID = 53 }
+            @{parametername = 'GenericField8'; testvalue = 'TestField8'; ListCount = 18; PWLID = 53 }
+            @{parametername = 'GenericField9'; testvalue = 'TestField9'; ListCount = 19; PWLID = 53 }
+            @{parametername = 'GenericField10'; testvalue = 'TestField10'; ListCount = 20; PWLID = 53 }
         ) {
             $Result = if ($parametername -ne '') {
                 ((Invoke-Expression -Command "$($FunctionName) -$($Parametername) '$($testvalue)'" ) | Measure-Object).Count
@@ -197,26 +210,26 @@ Describe 'Get-PasswordStatePassword' {
             }
         }
         It 'Should have a <parametername> matching "<testvalue>"' -ForEach @(
-            @{parametername = 'Title'; testvalue = "Demo AD Username"; ListCount = 2; PWLID = 53 }
-            @{parametername = 'UserName'; testvalue = "username1"; ListCount = 3; PWLID = 53 }
-            @{parametername = 'HostName'; testvalue = "HostA"; ListCount = 4; PWLID = 53 }
-            @{parametername = 'Domain'; testvalue = "MYDomain"; ListCount = 5; PWLID = 53 }
-            @{parametername = 'AccountType'; testvalue = ""; ListCount = 1; PWLID = 53 } # testvalue must be empty because the actual property is AccountTypeID
-            @{parametername = 'Description'; testvalue = "Description for "; ListCount = 6; PWLID = 53 }
-            @{parametername = 'Notes'; testvalue = "Same Notes"; ListCount = 7; PWLID = 53 }
-            @{parametername = 'URL'; testvalue = "https://passworstate.local"; ListCount = 8; PWLID = 53 }
-            @{parametername = 'SiteID'; testvalue = ""; ListCount = 9; PWLID = 53 }
-            @{parametername = 'SiteLocation'; testvalue = ""; ListCount = 11; PWLID = 53 }
-            @{parametername = 'GenericField1'; testvalue = "TestField1"; ListCount = 11; PWLID = 53 }
-            @{parametername = 'GenericField2'; testvalue = "TestField2"; ListCount = 12; PWLID = 53 }
-            @{parametername = 'GenericField3'; testvalue = "TestField3"; ListCount = 13; PWLID = 53 }
-            @{parametername = 'GenericField4'; testvalue = "TestField4"; ListCount = 14; PWLID = 53 }
-            @{parametername = 'GenericField5'; testvalue = "TestField5"; ListCount = 15; PWLID = 53 }
-            @{parametername = 'GenericField6'; testvalue = "TestField6"; ListCount = 16; PWLID = 53 }
-            @{parametername = 'GenericField7'; testvalue = "TestField7"; ListCount = 17; PWLID = 53 }
-            @{parametername = 'GenericField8'; testvalue = "TestField8"; ListCount = 18; PWLID = 53 }
-            @{parametername = 'GenericField9'; testvalue = "TestField9"; ListCount = 19; PWLID = 53 }
-            @{parametername = 'GenericField10'; testvalue = "TestField10"; ListCount = 20; PWLID = 53 }
+            @{parametername = 'Title'; testvalue = 'Demo AD Username'; ListCount = 2; PWLID = 53 }
+            @{parametername = 'UserName'; testvalue = 'username1'; ListCount = 3; PWLID = 53 }
+            @{parametername = 'HostName'; testvalue = 'HostA'; ListCount = 4; PWLID = 53 }
+            @{parametername = 'Domain'; testvalue = 'MYDomain'; ListCount = 5; PWLID = 53 }
+            @{parametername = 'AccountType'; testvalue = ''; ListCount = 1; PWLID = 53 } # testvalue must be empty because the actual property is AccountTypeID
+            @{parametername = 'Description'; testvalue = 'Description for '; ListCount = 6; PWLID = 53 }
+            @{parametername = 'Notes'; testvalue = 'Same Notes'; ListCount = 7; PWLID = 53 }
+            @{parametername = 'URL'; testvalue = 'https://passworstate.local'; ListCount = 8; PWLID = 53 }
+            @{parametername = 'SiteID'; testvalue = ''; ListCount = 9; PWLID = 53 }
+            @{parametername = 'SiteLocation'; testvalue = ''; ListCount = 11; PWLID = 53 }
+            @{parametername = 'GenericField1'; testvalue = 'TestField1'; ListCount = 11; PWLID = 53 }
+            @{parametername = 'GenericField2'; testvalue = 'TestField2'; ListCount = 12; PWLID = 53 }
+            @{parametername = 'GenericField3'; testvalue = 'TestField3'; ListCount = 13; PWLID = 53 }
+            @{parametername = 'GenericField4'; testvalue = 'TestField4'; ListCount = 14; PWLID = 53 }
+            @{parametername = 'GenericField5'; testvalue = 'TestField5'; ListCount = 15; PWLID = 53 }
+            @{parametername = 'GenericField6'; testvalue = 'TestField6'; ListCount = 16; PWLID = 53 }
+            @{parametername = 'GenericField7'; testvalue = 'TestField7'; ListCount = 17; PWLID = 53 }
+            @{parametername = 'GenericField8'; testvalue = 'TestField8'; ListCount = 18; PWLID = 53 }
+            @{parametername = 'GenericField9'; testvalue = 'TestField9'; ListCount = 19; PWLID = 53 }
+            @{parametername = 'GenericField10'; testvalue = 'TestField10'; ListCount = 20; PWLID = 53 }
         ) {
             $ResultValues = Invoke-Expression -Command "$($FunctionName) -$($Parametername) '$($testvalue)'"
             foreach ($ResultValue in $ResultValues) {
@@ -227,7 +240,7 @@ Describe 'Get-PasswordStatePassword' {
             }
         }
         It 'Should have a <parametername> matching "<testvalue>" for alias <alias>' -ForEach @(
-            @{parametername = 'ADDomainNetBios'; testvalue = "MYDomain"; ListCount = 5; PWLID = 53; alias='Domain' }
+            @{parametername = 'ADDomainNetBios'; testvalue = 'MYDomain'; ListCount = 5; PWLID = 53; alias = 'Domain' }
         ) {
             $ResultValues = Invoke-Expression -Command "$($FunctionName) -$($Parametername) '$($testvalue)'"
             foreach ($ResultValue in $ResultValues) {
@@ -245,29 +258,29 @@ Describe 'Get-PasswordStatePassword' {
             Mock -CommandName 'Get-PasswordStateResource' -ModuleName 'passwordstate-management' -MockWith { $Global:TestJSON["PasswordSearch$($ParameterName)Response"] } -ParameterFilter { $uri -and $uri -match '\/searchpasswords\/(\d+){0,1}\?\w+=[^\&]+$' } -Verifiable
         }
         AfterAll {
-            Remove-Item -Path "$([environment]::GetFolderPath("UserProfile"))\Passwordstate.json" -Force -Confirm:$false -ErrorAction SilentlyContinue
+            Remove-Item -Path "$([environment]::GetFolderPath('UserProfile'))\Passwordstate.json" -Force -Confirm:$false -ErrorAction SilentlyContinue
         }
         It 'Should return <ListCount> for parameter <parametername> without PasswordListID' -ForEach @(
-            @{parametername = 'Title'; testvalue = "Demo AD Username"; ListCount = 2; PWLID = 53 }
-            @{parametername = 'UserName'; testvalue = "username1"; ListCount = 3; PWLID = 53 }
-            @{parametername = 'HostName'; testvalue = "HostA"; ListCount = 4; PWLID = 53 }
-            @{parametername = 'Domain'; testvalue = "MYDomain"; ListCount = 5; PWLID = 53 }
-            @{parametername = 'AccountType'; testvalue = ""; ListCount = 1; PWLID = 53 } # testvalue must be empty because the actual property is AccountTypeID
-            @{parametername = 'Description'; testvalue = "Description for "; ListCount = 6; PWLID = 53 }
-            @{parametername = 'Notes'; testvalue = "Same Notes"; ListCount = 7; PWLID = 53 }
-            @{parametername = 'URL'; testvalue = "https://passworstate.local"; ListCount = 8; PWLID = 53 }
-            @{parametername = 'SiteID'; testvalue = ""; ListCount = 9; PWLID = 53 }
-            @{parametername = 'SiteLocation'; testvalue = ""; ListCount = 11; PWLID = 53 }
-            @{parametername = 'GenericField1'; testvalue = "TestField1"; ListCount = 11; PWLID = 53 }
-            @{parametername = 'GenericField2'; testvalue = "TestField2"; ListCount = 12; PWLID = 53 }
-            @{parametername = 'GenericField3'; testvalue = "TestField3"; ListCount = 13; PWLID = 53 }
-            @{parametername = 'GenericField4'; testvalue = "TestField4"; ListCount = 14; PWLID = 53 }
-            @{parametername = 'GenericField5'; testvalue = "TestField5"; ListCount = 15; PWLID = 53 }
-            @{parametername = 'GenericField6'; testvalue = "TestField6"; ListCount = 16; PWLID = 53 }
-            @{parametername = 'GenericField7'; testvalue = "TestField7"; ListCount = 17; PWLID = 53 }
-            @{parametername = 'GenericField8'; testvalue = "TestField8"; ListCount = 18; PWLID = 53 }
-            @{parametername = 'GenericField9'; testvalue = "TestField9"; ListCount = 19; PWLID = 53 }
-            @{parametername = 'GenericField10'; testvalue = "TestField10"; ListCount = 20; PWLID = 53 }
+            @{parametername = 'Title'; testvalue = 'Demo AD Username'; ListCount = 2; PWLID = 53 }
+            @{parametername = 'UserName'; testvalue = 'username1'; ListCount = 3; PWLID = 53 }
+            @{parametername = 'HostName'; testvalue = 'HostA'; ListCount = 4; PWLID = 53 }
+            @{parametername = 'Domain'; testvalue = 'MYDomain'; ListCount = 5; PWLID = 53 }
+            @{parametername = 'AccountType'; testvalue = ''; ListCount = 1; PWLID = 53 } # testvalue must be empty because the actual property is AccountTypeID
+            @{parametername = 'Description'; testvalue = 'Description for '; ListCount = 6; PWLID = 53 }
+            @{parametername = 'Notes'; testvalue = 'Same Notes'; ListCount = 7; PWLID = 53 }
+            @{parametername = 'URL'; testvalue = 'https://passworstate.local'; ListCount = 8; PWLID = 53 }
+            @{parametername = 'SiteID'; testvalue = ''; ListCount = 9; PWLID = 53 }
+            @{parametername = 'SiteLocation'; testvalue = ''; ListCount = 11; PWLID = 53 }
+            @{parametername = 'GenericField1'; testvalue = 'TestField1'; ListCount = 11; PWLID = 53 }
+            @{parametername = 'GenericField2'; testvalue = 'TestField2'; ListCount = 12; PWLID = 53 }
+            @{parametername = 'GenericField3'; testvalue = 'TestField3'; ListCount = 13; PWLID = 53 }
+            @{parametername = 'GenericField4'; testvalue = 'TestField4'; ListCount = 14; PWLID = 53 }
+            @{parametername = 'GenericField5'; testvalue = 'TestField5'; ListCount = 15; PWLID = 53 }
+            @{parametername = 'GenericField6'; testvalue = 'TestField6'; ListCount = 16; PWLID = 53 }
+            @{parametername = 'GenericField7'; testvalue = 'TestField7'; ListCount = 17; PWLID = 53 }
+            @{parametername = 'GenericField8'; testvalue = 'TestField8'; ListCount = 18; PWLID = 53 }
+            @{parametername = 'GenericField9'; testvalue = 'TestField9'; ListCount = 19; PWLID = 53 }
+            @{parametername = 'GenericField10'; testvalue = 'TestField10'; ListCount = 20; PWLID = 53 }
         ) {
             $Result = if ($parametername -ne '') {
                 ((Invoke-Expression -Command "$($FunctionName) -$($Parametername) '$($testvalue)'" ) | Measure-Object).Count
@@ -281,26 +294,26 @@ Describe 'Get-PasswordStatePassword' {
             }
         }
         It 'Should return <ListCount> for parameter <parametername> with PasswordListID <PWLID>' -ForEach @(
-            @{parametername = 'Title'; testvalue = "Demo AD Username"; ListCount = 2; PWLID = 53 }
-            @{parametername = 'UserName'; testvalue = "username1"; ListCount = 3; PWLID = 53 }
-            @{parametername = 'HostName'; testvalue = "HostA"; ListCount = 4; PWLID = 53 }
-            @{parametername = 'Domain'; testvalue = "MYDomain"; ListCount = 5; PWLID = 53 }
-            @{parametername = 'AccountType'; testvalue = ""; ListCount = 1; PWLID = 53 } # testvalue must be empty because the actual property is AccountTypeID
-            @{parametername = 'Description'; testvalue = "Description for "; ListCount = 6; PWLID = 53 }
-            @{parametername = 'Notes'; testvalue = "Same Notes"; ListCount = 7; PWLID = 53 }
-            @{parametername = 'URL'; testvalue = "https://passworstate.local"; ListCount = 8; PWLID = 53 }
-            @{parametername = 'SiteID'; testvalue = ""; ListCount = 9; PWLID = 53 }
-            @{parametername = 'SiteLocation'; testvalue = ""; ListCount = 11; PWLID = 53 }
-            @{parametername = 'GenericField1'; testvalue = "TestField1"; ListCount = 11; PWLID = 53 }
-            @{parametername = 'GenericField2'; testvalue = "TestField2"; ListCount = 12; PWLID = 53 }
-            @{parametername = 'GenericField3'; testvalue = "TestField3"; ListCount = 13; PWLID = 53 }
-            @{parametername = 'GenericField4'; testvalue = "TestField4"; ListCount = 14; PWLID = 53 }
-            @{parametername = 'GenericField5'; testvalue = "TestField5"; ListCount = 15; PWLID = 53 }
-            @{parametername = 'GenericField6'; testvalue = "TestField6"; ListCount = 16; PWLID = 53 }
-            @{parametername = 'GenericField7'; testvalue = "TestField7"; ListCount = 17; PWLID = 53 }
-            @{parametername = 'GenericField8'; testvalue = "TestField8"; ListCount = 18; PWLID = 53 }
-            @{parametername = 'GenericField9'; testvalue = "TestField9"; ListCount = 19; PWLID = 53 }
-            @{parametername = 'GenericField10'; testvalue = "TestField10"; ListCount = 20; PWLID = 53 }
+            @{parametername = 'Title'; testvalue = 'Demo AD Username'; ListCount = 2; PWLID = 53 }
+            @{parametername = 'UserName'; testvalue = 'username1'; ListCount = 3; PWLID = 53 }
+            @{parametername = 'HostName'; testvalue = 'HostA'; ListCount = 4; PWLID = 53 }
+            @{parametername = 'Domain'; testvalue = 'MYDomain'; ListCount = 5; PWLID = 53 }
+            @{parametername = 'AccountType'; testvalue = ''; ListCount = 1; PWLID = 53 } # testvalue must be empty because the actual property is AccountTypeID
+            @{parametername = 'Description'; testvalue = 'Description for '; ListCount = 6; PWLID = 53 }
+            @{parametername = 'Notes'; testvalue = 'Same Notes'; ListCount = 7; PWLID = 53 }
+            @{parametername = 'URL'; testvalue = 'https://passworstate.local'; ListCount = 8; PWLID = 53 }
+            @{parametername = 'SiteID'; testvalue = ''; ListCount = 9; PWLID = 53 }
+            @{parametername = 'SiteLocation'; testvalue = ''; ListCount = 11; PWLID = 53 }
+            @{parametername = 'GenericField1'; testvalue = 'TestField1'; ListCount = 11; PWLID = 53 }
+            @{parametername = 'GenericField2'; testvalue = 'TestField2'; ListCount = 12; PWLID = 53 }
+            @{parametername = 'GenericField3'; testvalue = 'TestField3'; ListCount = 13; PWLID = 53 }
+            @{parametername = 'GenericField4'; testvalue = 'TestField4'; ListCount = 14; PWLID = 53 }
+            @{parametername = 'GenericField5'; testvalue = 'TestField5'; ListCount = 15; PWLID = 53 }
+            @{parametername = 'GenericField6'; testvalue = 'TestField6'; ListCount = 16; PWLID = 53 }
+            @{parametername = 'GenericField7'; testvalue = 'TestField7'; ListCount = 17; PWLID = 53 }
+            @{parametername = 'GenericField8'; testvalue = 'TestField8'; ListCount = 18; PWLID = 53 }
+            @{parametername = 'GenericField9'; testvalue = 'TestField9'; ListCount = 19; PWLID = 53 }
+            @{parametername = 'GenericField10'; testvalue = 'TestField10'; ListCount = 20; PWLID = 53 }
         ) {
             $Result = if ($parametername -ne '') {
                 ((Invoke-Expression -Command "$($FunctionName) -$($Parametername) '$($testvalue)'" ) | Measure-Object).Count
@@ -314,26 +327,26 @@ Describe 'Get-PasswordStatePassword' {
             }
         }
         It 'Should return <ListCount> for parameter <parametername> without PasswordListID and PreventAudit set to True' -ForEach @(
-            @{parametername = 'Title'; testvalue = "Demo AD Username"; ListCount = 2; PWLID = 53 }
-            @{parametername = 'UserName'; testvalue = "username1"; ListCount = 3; PWLID = 53 }
-            @{parametername = 'HostName'; testvalue = "HostA"; ListCount = 4; PWLID = 53 }
-            @{parametername = 'Domain'; testvalue = "MYDomain"; ListCount = 5; PWLID = 53 }
-            @{parametername = 'AccountType'; testvalue = ""; ListCount = 1; PWLID = 53 } # testvalue must be empty because the actual property is AccountTypeID
-            @{parametername = 'Description'; testvalue = "Description for "; ListCount = 6; PWLID = 53 }
-            @{parametername = 'Notes'; testvalue = "Same Notes"; ListCount = 7; PWLID = 53 }
-            @{parametername = 'URL'; testvalue = "https://passworstate.local"; ListCount = 8; PWLID = 53 }
-            @{parametername = 'SiteID'; testvalue = ""; ListCount = 9; PWLID = 53 }
-            @{parametername = 'SiteLocation'; testvalue = ""; ListCount = 11; PWLID = 53 }
-            @{parametername = 'GenericField1'; testvalue = "TestField1"; ListCount = 11; PWLID = 53 }
-            @{parametername = 'GenericField2'; testvalue = "TestField2"; ListCount = 12; PWLID = 53 }
-            @{parametername = 'GenericField3'; testvalue = "TestField3"; ListCount = 13; PWLID = 53 }
-            @{parametername = 'GenericField4'; testvalue = "TestField4"; ListCount = 14; PWLID = 53 }
-            @{parametername = 'GenericField5'; testvalue = "TestField5"; ListCount = 15; PWLID = 53 }
-            @{parametername = 'GenericField6'; testvalue = "TestField6"; ListCount = 16; PWLID = 53 }
-            @{parametername = 'GenericField7'; testvalue = "TestField7"; ListCount = 17; PWLID = 53 }
-            @{parametername = 'GenericField8'; testvalue = "TestField8"; ListCount = 18; PWLID = 53 }
-            @{parametername = 'GenericField9'; testvalue = "TestField9"; ListCount = 19; PWLID = 53 }
-            @{parametername = 'GenericField10'; testvalue = "TestField10"; ListCount = 20; PWLID = 53 }
+            @{parametername = 'Title'; testvalue = 'Demo AD Username'; ListCount = 2; PWLID = 53 }
+            @{parametername = 'UserName'; testvalue = 'username1'; ListCount = 3; PWLID = 53 }
+            @{parametername = 'HostName'; testvalue = 'HostA'; ListCount = 4; PWLID = 53 }
+            @{parametername = 'Domain'; testvalue = 'MYDomain'; ListCount = 5; PWLID = 53 }
+            @{parametername = 'AccountType'; testvalue = ''; ListCount = 1; PWLID = 53 } # testvalue must be empty because the actual property is AccountTypeID
+            @{parametername = 'Description'; testvalue = 'Description for '; ListCount = 6; PWLID = 53 }
+            @{parametername = 'Notes'; testvalue = 'Same Notes'; ListCount = 7; PWLID = 53 }
+            @{parametername = 'URL'; testvalue = 'https://passworstate.local'; ListCount = 8; PWLID = 53 }
+            @{parametername = 'SiteID'; testvalue = ''; ListCount = 9; PWLID = 53 }
+            @{parametername = 'SiteLocation'; testvalue = ''; ListCount = 11; PWLID = 53 }
+            @{parametername = 'GenericField1'; testvalue = 'TestField1'; ListCount = 11; PWLID = 53 }
+            @{parametername = 'GenericField2'; testvalue = 'TestField2'; ListCount = 12; PWLID = 53 }
+            @{parametername = 'GenericField3'; testvalue = 'TestField3'; ListCount = 13; PWLID = 53 }
+            @{parametername = 'GenericField4'; testvalue = 'TestField4'; ListCount = 14; PWLID = 53 }
+            @{parametername = 'GenericField5'; testvalue = 'TestField5'; ListCount = 15; PWLID = 53 }
+            @{parametername = 'GenericField6'; testvalue = 'TestField6'; ListCount = 16; PWLID = 53 }
+            @{parametername = 'GenericField7'; testvalue = 'TestField7'; ListCount = 17; PWLID = 53 }
+            @{parametername = 'GenericField8'; testvalue = 'TestField8'; ListCount = 18; PWLID = 53 }
+            @{parametername = 'GenericField9'; testvalue = 'TestField9'; ListCount = 19; PWLID = 53 }
+            @{parametername = 'GenericField10'; testvalue = 'TestField10'; ListCount = 20; PWLID = 53 }
         ) {
             $Result = if ($parametername -ne '') {
                 ((Invoke-Expression -Command "$($FunctionName) -$($Parametername) '$($testvalue)' -PreventAuditing:`$True" ) | Measure-Object).Count
@@ -347,26 +360,26 @@ Describe 'Get-PasswordStatePassword' {
             }
         }
         It 'Should return <ListCount> for parameter <parametername> with PasswordListID <PWLID> and PreventAudit set to True' -ForEach @(
-            @{parametername = 'Title'; testvalue = "Demo AD Username"; ListCount = 2; PWLID = 53 }
-            @{parametername = 'UserName'; testvalue = "username1"; ListCount = 3; PWLID = 53 }
-            @{parametername = 'HostName'; testvalue = "HostA"; ListCount = 4; PWLID = 53 }
-            @{parametername = 'Domain'; testvalue = "MYDomain"; ListCount = 5; PWLID = 53 }
-            @{parametername = 'AccountType'; testvalue = ""; ListCount = 1; PWLID = 53 } # testvalue must be empty because the actual property is AccountTypeID
-            @{parametername = 'Description'; testvalue = "Description for "; ListCount = 6; PWLID = 53 }
-            @{parametername = 'Notes'; testvalue = "Same Notes"; ListCount = 7; PWLID = 53 }
-            @{parametername = 'URL'; testvalue = "https://passworstate.local"; ListCount = 8; PWLID = 53 }
-            @{parametername = 'SiteID'; testvalue = ""; ListCount = 9; PWLID = 53 }
-            @{parametername = 'SiteLocation'; testvalue = ""; ListCount = 11; PWLID = 53 }
-            @{parametername = 'GenericField1'; testvalue = "TestField1"; ListCount = 11; PWLID = 53 }
-            @{parametername = 'GenericField2'; testvalue = "TestField2"; ListCount = 12; PWLID = 53 }
-            @{parametername = 'GenericField3'; testvalue = "TestField3"; ListCount = 13; PWLID = 53 }
-            @{parametername = 'GenericField4'; testvalue = "TestField4"; ListCount = 14; PWLID = 53 }
-            @{parametername = 'GenericField5'; testvalue = "TestField5"; ListCount = 15; PWLID = 53 }
-            @{parametername = 'GenericField6'; testvalue = "TestField6"; ListCount = 16; PWLID = 53 }
-            @{parametername = 'GenericField7'; testvalue = "TestField7"; ListCount = 17; PWLID = 53 }
-            @{parametername = 'GenericField8'; testvalue = "TestField8"; ListCount = 18; PWLID = 53 }
-            @{parametername = 'GenericField9'; testvalue = "TestField9"; ListCount = 19; PWLID = 53 }
-            @{parametername = 'GenericField10'; testvalue = "TestField10"; ListCount = 20; PWLID = 53 }
+            @{parametername = 'Title'; testvalue = 'Demo AD Username'; ListCount = 2; PWLID = 53 }
+            @{parametername = 'UserName'; testvalue = 'username1'; ListCount = 3; PWLID = 53 }
+            @{parametername = 'HostName'; testvalue = 'HostA'; ListCount = 4; PWLID = 53 }
+            @{parametername = 'Domain'; testvalue = 'MYDomain'; ListCount = 5; PWLID = 53 }
+            @{parametername = 'AccountType'; testvalue = ''; ListCount = 1; PWLID = 53 } # testvalue must be empty because the actual property is AccountTypeID
+            @{parametername = 'Description'; testvalue = 'Description for '; ListCount = 6; PWLID = 53 }
+            @{parametername = 'Notes'; testvalue = 'Same Notes'; ListCount = 7; PWLID = 53 }
+            @{parametername = 'URL'; testvalue = 'https://passworstate.local'; ListCount = 8; PWLID = 53 }
+            @{parametername = 'SiteID'; testvalue = ''; ListCount = 9; PWLID = 53 }
+            @{parametername = 'SiteLocation'; testvalue = ''; ListCount = 11; PWLID = 53 }
+            @{parametername = 'GenericField1'; testvalue = 'TestField1'; ListCount = 11; PWLID = 53 }
+            @{parametername = 'GenericField2'; testvalue = 'TestField2'; ListCount = 12; PWLID = 53 }
+            @{parametername = 'GenericField3'; testvalue = 'TestField3'; ListCount = 13; PWLID = 53 }
+            @{parametername = 'GenericField4'; testvalue = 'TestField4'; ListCount = 14; PWLID = 53 }
+            @{parametername = 'GenericField5'; testvalue = 'TestField5'; ListCount = 15; PWLID = 53 }
+            @{parametername = 'GenericField6'; testvalue = 'TestField6'; ListCount = 16; PWLID = 53 }
+            @{parametername = 'GenericField7'; testvalue = 'TestField7'; ListCount = 17; PWLID = 53 }
+            @{parametername = 'GenericField8'; testvalue = 'TestField8'; ListCount = 18; PWLID = 53 }
+            @{parametername = 'GenericField9'; testvalue = 'TestField9'; ListCount = 19; PWLID = 53 }
+            @{parametername = 'GenericField10'; testvalue = 'TestField10'; ListCount = 20; PWLID = 53 }
         ) {
             $Result = if ($parametername -ne '') {
                 ((Invoke-Expression -Command "$($FunctionName) -$($Parametername) '$($testvalue)'" ) | Measure-Object).Count
@@ -380,26 +393,26 @@ Describe 'Get-PasswordStatePassword' {
             }
         }
         It 'Should have a <parametername> matching "<testvalue>"' -ForEach @(
-            @{parametername = 'Title'; testvalue = "Demo AD Username"; ListCount = 2; PWLID = 53 }
-            @{parametername = 'UserName'; testvalue = "username1"; ListCount = 3; PWLID = 53 }
-            @{parametername = 'HostName'; testvalue = "HostA"; ListCount = 4; PWLID = 53 }
-            @{parametername = 'Domain'; testvalue = "MYDomain"; ListCount = 5; PWLID = 53 }
-            @{parametername = 'AccountType'; testvalue = ""; ListCount = 1; PWLID = 53 } # testvalue must be empty because the actual property is AccountTypeID
-            @{parametername = 'Description'; testvalue = "Description for "; ListCount = 6; PWLID = 53 }
-            @{parametername = 'Notes'; testvalue = "Same Notes"; ListCount = 7; PWLID = 53 }
-            @{parametername = 'URL'; testvalue = "https://passworstate.local"; ListCount = 8; PWLID = 53 }
-            @{parametername = 'SiteID'; testvalue = ""; ListCount = 9; PWLID = 53 }
-            @{parametername = 'SiteLocation'; testvalue = ""; ListCount = 11; PWLID = 53 }
-            @{parametername = 'GenericField1'; testvalue = "TestField1"; ListCount = 11; PWLID = 53 }
-            @{parametername = 'GenericField2'; testvalue = "TestField2"; ListCount = 12; PWLID = 53 }
-            @{parametername = 'GenericField3'; testvalue = "TestField3"; ListCount = 13; PWLID = 53 }
-            @{parametername = 'GenericField4'; testvalue = "TestField4"; ListCount = 14; PWLID = 53 }
-            @{parametername = 'GenericField5'; testvalue = "TestField5"; ListCount = 15; PWLID = 53 }
-            @{parametername = 'GenericField6'; testvalue = "TestField6"; ListCount = 16; PWLID = 53 }
-            @{parametername = 'GenericField7'; testvalue = "TestField7"; ListCount = 17; PWLID = 53 }
-            @{parametername = 'GenericField8'; testvalue = "TestField8"; ListCount = 18; PWLID = 53 }
-            @{parametername = 'GenericField9'; testvalue = "TestField9"; ListCount = 19; PWLID = 53 }
-            @{parametername = 'GenericField10'; testvalue = "TestField10"; ListCount = 20; PWLID = 53 }
+            @{parametername = 'Title'; testvalue = 'Demo AD Username'; ListCount = 2; PWLID = 53 }
+            @{parametername = 'UserName'; testvalue = 'username1'; ListCount = 3; PWLID = 53 }
+            @{parametername = 'HostName'; testvalue = 'HostA'; ListCount = 4; PWLID = 53 }
+            @{parametername = 'Domain'; testvalue = 'MYDomain'; ListCount = 5; PWLID = 53 }
+            @{parametername = 'AccountType'; testvalue = ''; ListCount = 1; PWLID = 53 } # testvalue must be empty because the actual property is AccountTypeID
+            @{parametername = 'Description'; testvalue = 'Description for '; ListCount = 6; PWLID = 53 }
+            @{parametername = 'Notes'; testvalue = 'Same Notes'; ListCount = 7; PWLID = 53 }
+            @{parametername = 'URL'; testvalue = 'https://passworstate.local'; ListCount = 8; PWLID = 53 }
+            @{parametername = 'SiteID'; testvalue = ''; ListCount = 9; PWLID = 53 }
+            @{parametername = 'SiteLocation'; testvalue = ''; ListCount = 11; PWLID = 53 }
+            @{parametername = 'GenericField1'; testvalue = 'TestField1'; ListCount = 11; PWLID = 53 }
+            @{parametername = 'GenericField2'; testvalue = 'TestField2'; ListCount = 12; PWLID = 53 }
+            @{parametername = 'GenericField3'; testvalue = 'TestField3'; ListCount = 13; PWLID = 53 }
+            @{parametername = 'GenericField4'; testvalue = 'TestField4'; ListCount = 14; PWLID = 53 }
+            @{parametername = 'GenericField5'; testvalue = 'TestField5'; ListCount = 15; PWLID = 53 }
+            @{parametername = 'GenericField6'; testvalue = 'TestField6'; ListCount = 16; PWLID = 53 }
+            @{parametername = 'GenericField7'; testvalue = 'TestField7'; ListCount = 17; PWLID = 53 }
+            @{parametername = 'GenericField8'; testvalue = 'TestField8'; ListCount = 18; PWLID = 53 }
+            @{parametername = 'GenericField9'; testvalue = 'TestField9'; ListCount = 19; PWLID = 53 }
+            @{parametername = 'GenericField10'; testvalue = 'TestField10'; ListCount = 20; PWLID = 53 }
         ) {
             $ResultValues = Invoke-Expression -Command "$($FunctionName) -$($Parametername) '$($testvalue)'"
             foreach ($ResultValue in $ResultValues) {
@@ -410,7 +423,7 @@ Describe 'Get-PasswordStatePassword' {
             }
         }
         It 'Should have a <parametername> matching "<testvalue>" for alias <alias>' -ForEach @(
-            @{parametername = 'ADDomainNetBios'; testvalue = "MYDomain"; ListCount = 5; PWLID = 53; alias='Domain' }
+            @{parametername = 'ADDomainNetBios'; testvalue = 'MYDomain'; ListCount = 5; PWLID = 53; alias = 'Domain' }
         ) {
             $ResultValues = Invoke-Expression -Command "$($FunctionName) -$($Parametername) '$($testvalue)'"
             foreach ($ResultValue in $ResultValues) {
@@ -428,29 +441,29 @@ Describe 'Get-PasswordStatePassword' {
             Mock -CommandName 'Get-PasswordStateResource' -ModuleName 'passwordstate-management' -MockWith { $Global:TestJSON["PasswordSearch$($ParameterName)Response"] } -ParameterFilter { $uri -and $uri -match '\/searchpasswords\/(\d+){0,1}\?\w+=[^\&]+$' } -Verifiable
         }
         AfterAll {
-            Remove-Item -Path "$([environment]::GetFolderPath("UserProfile"))\Passwordstate.json" -Force -Confirm:$false -ErrorAction SilentlyContinue
+            Remove-Item -Path "$([environment]::GetFolderPath('UserProfile'))\Passwordstate.json" -Force -Confirm:$false -ErrorAction SilentlyContinue
         }
         It 'Should return <ListCount> for parameter <parametername> without PasswordListID' -ForEach @(
-            @{parametername = 'Title'; testvalue = "Demo AD Username"; ListCount = 2; PWLID = 53 }
-            @{parametername = 'UserName'; testvalue = "username1"; ListCount = 3; PWLID = 53 }
-            @{parametername = 'HostName'; testvalue = "HostA"; ListCount = 4; PWLID = 53 }
-            @{parametername = 'Domain'; testvalue = "MYDomain"; ListCount = 5; PWLID = 53 }
-            @{parametername = 'AccountType'; testvalue = ""; ListCount = 1; PWLID = 53 } # testvalue must be empty because the actual property is AccountTypeID
-            @{parametername = 'Description'; testvalue = "Description for "; ListCount = 6; PWLID = 53 }
-            @{parametername = 'Notes'; testvalue = "Same Notes"; ListCount = 7; PWLID = 53 }
-            @{parametername = 'URL'; testvalue = "https://passworstate.local"; ListCount = 8; PWLID = 53 }
-            @{parametername = 'SiteID'; testvalue = ""; ListCount = 9; PWLID = 53 }
-            @{parametername = 'SiteLocation'; testvalue = ""; ListCount = 11; PWLID = 53 }
-            @{parametername = 'GenericField1'; testvalue = "TestField1"; ListCount = 11; PWLID = 53 }
-            @{parametername = 'GenericField2'; testvalue = "TestField2"; ListCount = 12; PWLID = 53 }
-            @{parametername = 'GenericField3'; testvalue = "TestField3"; ListCount = 13; PWLID = 53 }
-            @{parametername = 'GenericField4'; testvalue = "TestField4"; ListCount = 14; PWLID = 53 }
-            @{parametername = 'GenericField5'; testvalue = "TestField5"; ListCount = 15; PWLID = 53 }
-            @{parametername = 'GenericField6'; testvalue = "TestField6"; ListCount = 16; PWLID = 53 }
-            @{parametername = 'GenericField7'; testvalue = "TestField7"; ListCount = 17; PWLID = 53 }
-            @{parametername = 'GenericField8'; testvalue = "TestField8"; ListCount = 18; PWLID = 53 }
-            @{parametername = 'GenericField9'; testvalue = "TestField9"; ListCount = 19; PWLID = 53 }
-            @{parametername = 'GenericField10'; testvalue = "TestField10"; ListCount = 20; PWLID = 53 }
+            @{parametername = 'Title'; testvalue = 'Demo AD Username'; ListCount = 2; PWLID = 53 }
+            @{parametername = 'UserName'; testvalue = 'username1'; ListCount = 3; PWLID = 53 }
+            @{parametername = 'HostName'; testvalue = 'HostA'; ListCount = 4; PWLID = 53 }
+            @{parametername = 'Domain'; testvalue = 'MYDomain'; ListCount = 5; PWLID = 53 }
+            @{parametername = 'AccountType'; testvalue = ''; ListCount = 1; PWLID = 53 } # testvalue must be empty because the actual property is AccountTypeID
+            @{parametername = 'Description'; testvalue = 'Description for '; ListCount = 6; PWLID = 53 }
+            @{parametername = 'Notes'; testvalue = 'Same Notes'; ListCount = 7; PWLID = 53 }
+            @{parametername = 'URL'; testvalue = 'https://passworstate.local'; ListCount = 8; PWLID = 53 }
+            @{parametername = 'SiteID'; testvalue = ''; ListCount = 9; PWLID = 53 }
+            @{parametername = 'SiteLocation'; testvalue = ''; ListCount = 11; PWLID = 53 }
+            @{parametername = 'GenericField1'; testvalue = 'TestField1'; ListCount = 11; PWLID = 53 }
+            @{parametername = 'GenericField2'; testvalue = 'TestField2'; ListCount = 12; PWLID = 53 }
+            @{parametername = 'GenericField3'; testvalue = 'TestField3'; ListCount = 13; PWLID = 53 }
+            @{parametername = 'GenericField4'; testvalue = 'TestField4'; ListCount = 14; PWLID = 53 }
+            @{parametername = 'GenericField5'; testvalue = 'TestField5'; ListCount = 15; PWLID = 53 }
+            @{parametername = 'GenericField6'; testvalue = 'TestField6'; ListCount = 16; PWLID = 53 }
+            @{parametername = 'GenericField7'; testvalue = 'TestField7'; ListCount = 17; PWLID = 53 }
+            @{parametername = 'GenericField8'; testvalue = 'TestField8'; ListCount = 18; PWLID = 53 }
+            @{parametername = 'GenericField9'; testvalue = 'TestField9'; ListCount = 19; PWLID = 53 }
+            @{parametername = 'GenericField10'; testvalue = 'TestField10'; ListCount = 20; PWLID = 53 }
         ) {
             $Result = if ($parametername -ne '') {
                 ((Invoke-Expression -Command "$($FunctionName) -$($Parametername) '$($testvalue)'" ) | Measure-Object).Count
@@ -464,26 +477,26 @@ Describe 'Get-PasswordStatePassword' {
             }
         }
         It 'Should return <ListCount> for parameter <parametername> with PasswordListID <PWLID>' -ForEach @(
-            @{parametername = 'Title'; testvalue = "Demo AD Username"; ListCount = 2; PWLID = 53 }
-            @{parametername = 'UserName'; testvalue = "username1"; ListCount = 3; PWLID = 53 }
-            @{parametername = 'HostName'; testvalue = "HostA"; ListCount = 4; PWLID = 53 }
-            @{parametername = 'Domain'; testvalue = "MYDomain"; ListCount = 5; PWLID = 53 }
-            @{parametername = 'AccountType'; testvalue = ""; ListCount = 1; PWLID = 53 } # testvalue must be empty because the actual property is AccountTypeID
-            @{parametername = 'Description'; testvalue = "Description for "; ListCount = 6; PWLID = 53 }
-            @{parametername = 'Notes'; testvalue = "Same Notes"; ListCount = 7; PWLID = 53 }
-            @{parametername = 'URL'; testvalue = "https://passworstate.local"; ListCount = 8; PWLID = 53 }
-            @{parametername = 'SiteID'; testvalue = ""; ListCount = 9; PWLID = 53 }
-            @{parametername = 'SiteLocation'; testvalue = ""; ListCount = 11; PWLID = 53 }
-            @{parametername = 'GenericField1'; testvalue = "TestField1"; ListCount = 11; PWLID = 53 }
-            @{parametername = 'GenericField2'; testvalue = "TestField2"; ListCount = 12; PWLID = 53 }
-            @{parametername = 'GenericField3'; testvalue = "TestField3"; ListCount = 13; PWLID = 53 }
-            @{parametername = 'GenericField4'; testvalue = "TestField4"; ListCount = 14; PWLID = 53 }
-            @{parametername = 'GenericField5'; testvalue = "TestField5"; ListCount = 15; PWLID = 53 }
-            @{parametername = 'GenericField6'; testvalue = "TestField6"; ListCount = 16; PWLID = 53 }
-            @{parametername = 'GenericField7'; testvalue = "TestField7"; ListCount = 17; PWLID = 53 }
-            @{parametername = 'GenericField8'; testvalue = "TestField8"; ListCount = 18; PWLID = 53 }
-            @{parametername = 'GenericField9'; testvalue = "TestField9"; ListCount = 19; PWLID = 53 }
-            @{parametername = 'GenericField10'; testvalue = "TestField10"; ListCount = 20; PWLID = 53 }
+            @{parametername = 'Title'; testvalue = 'Demo AD Username'; ListCount = 2; PWLID = 53 }
+            @{parametername = 'UserName'; testvalue = 'username1'; ListCount = 3; PWLID = 53 }
+            @{parametername = 'HostName'; testvalue = 'HostA'; ListCount = 4; PWLID = 53 }
+            @{parametername = 'Domain'; testvalue = 'MYDomain'; ListCount = 5; PWLID = 53 }
+            @{parametername = 'AccountType'; testvalue = ''; ListCount = 1; PWLID = 53 } # testvalue must be empty because the actual property is AccountTypeID
+            @{parametername = 'Description'; testvalue = 'Description for '; ListCount = 6; PWLID = 53 }
+            @{parametername = 'Notes'; testvalue = 'Same Notes'; ListCount = 7; PWLID = 53 }
+            @{parametername = 'URL'; testvalue = 'https://passworstate.local'; ListCount = 8; PWLID = 53 }
+            @{parametername = 'SiteID'; testvalue = ''; ListCount = 9; PWLID = 53 }
+            @{parametername = 'SiteLocation'; testvalue = ''; ListCount = 11; PWLID = 53 }
+            @{parametername = 'GenericField1'; testvalue = 'TestField1'; ListCount = 11; PWLID = 53 }
+            @{parametername = 'GenericField2'; testvalue = 'TestField2'; ListCount = 12; PWLID = 53 }
+            @{parametername = 'GenericField3'; testvalue = 'TestField3'; ListCount = 13; PWLID = 53 }
+            @{parametername = 'GenericField4'; testvalue = 'TestField4'; ListCount = 14; PWLID = 53 }
+            @{parametername = 'GenericField5'; testvalue = 'TestField5'; ListCount = 15; PWLID = 53 }
+            @{parametername = 'GenericField6'; testvalue = 'TestField6'; ListCount = 16; PWLID = 53 }
+            @{parametername = 'GenericField7'; testvalue = 'TestField7'; ListCount = 17; PWLID = 53 }
+            @{parametername = 'GenericField8'; testvalue = 'TestField8'; ListCount = 18; PWLID = 53 }
+            @{parametername = 'GenericField9'; testvalue = 'TestField9'; ListCount = 19; PWLID = 53 }
+            @{parametername = 'GenericField10'; testvalue = 'TestField10'; ListCount = 20; PWLID = 53 }
         ) {
             $Result = if ($parametername -ne '') {
                 ((Invoke-Expression -Command "$($FunctionName) -$($Parametername) '$($testvalue)'" ) | Measure-Object).Count
@@ -497,26 +510,26 @@ Describe 'Get-PasswordStatePassword' {
             }
         }
         It 'Should return <ListCount> for parameter <parametername> without PasswordListID and PreventAudit set to True' -ForEach @(
-            @{parametername = 'Title'; testvalue = "Demo AD Username"; ListCount = 2; PWLID = 53 }
-            @{parametername = 'UserName'; testvalue = "username1"; ListCount = 3; PWLID = 53 }
-            @{parametername = 'HostName'; testvalue = "HostA"; ListCount = 4; PWLID = 53 }
-            @{parametername = 'Domain'; testvalue = "MYDomain"; ListCount = 5; PWLID = 53 }
-            @{parametername = 'AccountType'; testvalue = ""; ListCount = 1; PWLID = 53 } # testvalue must be empty because the actual property is AccountTypeID
-            @{parametername = 'Description'; testvalue = "Description for "; ListCount = 6; PWLID = 53 }
-            @{parametername = 'Notes'; testvalue = "Same Notes"; ListCount = 7; PWLID = 53 }
-            @{parametername = 'URL'; testvalue = "https://passworstate.local"; ListCount = 8; PWLID = 53 }
-            @{parametername = 'SiteID'; testvalue = ""; ListCount = 9; PWLID = 53 }
-            @{parametername = 'SiteLocation'; testvalue = ""; ListCount = 11; PWLID = 53 }
-            @{parametername = 'GenericField1'; testvalue = "TestField1"; ListCount = 11; PWLID = 53 }
-            @{parametername = 'GenericField2'; testvalue = "TestField2"; ListCount = 12; PWLID = 53 }
-            @{parametername = 'GenericField3'; testvalue = "TestField3"; ListCount = 13; PWLID = 53 }
-            @{parametername = 'GenericField4'; testvalue = "TestField4"; ListCount = 14; PWLID = 53 }
-            @{parametername = 'GenericField5'; testvalue = "TestField5"; ListCount = 15; PWLID = 53 }
-            @{parametername = 'GenericField6'; testvalue = "TestField6"; ListCount = 16; PWLID = 53 }
-            @{parametername = 'GenericField7'; testvalue = "TestField7"; ListCount = 17; PWLID = 53 }
-            @{parametername = 'GenericField8'; testvalue = "TestField8"; ListCount = 18; PWLID = 53 }
-            @{parametername = 'GenericField9'; testvalue = "TestField9"; ListCount = 19; PWLID = 53 }
-            @{parametername = 'GenericField10'; testvalue = "TestField10"; ListCount = 20; PWLID = 53 }
+            @{parametername = 'Title'; testvalue = 'Demo AD Username'; ListCount = 2; PWLID = 53 }
+            @{parametername = 'UserName'; testvalue = 'username1'; ListCount = 3; PWLID = 53 }
+            @{parametername = 'HostName'; testvalue = 'HostA'; ListCount = 4; PWLID = 53 }
+            @{parametername = 'Domain'; testvalue = 'MYDomain'; ListCount = 5; PWLID = 53 }
+            @{parametername = 'AccountType'; testvalue = ''; ListCount = 1; PWLID = 53 } # testvalue must be empty because the actual property is AccountTypeID
+            @{parametername = 'Description'; testvalue = 'Description for '; ListCount = 6; PWLID = 53 }
+            @{parametername = 'Notes'; testvalue = 'Same Notes'; ListCount = 7; PWLID = 53 }
+            @{parametername = 'URL'; testvalue = 'https://passworstate.local'; ListCount = 8; PWLID = 53 }
+            @{parametername = 'SiteID'; testvalue = ''; ListCount = 9; PWLID = 53 }
+            @{parametername = 'SiteLocation'; testvalue = ''; ListCount = 11; PWLID = 53 }
+            @{parametername = 'GenericField1'; testvalue = 'TestField1'; ListCount = 11; PWLID = 53 }
+            @{parametername = 'GenericField2'; testvalue = 'TestField2'; ListCount = 12; PWLID = 53 }
+            @{parametername = 'GenericField3'; testvalue = 'TestField3'; ListCount = 13; PWLID = 53 }
+            @{parametername = 'GenericField4'; testvalue = 'TestField4'; ListCount = 14; PWLID = 53 }
+            @{parametername = 'GenericField5'; testvalue = 'TestField5'; ListCount = 15; PWLID = 53 }
+            @{parametername = 'GenericField6'; testvalue = 'TestField6'; ListCount = 16; PWLID = 53 }
+            @{parametername = 'GenericField7'; testvalue = 'TestField7'; ListCount = 17; PWLID = 53 }
+            @{parametername = 'GenericField8'; testvalue = 'TestField8'; ListCount = 18; PWLID = 53 }
+            @{parametername = 'GenericField9'; testvalue = 'TestField9'; ListCount = 19; PWLID = 53 }
+            @{parametername = 'GenericField10'; testvalue = 'TestField10'; ListCount = 20; PWLID = 53 }
         ) {
             $Result = if ($parametername -ne '') {
                 ((Invoke-Expression -Command "$($FunctionName) -$($Parametername) '$($testvalue)' -PreventAuditing:`$True" ) | Measure-Object).Count
@@ -530,26 +543,26 @@ Describe 'Get-PasswordStatePassword' {
             }
         }
         It 'Should return <ListCount> for parameter <parametername> with PasswordListID <PWLID> and PreventAudit set to True' -ForEach @(
-            @{parametername = 'Title'; testvalue = "Demo AD Username"; ListCount = 2; PWLID = 53 }
-            @{parametername = 'UserName'; testvalue = "username1"; ListCount = 3; PWLID = 53 }
-            @{parametername = 'HostName'; testvalue = "HostA"; ListCount = 4; PWLID = 53 }
-            @{parametername = 'Domain'; testvalue = "MYDomain"; ListCount = 5; PWLID = 53 }
-            @{parametername = 'AccountType'; testvalue = ""; ListCount = 1; PWLID = 53 } # testvalue must be empty because the actual property is AccountTypeID
-            @{parametername = 'Description'; testvalue = "Description for "; ListCount = 6; PWLID = 53 }
-            @{parametername = 'Notes'; testvalue = "Same Notes"; ListCount = 7; PWLID = 53 }
-            @{parametername = 'URL'; testvalue = "https://passworstate.local"; ListCount = 8; PWLID = 53 }
-            @{parametername = 'SiteID'; testvalue = ""; ListCount = 9; PWLID = 53 }
-            @{parametername = 'SiteLocation'; testvalue = ""; ListCount = 11; PWLID = 53 }
-            @{parametername = 'GenericField1'; testvalue = "TestField1"; ListCount = 11; PWLID = 53 }
-            @{parametername = 'GenericField2'; testvalue = "TestField2"; ListCount = 12; PWLID = 53 }
-            @{parametername = 'GenericField3'; testvalue = "TestField3"; ListCount = 13; PWLID = 53 }
-            @{parametername = 'GenericField4'; testvalue = "TestField4"; ListCount = 14; PWLID = 53 }
-            @{parametername = 'GenericField5'; testvalue = "TestField5"; ListCount = 15; PWLID = 53 }
-            @{parametername = 'GenericField6'; testvalue = "TestField6"; ListCount = 16; PWLID = 53 }
-            @{parametername = 'GenericField7'; testvalue = "TestField7"; ListCount = 17; PWLID = 53 }
-            @{parametername = 'GenericField8'; testvalue = "TestField8"; ListCount = 18; PWLID = 53 }
-            @{parametername = 'GenericField9'; testvalue = "TestField9"; ListCount = 19; PWLID = 53 }
-            @{parametername = 'GenericField10'; testvalue = "TestField10"; ListCount = 20; PWLID = 53 }
+            @{parametername = 'Title'; testvalue = 'Demo AD Username'; ListCount = 2; PWLID = 53 }
+            @{parametername = 'UserName'; testvalue = 'username1'; ListCount = 3; PWLID = 53 }
+            @{parametername = 'HostName'; testvalue = 'HostA'; ListCount = 4; PWLID = 53 }
+            @{parametername = 'Domain'; testvalue = 'MYDomain'; ListCount = 5; PWLID = 53 }
+            @{parametername = 'AccountType'; testvalue = ''; ListCount = 1; PWLID = 53 } # testvalue must be empty because the actual property is AccountTypeID
+            @{parametername = 'Description'; testvalue = 'Description for '; ListCount = 6; PWLID = 53 }
+            @{parametername = 'Notes'; testvalue = 'Same Notes'; ListCount = 7; PWLID = 53 }
+            @{parametername = 'URL'; testvalue = 'https://passworstate.local'; ListCount = 8; PWLID = 53 }
+            @{parametername = 'SiteID'; testvalue = ''; ListCount = 9; PWLID = 53 }
+            @{parametername = 'SiteLocation'; testvalue = ''; ListCount = 11; PWLID = 53 }
+            @{parametername = 'GenericField1'; testvalue = 'TestField1'; ListCount = 11; PWLID = 53 }
+            @{parametername = 'GenericField2'; testvalue = 'TestField2'; ListCount = 12; PWLID = 53 }
+            @{parametername = 'GenericField3'; testvalue = 'TestField3'; ListCount = 13; PWLID = 53 }
+            @{parametername = 'GenericField4'; testvalue = 'TestField4'; ListCount = 14; PWLID = 53 }
+            @{parametername = 'GenericField5'; testvalue = 'TestField5'; ListCount = 15; PWLID = 53 }
+            @{parametername = 'GenericField6'; testvalue = 'TestField6'; ListCount = 16; PWLID = 53 }
+            @{parametername = 'GenericField7'; testvalue = 'TestField7'; ListCount = 17; PWLID = 53 }
+            @{parametername = 'GenericField8'; testvalue = 'TestField8'; ListCount = 18; PWLID = 53 }
+            @{parametername = 'GenericField9'; testvalue = 'TestField9'; ListCount = 19; PWLID = 53 }
+            @{parametername = 'GenericField10'; testvalue = 'TestField10'; ListCount = 20; PWLID = 53 }
         ) {
             $Result = if ($parametername -ne '') {
                 ((Invoke-Expression -Command "$($FunctionName) -$($Parametername) '$($testvalue)'" ) | Measure-Object).Count
@@ -563,26 +576,26 @@ Describe 'Get-PasswordStatePassword' {
             }
         }
         It 'Should have a <parametername> matching "<testvalue>"' -ForEach @(
-            @{parametername = 'Title'; testvalue = "Demo AD Username"; ListCount = 2; PWLID = 53 }
-            @{parametername = 'UserName'; testvalue = "username1"; ListCount = 3; PWLID = 53 }
-            @{parametername = 'HostName'; testvalue = "HostA"; ListCount = 4; PWLID = 53 }
-            @{parametername = 'Domain'; testvalue = "MYDomain"; ListCount = 5; PWLID = 53 }
-            @{parametername = 'AccountType'; testvalue = ""; ListCount = 1; PWLID = 53 } # testvalue must be empty because the actual property is AccountTypeID
-            @{parametername = 'Description'; testvalue = "Description for "; ListCount = 6; PWLID = 53 }
-            @{parametername = 'Notes'; testvalue = "Same Notes"; ListCount = 7; PWLID = 53 }
-            @{parametername = 'URL'; testvalue = "https://passworstate.local"; ListCount = 8; PWLID = 53 }
-            @{parametername = 'SiteID'; testvalue = ""; ListCount = 9; PWLID = 53 }
-            @{parametername = 'SiteLocation'; testvalue = ""; ListCount = 11; PWLID = 53 }
-            @{parametername = 'GenericField1'; testvalue = "TestField1"; ListCount = 11; PWLID = 53 }
-            @{parametername = 'GenericField2'; testvalue = "TestField2"; ListCount = 12; PWLID = 53 }
-            @{parametername = 'GenericField3'; testvalue = "TestField3"; ListCount = 13; PWLID = 53 }
-            @{parametername = 'GenericField4'; testvalue = "TestField4"; ListCount = 14; PWLID = 53 }
-            @{parametername = 'GenericField5'; testvalue = "TestField5"; ListCount = 15; PWLID = 53 }
-            @{parametername = 'GenericField6'; testvalue = "TestField6"; ListCount = 16; PWLID = 53 }
-            @{parametername = 'GenericField7'; testvalue = "TestField7"; ListCount = 17; PWLID = 53 }
-            @{parametername = 'GenericField8'; testvalue = "TestField8"; ListCount = 18; PWLID = 53 }
-            @{parametername = 'GenericField9'; testvalue = "TestField9"; ListCount = 19; PWLID = 53 }
-            @{parametername = 'GenericField10'; testvalue = "TestField10"; ListCount = 20; PWLID = 53 }
+            @{parametername = 'Title'; testvalue = 'Demo AD Username'; ListCount = 2; PWLID = 53 }
+            @{parametername = 'UserName'; testvalue = 'username1'; ListCount = 3; PWLID = 53 }
+            @{parametername = 'HostName'; testvalue = 'HostA'; ListCount = 4; PWLID = 53 }
+            @{parametername = 'Domain'; testvalue = 'MYDomain'; ListCount = 5; PWLID = 53 }
+            @{parametername = 'AccountType'; testvalue = ''; ListCount = 1; PWLID = 53 } # testvalue must be empty because the actual property is AccountTypeID
+            @{parametername = 'Description'; testvalue = 'Description for '; ListCount = 6; PWLID = 53 }
+            @{parametername = 'Notes'; testvalue = 'Same Notes'; ListCount = 7; PWLID = 53 }
+            @{parametername = 'URL'; testvalue = 'https://passworstate.local'; ListCount = 8; PWLID = 53 }
+            @{parametername = 'SiteID'; testvalue = ''; ListCount = 9; PWLID = 53 }
+            @{parametername = 'SiteLocation'; testvalue = ''; ListCount = 11; PWLID = 53 }
+            @{parametername = 'GenericField1'; testvalue = 'TestField1'; ListCount = 11; PWLID = 53 }
+            @{parametername = 'GenericField2'; testvalue = 'TestField2'; ListCount = 12; PWLID = 53 }
+            @{parametername = 'GenericField3'; testvalue = 'TestField3'; ListCount = 13; PWLID = 53 }
+            @{parametername = 'GenericField4'; testvalue = 'TestField4'; ListCount = 14; PWLID = 53 }
+            @{parametername = 'GenericField5'; testvalue = 'TestField5'; ListCount = 15; PWLID = 53 }
+            @{parametername = 'GenericField6'; testvalue = 'TestField6'; ListCount = 16; PWLID = 53 }
+            @{parametername = 'GenericField7'; testvalue = 'TestField7'; ListCount = 17; PWLID = 53 }
+            @{parametername = 'GenericField8'; testvalue = 'TestField8'; ListCount = 18; PWLID = 53 }
+            @{parametername = 'GenericField9'; testvalue = 'TestField9'; ListCount = 19; PWLID = 53 }
+            @{parametername = 'GenericField10'; testvalue = 'TestField10'; ListCount = 20; PWLID = 53 }
         ) {
             $ResultValues = Invoke-Expression -Command "$($FunctionName) -$($Parametername) '$($testvalue)'"
             foreach ($ResultValue in $ResultValues) {
@@ -593,7 +606,7 @@ Describe 'Get-PasswordStatePassword' {
             }
         }
         It 'Should have a <parametername> matching "<testvalue>" for alias <alias>' -ForEach @(
-            @{parametername = 'ADDomainNetBios'; testvalue = "MYDomain"; ListCount = 5; PWLID = 53; alias='Domain' }
+            @{parametername = 'ADDomainNetBios'; testvalue = 'MYDomain'; ListCount = 5; PWLID = 53; alias = 'Domain' }
         ) {
             $ResultValues = Invoke-Expression -Command "$($FunctionName) -$($Parametername) '$($testvalue)'"
             foreach ($ResultValue in $ResultValues) {
@@ -608,32 +621,32 @@ Describe 'Get-PasswordStatePassword' {
         BeforeAll {
             Set-PasswordStateEnvironment -Uri $BaseURI -Apikey $APIKey -path $ProfilePath | Out-Null
             Mock -CommandName 'Get-PasswordStateResource' -ModuleName 'passwordstate-management' -MockWith { $Global:TestJSON["PasswordSearch$($ParameterName)Response"] }
-            Mock -CommandName 'Get-PasswordStateResource' -ModuleName 'passwordstate-management' -MockWith { $Global:TestJSON["PasswordSearch$($ParameterName)Response"] } -ParameterFilter { $uri -and $uri -match '\/searchpasswords\/(\d+){0,1}\?\w+=[^\&]+$' -and 'Headers' -in $extraparams.keys} -Verifiable
+            Mock -CommandName 'Get-PasswordStateResource' -ModuleName 'passwordstate-management' -MockWith { $Global:TestJSON["PasswordSearch$($ParameterName)Response"] } -ParameterFilter { $uri -and $uri -match '\/searchpasswords\/(\d+){0,1}\?\w+=[^\&]+$' -and 'Headers' -in $extraparams.keys } -Verifiable
         }
         AfterAll {
-            Remove-Item -Path "$([environment]::GetFolderPath("UserProfile"))\Passwordstate.json" -Force -Confirm:$false -ErrorAction SilentlyContinue
+            Remove-Item -Path "$([environment]::GetFolderPath('UserProfile'))\Passwordstate.json" -Force -Confirm:$false -ErrorAction SilentlyContinue
         }
         It 'Should return <ListCount> for parameter <parametername> without PasswordListID' -ForEach @(
-            @{parametername = 'Title'; testvalue = "Demo AD Username"; ListCount = 2; PWLID = 53 }
-            @{parametername = 'UserName'; testvalue = "username1"; ListCount = 3; PWLID = 53 }
-            @{parametername = 'HostName'; testvalue = "HostA"; ListCount = 4; PWLID = 53 }
-            @{parametername = 'Domain'; testvalue = "MYDomain"; ListCount = 5; PWLID = 53 }
-            @{parametername = 'AccountType'; testvalue = ""; ListCount = 1; PWLID = 53 } # testvalue must be empty because the actual property is AccountTypeID
-            @{parametername = 'Description'; testvalue = "Description for "; ListCount = 6; PWLID = 53 }
-            @{parametername = 'Notes'; testvalue = "Same Notes"; ListCount = 7; PWLID = 53 }
-            @{parametername = 'URL'; testvalue = "https://passworstate.local"; ListCount = 8; PWLID = 53 }
-            @{parametername = 'SiteID'; testvalue = ""; ListCount = 9; PWLID = 53 }
-            @{parametername = 'SiteLocation'; testvalue = ""; ListCount = 11; PWLID = 53 }
-            @{parametername = 'GenericField1'; testvalue = "TestField1"; ListCount = 11; PWLID = 53 }
-            @{parametername = 'GenericField2'; testvalue = "TestField2"; ListCount = 12; PWLID = 53 }
-            @{parametername = 'GenericField3'; testvalue = "TestField3"; ListCount = 13; PWLID = 53 }
-            @{parametername = 'GenericField4'; testvalue = "TestField4"; ListCount = 14; PWLID = 53 }
-            @{parametername = 'GenericField5'; testvalue = "TestField5"; ListCount = 15; PWLID = 53 }
-            @{parametername = 'GenericField6'; testvalue = "TestField6"; ListCount = 16; PWLID = 53 }
-            @{parametername = 'GenericField7'; testvalue = "TestField7"; ListCount = 17; PWLID = 53 }
-            @{parametername = 'GenericField8'; testvalue = "TestField8"; ListCount = 18; PWLID = 53 }
-            @{parametername = 'GenericField9'; testvalue = "TestField9"; ListCount = 19; PWLID = 53 }
-            @{parametername = 'GenericField10'; testvalue = "TestField10"; ListCount = 20; PWLID = 53 }
+            @{parametername = 'Title'; testvalue = 'Demo AD Username'; ListCount = 2; PWLID = 53 }
+            @{parametername = 'UserName'; testvalue = 'username1'; ListCount = 3; PWLID = 53 }
+            @{parametername = 'HostName'; testvalue = 'HostA'; ListCount = 4; PWLID = 53 }
+            @{parametername = 'Domain'; testvalue = 'MYDomain'; ListCount = 5; PWLID = 53 }
+            @{parametername = 'AccountType'; testvalue = ''; ListCount = 1; PWLID = 53 } # testvalue must be empty because the actual property is AccountTypeID
+            @{parametername = 'Description'; testvalue = 'Description for '; ListCount = 6; PWLID = 53 }
+            @{parametername = 'Notes'; testvalue = 'Same Notes'; ListCount = 7; PWLID = 53 }
+            @{parametername = 'URL'; testvalue = 'https://passworstate.local'; ListCount = 8; PWLID = 53 }
+            @{parametername = 'SiteID'; testvalue = ''; ListCount = 9; PWLID = 53 }
+            @{parametername = 'SiteLocation'; testvalue = ''; ListCount = 11; PWLID = 53 }
+            @{parametername = 'GenericField1'; testvalue = 'TestField1'; ListCount = 11; PWLID = 53 }
+            @{parametername = 'GenericField2'; testvalue = 'TestField2'; ListCount = 12; PWLID = 53 }
+            @{parametername = 'GenericField3'; testvalue = 'TestField3'; ListCount = 13; PWLID = 53 }
+            @{parametername = 'GenericField4'; testvalue = 'TestField4'; ListCount = 14; PWLID = 53 }
+            @{parametername = 'GenericField5'; testvalue = 'TestField5'; ListCount = 15; PWLID = 53 }
+            @{parametername = 'GenericField6'; testvalue = 'TestField6'; ListCount = 16; PWLID = 53 }
+            @{parametername = 'GenericField7'; testvalue = 'TestField7'; ListCount = 17; PWLID = 53 }
+            @{parametername = 'GenericField8'; testvalue = 'TestField8'; ListCount = 18; PWLID = 53 }
+            @{parametername = 'GenericField9'; testvalue = 'TestField9'; ListCount = 19; PWLID = 53 }
+            @{parametername = 'GenericField10'; testvalue = 'TestField10'; ListCount = 20; PWLID = 53 }
         ) {
             $Result = if ($parametername -ne '') {
                 ((Invoke-Expression -Command "$($FunctionName) -$($Parametername) '$($testvalue)' -Reason 'Audit reason provided'" ) | Measure-Object).Count
@@ -647,26 +660,26 @@ Describe 'Get-PasswordStatePassword' {
             }
         }
         It 'Should return <ListCount> for parameter <parametername> with PasswordListID <PWLID>' -ForEach @(
-            @{parametername = 'Title'; testvalue = "Demo AD Username"; ListCount = 2; PWLID = 53 }
-            @{parametername = 'UserName'; testvalue = "username1"; ListCount = 3; PWLID = 53 }
-            @{parametername = 'HostName'; testvalue = "HostA"; ListCount = 4; PWLID = 53 }
-            @{parametername = 'Domain'; testvalue = "MYDomain"; ListCount = 5; PWLID = 53 }
-            @{parametername = 'AccountType'; testvalue = ""; ListCount = 1; PWLID = 53 } # testvalue must be empty because the actual property is AccountTypeID
-            @{parametername = 'Description'; testvalue = "Description for "; ListCount = 6; PWLID = 53 }
-            @{parametername = 'Notes'; testvalue = "Same Notes"; ListCount = 7; PWLID = 53 }
-            @{parametername = 'URL'; testvalue = "https://passworstate.local"; ListCount = 8; PWLID = 53 }
-            @{parametername = 'SiteID'; testvalue = ""; ListCount = 9; PWLID = 53 }
-            @{parametername = 'SiteLocation'; testvalue = ""; ListCount = 11; PWLID = 53 }
-            @{parametername = 'GenericField1'; testvalue = "TestField1"; ListCount = 11; PWLID = 53 }
-            @{parametername = 'GenericField2'; testvalue = "TestField2"; ListCount = 12; PWLID = 53 }
-            @{parametername = 'GenericField3'; testvalue = "TestField3"; ListCount = 13; PWLID = 53 }
-            @{parametername = 'GenericField4'; testvalue = "TestField4"; ListCount = 14; PWLID = 53 }
-            @{parametername = 'GenericField5'; testvalue = "TestField5"; ListCount = 15; PWLID = 53 }
-            @{parametername = 'GenericField6'; testvalue = "TestField6"; ListCount = 16; PWLID = 53 }
-            @{parametername = 'GenericField7'; testvalue = "TestField7"; ListCount = 17; PWLID = 53 }
-            @{parametername = 'GenericField8'; testvalue = "TestField8"; ListCount = 18; PWLID = 53 }
-            @{parametername = 'GenericField9'; testvalue = "TestField9"; ListCount = 19; PWLID = 53 }
-            @{parametername = 'GenericField10'; testvalue = "TestField10"; ListCount = 20; PWLID = 53 }
+            @{parametername = 'Title'; testvalue = 'Demo AD Username'; ListCount = 2; PWLID = 53 }
+            @{parametername = 'UserName'; testvalue = 'username1'; ListCount = 3; PWLID = 53 }
+            @{parametername = 'HostName'; testvalue = 'HostA'; ListCount = 4; PWLID = 53 }
+            @{parametername = 'Domain'; testvalue = 'MYDomain'; ListCount = 5; PWLID = 53 }
+            @{parametername = 'AccountType'; testvalue = ''; ListCount = 1; PWLID = 53 } # testvalue must be empty because the actual property is AccountTypeID
+            @{parametername = 'Description'; testvalue = 'Description for '; ListCount = 6; PWLID = 53 }
+            @{parametername = 'Notes'; testvalue = 'Same Notes'; ListCount = 7; PWLID = 53 }
+            @{parametername = 'URL'; testvalue = 'https://passworstate.local'; ListCount = 8; PWLID = 53 }
+            @{parametername = 'SiteID'; testvalue = ''; ListCount = 9; PWLID = 53 }
+            @{parametername = 'SiteLocation'; testvalue = ''; ListCount = 11; PWLID = 53 }
+            @{parametername = 'GenericField1'; testvalue = 'TestField1'; ListCount = 11; PWLID = 53 }
+            @{parametername = 'GenericField2'; testvalue = 'TestField2'; ListCount = 12; PWLID = 53 }
+            @{parametername = 'GenericField3'; testvalue = 'TestField3'; ListCount = 13; PWLID = 53 }
+            @{parametername = 'GenericField4'; testvalue = 'TestField4'; ListCount = 14; PWLID = 53 }
+            @{parametername = 'GenericField5'; testvalue = 'TestField5'; ListCount = 15; PWLID = 53 }
+            @{parametername = 'GenericField6'; testvalue = 'TestField6'; ListCount = 16; PWLID = 53 }
+            @{parametername = 'GenericField7'; testvalue = 'TestField7'; ListCount = 17; PWLID = 53 }
+            @{parametername = 'GenericField8'; testvalue = 'TestField8'; ListCount = 18; PWLID = 53 }
+            @{parametername = 'GenericField9'; testvalue = 'TestField9'; ListCount = 19; PWLID = 53 }
+            @{parametername = 'GenericField10'; testvalue = 'TestField10'; ListCount = 20; PWLID = 53 }
         ) {
             $Result = if ($parametername -ne '') {
                 ((Invoke-Expression -Command "$($FunctionName) -$($Parametername) '$($testvalue)' -Reason 'Audit reason provided'" ) | Measure-Object).Count
@@ -680,26 +693,26 @@ Describe 'Get-PasswordStatePassword' {
             }
         }
         It 'Should return <ListCount> for parameter <parametername> without PasswordListID and PreventAudit set to True' -ForEach @(
-            @{parametername = 'Title'; testvalue = "Demo AD Username"; ListCount = 2; PWLID = 53 }
-            @{parametername = 'UserName'; testvalue = "username1"; ListCount = 3; PWLID = 53 }
-            @{parametername = 'HostName'; testvalue = "HostA"; ListCount = 4; PWLID = 53 }
-            @{parametername = 'Domain'; testvalue = "MYDomain"; ListCount = 5; PWLID = 53 }
-            @{parametername = 'AccountType'; testvalue = ""; ListCount = 1; PWLID = 53 } # testvalue must be empty because the actual property is AccountTypeID
-            @{parametername = 'Description'; testvalue = "Description for "; ListCount = 6; PWLID = 53 }
-            @{parametername = 'Notes'; testvalue = "Same Notes"; ListCount = 7; PWLID = 53 }
-            @{parametername = 'URL'; testvalue = "https://passworstate.local"; ListCount = 8; PWLID = 53 }
-            @{parametername = 'SiteID'; testvalue = ""; ListCount = 9; PWLID = 53 }
-            @{parametername = 'SiteLocation'; testvalue = ""; ListCount = 11; PWLID = 53 }
-            @{parametername = 'GenericField1'; testvalue = "TestField1"; ListCount = 11; PWLID = 53 }
-            @{parametername = 'GenericField2'; testvalue = "TestField2"; ListCount = 12; PWLID = 53 }
-            @{parametername = 'GenericField3'; testvalue = "TestField3"; ListCount = 13; PWLID = 53 }
-            @{parametername = 'GenericField4'; testvalue = "TestField4"; ListCount = 14; PWLID = 53 }
-            @{parametername = 'GenericField5'; testvalue = "TestField5"; ListCount = 15; PWLID = 53 }
-            @{parametername = 'GenericField6'; testvalue = "TestField6"; ListCount = 16; PWLID = 53 }
-            @{parametername = 'GenericField7'; testvalue = "TestField7"; ListCount = 17; PWLID = 53 }
-            @{parametername = 'GenericField8'; testvalue = "TestField8"; ListCount = 18; PWLID = 53 }
-            @{parametername = 'GenericField9'; testvalue = "TestField9"; ListCount = 19; PWLID = 53 }
-            @{parametername = 'GenericField10'; testvalue = "TestField10"; ListCount = 20; PWLID = 53 }
+            @{parametername = 'Title'; testvalue = 'Demo AD Username'; ListCount = 2; PWLID = 53 }
+            @{parametername = 'UserName'; testvalue = 'username1'; ListCount = 3; PWLID = 53 }
+            @{parametername = 'HostName'; testvalue = 'HostA'; ListCount = 4; PWLID = 53 }
+            @{parametername = 'Domain'; testvalue = 'MYDomain'; ListCount = 5; PWLID = 53 }
+            @{parametername = 'AccountType'; testvalue = ''; ListCount = 1; PWLID = 53 } # testvalue must be empty because the actual property is AccountTypeID
+            @{parametername = 'Description'; testvalue = 'Description for '; ListCount = 6; PWLID = 53 }
+            @{parametername = 'Notes'; testvalue = 'Same Notes'; ListCount = 7; PWLID = 53 }
+            @{parametername = 'URL'; testvalue = 'https://passworstate.local'; ListCount = 8; PWLID = 53 }
+            @{parametername = 'SiteID'; testvalue = ''; ListCount = 9; PWLID = 53 }
+            @{parametername = 'SiteLocation'; testvalue = ''; ListCount = 11; PWLID = 53 }
+            @{parametername = 'GenericField1'; testvalue = 'TestField1'; ListCount = 11; PWLID = 53 }
+            @{parametername = 'GenericField2'; testvalue = 'TestField2'; ListCount = 12; PWLID = 53 }
+            @{parametername = 'GenericField3'; testvalue = 'TestField3'; ListCount = 13; PWLID = 53 }
+            @{parametername = 'GenericField4'; testvalue = 'TestField4'; ListCount = 14; PWLID = 53 }
+            @{parametername = 'GenericField5'; testvalue = 'TestField5'; ListCount = 15; PWLID = 53 }
+            @{parametername = 'GenericField6'; testvalue = 'TestField6'; ListCount = 16; PWLID = 53 }
+            @{parametername = 'GenericField7'; testvalue = 'TestField7'; ListCount = 17; PWLID = 53 }
+            @{parametername = 'GenericField8'; testvalue = 'TestField8'; ListCount = 18; PWLID = 53 }
+            @{parametername = 'GenericField9'; testvalue = 'TestField9'; ListCount = 19; PWLID = 53 }
+            @{parametername = 'GenericField10'; testvalue = 'TestField10'; ListCount = 20; PWLID = 53 }
         ) {
             $Result = if ($parametername -ne '') {
                 ((Invoke-Expression -Command "$($FunctionName) -$($Parametername) '$($testvalue)' -PreventAuditing:`$True -Reason 'Audit reason provided'" ) | Measure-Object).Count
@@ -713,26 +726,26 @@ Describe 'Get-PasswordStatePassword' {
             }
         }
         It 'Should return <ListCount> for parameter <parametername> with PasswordListID <PWLID> and PreventAudit set to True' -ForEach @(
-            @{parametername = 'Title'; testvalue = "Demo AD Username"; ListCount = 2; PWLID = 53 }
-            @{parametername = 'UserName'; testvalue = "username1"; ListCount = 3; PWLID = 53 }
-            @{parametername = 'HostName'; testvalue = "HostA"; ListCount = 4; PWLID = 53 }
-            @{parametername = 'Domain'; testvalue = "MYDomain"; ListCount = 5; PWLID = 53 }
-            @{parametername = 'AccountType'; testvalue = ""; ListCount = 1; PWLID = 53 } # testvalue must be empty because the actual property is AccountTypeID
-            @{parametername = 'Description'; testvalue = "Description for "; ListCount = 6; PWLID = 53 }
-            @{parametername = 'Notes'; testvalue = "Same Notes"; ListCount = 7; PWLID = 53 }
-            @{parametername = 'URL'; testvalue = "https://passworstate.local"; ListCount = 8; PWLID = 53 }
-            @{parametername = 'SiteID'; testvalue = ""; ListCount = 9; PWLID = 53 }
-            @{parametername = 'SiteLocation'; testvalue = ""; ListCount = 11; PWLID = 53 }
-            @{parametername = 'GenericField1'; testvalue = "TestField1"; ListCount = 11; PWLID = 53 }
-            @{parametername = 'GenericField2'; testvalue = "TestField2"; ListCount = 12; PWLID = 53 }
-            @{parametername = 'GenericField3'; testvalue = "TestField3"; ListCount = 13; PWLID = 53 }
-            @{parametername = 'GenericField4'; testvalue = "TestField4"; ListCount = 14; PWLID = 53 }
-            @{parametername = 'GenericField5'; testvalue = "TestField5"; ListCount = 15; PWLID = 53 }
-            @{parametername = 'GenericField6'; testvalue = "TestField6"; ListCount = 16; PWLID = 53 }
-            @{parametername = 'GenericField7'; testvalue = "TestField7"; ListCount = 17; PWLID = 53 }
-            @{parametername = 'GenericField8'; testvalue = "TestField8"; ListCount = 18; PWLID = 53 }
-            @{parametername = 'GenericField9'; testvalue = "TestField9"; ListCount = 19; PWLID = 53 }
-            @{parametername = 'GenericField10'; testvalue = "TestField10"; ListCount = 20; PWLID = 53 }
+            @{parametername = 'Title'; testvalue = 'Demo AD Username'; ListCount = 2; PWLID = 53 }
+            @{parametername = 'UserName'; testvalue = 'username1'; ListCount = 3; PWLID = 53 }
+            @{parametername = 'HostName'; testvalue = 'HostA'; ListCount = 4; PWLID = 53 }
+            @{parametername = 'Domain'; testvalue = 'MYDomain'; ListCount = 5; PWLID = 53 }
+            @{parametername = 'AccountType'; testvalue = ''; ListCount = 1; PWLID = 53 } # testvalue must be empty because the actual property is AccountTypeID
+            @{parametername = 'Description'; testvalue = 'Description for '; ListCount = 6; PWLID = 53 }
+            @{parametername = 'Notes'; testvalue = 'Same Notes'; ListCount = 7; PWLID = 53 }
+            @{parametername = 'URL'; testvalue = 'https://passworstate.local'; ListCount = 8; PWLID = 53 }
+            @{parametername = 'SiteID'; testvalue = ''; ListCount = 9; PWLID = 53 }
+            @{parametername = 'SiteLocation'; testvalue = ''; ListCount = 11; PWLID = 53 }
+            @{parametername = 'GenericField1'; testvalue = 'TestField1'; ListCount = 11; PWLID = 53 }
+            @{parametername = 'GenericField2'; testvalue = 'TestField2'; ListCount = 12; PWLID = 53 }
+            @{parametername = 'GenericField3'; testvalue = 'TestField3'; ListCount = 13; PWLID = 53 }
+            @{parametername = 'GenericField4'; testvalue = 'TestField4'; ListCount = 14; PWLID = 53 }
+            @{parametername = 'GenericField5'; testvalue = 'TestField5'; ListCount = 15; PWLID = 53 }
+            @{parametername = 'GenericField6'; testvalue = 'TestField6'; ListCount = 16; PWLID = 53 }
+            @{parametername = 'GenericField7'; testvalue = 'TestField7'; ListCount = 17; PWLID = 53 }
+            @{parametername = 'GenericField8'; testvalue = 'TestField8'; ListCount = 18; PWLID = 53 }
+            @{parametername = 'GenericField9'; testvalue = 'TestField9'; ListCount = 19; PWLID = 53 }
+            @{parametername = 'GenericField10'; testvalue = 'TestField10'; ListCount = 20; PWLID = 53 }
         ) {
             $Result = if ($parametername -ne '') {
                 ((Invoke-Expression -Command "$($FunctionName) -$($Parametername) '$($testvalue)' -Reason 'Audit reason provided'" ) | Measure-Object).Count
@@ -746,26 +759,26 @@ Describe 'Get-PasswordStatePassword' {
             }
         }
         It 'Should have a <parametername> matching "<testvalue>"' -ForEach @(
-            @{parametername = 'Title'; testvalue = "Demo AD Username"; ListCount = 2; PWLID = 53 }
-            @{parametername = 'UserName'; testvalue = "username1"; ListCount = 3; PWLID = 53 }
-            @{parametername = 'HostName'; testvalue = "HostA"; ListCount = 4; PWLID = 53 }
-            @{parametername = 'Domain'; testvalue = "MYDomain"; ListCount = 5; PWLID = 53 }
-            @{parametername = 'AccountType'; testvalue = ""; ListCount = 1; PWLID = 53 } # testvalue must be empty because the actual property is AccountTypeID
-            @{parametername = 'Description'; testvalue = "Description for "; ListCount = 6; PWLID = 53 }
-            @{parametername = 'Notes'; testvalue = "Same Notes"; ListCount = 7; PWLID = 53 }
-            @{parametername = 'URL'; testvalue = "https://passworstate.local"; ListCount = 8; PWLID = 53 }
-            @{parametername = 'SiteID'; testvalue = ""; ListCount = 9; PWLID = 53 }
-            @{parametername = 'SiteLocation'; testvalue = ""; ListCount = 11; PWLID = 53 }
-            @{parametername = 'GenericField1'; testvalue = "TestField1"; ListCount = 11; PWLID = 53 }
-            @{parametername = 'GenericField2'; testvalue = "TestField2"; ListCount = 12; PWLID = 53 }
-            @{parametername = 'GenericField3'; testvalue = "TestField3"; ListCount = 13; PWLID = 53 }
-            @{parametername = 'GenericField4'; testvalue = "TestField4"; ListCount = 14; PWLID = 53 }
-            @{parametername = 'GenericField5'; testvalue = "TestField5"; ListCount = 15; PWLID = 53 }
-            @{parametername = 'GenericField6'; testvalue = "TestField6"; ListCount = 16; PWLID = 53 }
-            @{parametername = 'GenericField7'; testvalue = "TestField7"; ListCount = 17; PWLID = 53 }
-            @{parametername = 'GenericField8'; testvalue = "TestField8"; ListCount = 18; PWLID = 53 }
-            @{parametername = 'GenericField9'; testvalue = "TestField9"; ListCount = 19; PWLID = 53 }
-            @{parametername = 'GenericField10'; testvalue = "TestField10"; ListCount = 20; PWLID = 53 }
+            @{parametername = 'Title'; testvalue = 'Demo AD Username'; ListCount = 2; PWLID = 53 }
+            @{parametername = 'UserName'; testvalue = 'username1'; ListCount = 3; PWLID = 53 }
+            @{parametername = 'HostName'; testvalue = 'HostA'; ListCount = 4; PWLID = 53 }
+            @{parametername = 'Domain'; testvalue = 'MYDomain'; ListCount = 5; PWLID = 53 }
+            @{parametername = 'AccountType'; testvalue = ''; ListCount = 1; PWLID = 53 } # testvalue must be empty because the actual property is AccountTypeID
+            @{parametername = 'Description'; testvalue = 'Description for '; ListCount = 6; PWLID = 53 }
+            @{parametername = 'Notes'; testvalue = 'Same Notes'; ListCount = 7; PWLID = 53 }
+            @{parametername = 'URL'; testvalue = 'https://passworstate.local'; ListCount = 8; PWLID = 53 }
+            @{parametername = 'SiteID'; testvalue = ''; ListCount = 9; PWLID = 53 }
+            @{parametername = 'SiteLocation'; testvalue = ''; ListCount = 11; PWLID = 53 }
+            @{parametername = 'GenericField1'; testvalue = 'TestField1'; ListCount = 11; PWLID = 53 }
+            @{parametername = 'GenericField2'; testvalue = 'TestField2'; ListCount = 12; PWLID = 53 }
+            @{parametername = 'GenericField3'; testvalue = 'TestField3'; ListCount = 13; PWLID = 53 }
+            @{parametername = 'GenericField4'; testvalue = 'TestField4'; ListCount = 14; PWLID = 53 }
+            @{parametername = 'GenericField5'; testvalue = 'TestField5'; ListCount = 15; PWLID = 53 }
+            @{parametername = 'GenericField6'; testvalue = 'TestField6'; ListCount = 16; PWLID = 53 }
+            @{parametername = 'GenericField7'; testvalue = 'TestField7'; ListCount = 17; PWLID = 53 }
+            @{parametername = 'GenericField8'; testvalue = 'TestField8'; ListCount = 18; PWLID = 53 }
+            @{parametername = 'GenericField9'; testvalue = 'TestField9'; ListCount = 19; PWLID = 53 }
+            @{parametername = 'GenericField10'; testvalue = 'TestField10'; ListCount = 20; PWLID = 53 }
         ) {
             $ResultValues = Invoke-Expression -Command "$($FunctionName) -$($Parametername) '$($testvalue)' -Reason 'Audit reason provided'"
             foreach ($ResultValue in $ResultValues) {
@@ -776,7 +789,7 @@ Describe 'Get-PasswordStatePassword' {
             }
         }
         It 'Should have a <parametername> matching "<testvalue>" for alias <alias>' -ForEach @(
-            @{parametername = 'ADDomainNetBios'; testvalue = "MYDomain"; ListCount = 5; PWLID = 53; alias='Domain' }
+            @{parametername = 'ADDomainNetBios'; testvalue = 'MYDomain'; ListCount = 5; PWLID = 53; alias = 'Domain' }
         ) {
             $ResultValues = Invoke-Expression -Command "$($FunctionName) -$($Parametername) '$($testvalue)' -Reason 'Audit reason provided'"
             foreach ($ResultValue in $ResultValues) {
@@ -794,29 +807,29 @@ Describe 'Get-PasswordStatePassword' {
             Mock -CommandName 'Get-PasswordStateResource' -ModuleName 'passwordstate-management' -MockWith { $Global:TestJSON["PasswordSearch$($ParameterName)Response"] } -ParameterFilter { $uri -and $uri -match '\/searchpasswords\/(\d+){0,1}\?\w+=[^\&]+$' } -Verifiable
         }
         AfterAll {
-            Remove-Item -Path "$([environment]::GetFolderPath("UserProfile"))\Passwordstate.json" -Force -Confirm:$false -ErrorAction SilentlyContinue
+            Remove-Item -Path "$([environment]::GetFolderPath('UserProfile'))\Passwordstate.json" -Force -Confirm:$false -ErrorAction SilentlyContinue
         }
         It 'Should return <ListCount> for parameter <parametername> without PasswordListID' -ForEach @(
-            @{parametername = 'Title'; testvalue = "Demo AD Username"; ListCount = 2; PWLID = 53 }
-            @{parametername = 'UserName'; testvalue = "username1"; ListCount = 3; PWLID = 53 }
-            @{parametername = 'HostName'; testvalue = "HostA"; ListCount = 4; PWLID = 53 }
-            @{parametername = 'Domain'; testvalue = "MYDomain"; ListCount = 5; PWLID = 53 }
-            @{parametername = 'AccountType'; testvalue = ""; ListCount = 1; PWLID = 53 } # testvalue must be empty because the actual property is AccountTypeID
-            @{parametername = 'Description'; testvalue = "Description for "; ListCount = 6; PWLID = 53 }
-            @{parametername = 'Notes'; testvalue = "Same Notes"; ListCount = 7; PWLID = 53 }
-            @{parametername = 'URL'; testvalue = "https://passworstate.local"; ListCount = 8; PWLID = 53 }
-            @{parametername = 'SiteID'; testvalue = ""; ListCount = 9; PWLID = 53 }
-            @{parametername = 'SiteLocation'; testvalue = ""; ListCount = 11; PWLID = 53 }
-            @{parametername = 'GenericField1'; testvalue = "TestField1"; ListCount = 11; PWLID = 53 }
-            @{parametername = 'GenericField2'; testvalue = "TestField2"; ListCount = 12; PWLID = 53 }
-            @{parametername = 'GenericField3'; testvalue = "TestField3"; ListCount = 13; PWLID = 53 }
-            @{parametername = 'GenericField4'; testvalue = "TestField4"; ListCount = 14; PWLID = 53 }
-            @{parametername = 'GenericField5'; testvalue = "TestField5"; ListCount = 15; PWLID = 53 }
-            @{parametername = 'GenericField6'; testvalue = "TestField6"; ListCount = 16; PWLID = 53 }
-            @{parametername = 'GenericField7'; testvalue = "TestField7"; ListCount = 17; PWLID = 53 }
-            @{parametername = 'GenericField8'; testvalue = "TestField8"; ListCount = 18; PWLID = 53 }
-            @{parametername = 'GenericField9'; testvalue = "TestField9"; ListCount = 19; PWLID = 53 }
-            @{parametername = 'GenericField10'; testvalue = "TestField10"; ListCount = 20; PWLID = 53 }
+            @{parametername = 'Title'; testvalue = 'Demo AD Username'; ListCount = 2; PWLID = 53 }
+            @{parametername = 'UserName'; testvalue = 'username1'; ListCount = 3; PWLID = 53 }
+            @{parametername = 'HostName'; testvalue = 'HostA'; ListCount = 4; PWLID = 53 }
+            @{parametername = 'Domain'; testvalue = 'MYDomain'; ListCount = 5; PWLID = 53 }
+            @{parametername = 'AccountType'; testvalue = ''; ListCount = 1; PWLID = 53 } # testvalue must be empty because the actual property is AccountTypeID
+            @{parametername = 'Description'; testvalue = 'Description for '; ListCount = 6; PWLID = 53 }
+            @{parametername = 'Notes'; testvalue = 'Same Notes'; ListCount = 7; PWLID = 53 }
+            @{parametername = 'URL'; testvalue = 'https://passworstate.local'; ListCount = 8; PWLID = 53 }
+            @{parametername = 'SiteID'; testvalue = ''; ListCount = 9; PWLID = 53 }
+            @{parametername = 'SiteLocation'; testvalue = ''; ListCount = 11; PWLID = 53 }
+            @{parametername = 'GenericField1'; testvalue = 'TestField1'; ListCount = 11; PWLID = 53 }
+            @{parametername = 'GenericField2'; testvalue = 'TestField2'; ListCount = 12; PWLID = 53 }
+            @{parametername = 'GenericField3'; testvalue = 'TestField3'; ListCount = 13; PWLID = 53 }
+            @{parametername = 'GenericField4'; testvalue = 'TestField4'; ListCount = 14; PWLID = 53 }
+            @{parametername = 'GenericField5'; testvalue = 'TestField5'; ListCount = 15; PWLID = 53 }
+            @{parametername = 'GenericField6'; testvalue = 'TestField6'; ListCount = 16; PWLID = 53 }
+            @{parametername = 'GenericField7'; testvalue = 'TestField7'; ListCount = 17; PWLID = 53 }
+            @{parametername = 'GenericField8'; testvalue = 'TestField8'; ListCount = 18; PWLID = 53 }
+            @{parametername = 'GenericField9'; testvalue = 'TestField9'; ListCount = 19; PWLID = 53 }
+            @{parametername = 'GenericField10'; testvalue = 'TestField10'; ListCount = 20; PWLID = 53 }
         ) {
             $Result = if ($parametername -ne '') {
                 ((Invoke-Expression -Command "$($FunctionName) -$($Parametername) '$($testvalue)' -Reason 'Audit reason specified'" ) | Measure-Object).Count
@@ -830,26 +843,26 @@ Describe 'Get-PasswordStatePassword' {
             }
         }
         It 'Should return <ListCount> for parameter <parametername> with PasswordListID <PWLID>' -ForEach @(
-            @{parametername = 'Title'; testvalue = "Demo AD Username"; ListCount = 2; PWLID = 53 }
-            @{parametername = 'UserName'; testvalue = "username1"; ListCount = 3; PWLID = 53 }
-            @{parametername = 'HostName'; testvalue = "HostA"; ListCount = 4; PWLID = 53 }
-            @{parametername = 'Domain'; testvalue = "MYDomain"; ListCount = 5; PWLID = 53 }
-            @{parametername = 'AccountType'; testvalue = ""; ListCount = 1; PWLID = 53 } # testvalue must be empty because the actual property is AccountTypeID
-            @{parametername = 'Description'; testvalue = "Description for "; ListCount = 6; PWLID = 53 }
-            @{parametername = 'Notes'; testvalue = "Same Notes"; ListCount = 7; PWLID = 53 }
-            @{parametername = 'URL'; testvalue = "https://passworstate.local"; ListCount = 8; PWLID = 53 }
-            @{parametername = 'SiteID'; testvalue = ""; ListCount = 9; PWLID = 53 }
-            @{parametername = 'SiteLocation'; testvalue = ""; ListCount = 11; PWLID = 53 }
-            @{parametername = 'GenericField1'; testvalue = "TestField1"; ListCount = 11; PWLID = 53 }
-            @{parametername = 'GenericField2'; testvalue = "TestField2"; ListCount = 12; PWLID = 53 }
-            @{parametername = 'GenericField3'; testvalue = "TestField3"; ListCount = 13; PWLID = 53 }
-            @{parametername = 'GenericField4'; testvalue = "TestField4"; ListCount = 14; PWLID = 53 }
-            @{parametername = 'GenericField5'; testvalue = "TestField5"; ListCount = 15; PWLID = 53 }
-            @{parametername = 'GenericField6'; testvalue = "TestField6"; ListCount = 16; PWLID = 53 }
-            @{parametername = 'GenericField7'; testvalue = "TestField7"; ListCount = 17; PWLID = 53 }
-            @{parametername = 'GenericField8'; testvalue = "TestField8"; ListCount = 18; PWLID = 53 }
-            @{parametername = 'GenericField9'; testvalue = "TestField9"; ListCount = 19; PWLID = 53 }
-            @{parametername = 'GenericField10'; testvalue = "TestField10"; ListCount = 20; PWLID = 53 }
+            @{parametername = 'Title'; testvalue = 'Demo AD Username'; ListCount = 2; PWLID = 53 }
+            @{parametername = 'UserName'; testvalue = 'username1'; ListCount = 3; PWLID = 53 }
+            @{parametername = 'HostName'; testvalue = 'HostA'; ListCount = 4; PWLID = 53 }
+            @{parametername = 'Domain'; testvalue = 'MYDomain'; ListCount = 5; PWLID = 53 }
+            @{parametername = 'AccountType'; testvalue = ''; ListCount = 1; PWLID = 53 } # testvalue must be empty because the actual property is AccountTypeID
+            @{parametername = 'Description'; testvalue = 'Description for '; ListCount = 6; PWLID = 53 }
+            @{parametername = 'Notes'; testvalue = 'Same Notes'; ListCount = 7; PWLID = 53 }
+            @{parametername = 'URL'; testvalue = 'https://passworstate.local'; ListCount = 8; PWLID = 53 }
+            @{parametername = 'SiteID'; testvalue = ''; ListCount = 9; PWLID = 53 }
+            @{parametername = 'SiteLocation'; testvalue = ''; ListCount = 11; PWLID = 53 }
+            @{parametername = 'GenericField1'; testvalue = 'TestField1'; ListCount = 11; PWLID = 53 }
+            @{parametername = 'GenericField2'; testvalue = 'TestField2'; ListCount = 12; PWLID = 53 }
+            @{parametername = 'GenericField3'; testvalue = 'TestField3'; ListCount = 13; PWLID = 53 }
+            @{parametername = 'GenericField4'; testvalue = 'TestField4'; ListCount = 14; PWLID = 53 }
+            @{parametername = 'GenericField5'; testvalue = 'TestField5'; ListCount = 15; PWLID = 53 }
+            @{parametername = 'GenericField6'; testvalue = 'TestField6'; ListCount = 16; PWLID = 53 }
+            @{parametername = 'GenericField7'; testvalue = 'TestField7'; ListCount = 17; PWLID = 53 }
+            @{parametername = 'GenericField8'; testvalue = 'TestField8'; ListCount = 18; PWLID = 53 }
+            @{parametername = 'GenericField9'; testvalue = 'TestField9'; ListCount = 19; PWLID = 53 }
+            @{parametername = 'GenericField10'; testvalue = 'TestField10'; ListCount = 20; PWLID = 53 }
         ) {
             $Result = if ($parametername -ne '') {
                 ((Invoke-Expression -Command "$($FunctionName) -$($Parametername) '$($testvalue)' -Reason 'Audit reason specified'" ) | Measure-Object).Count
@@ -863,26 +876,26 @@ Describe 'Get-PasswordStatePassword' {
             }
         }
         It 'Should return <ListCount> for parameter <parametername> without PasswordListID and PreventAudit set to True' -ForEach @(
-            @{parametername = 'Title'; testvalue = "Demo AD Username"; ListCount = 2; PWLID = 53 }
-            @{parametername = 'UserName'; testvalue = "username1"; ListCount = 3; PWLID = 53 }
-            @{parametername = 'HostName'; testvalue = "HostA"; ListCount = 4; PWLID = 53 }
-            @{parametername = 'Domain'; testvalue = "MYDomain"; ListCount = 5; PWLID = 53 }
-            @{parametername = 'AccountType'; testvalue = ""; ListCount = 1; PWLID = 53 } # testvalue must be empty because the actual property is AccountTypeID
-            @{parametername = 'Description'; testvalue = "Description for "; ListCount = 6; PWLID = 53 }
-            @{parametername = 'Notes'; testvalue = "Same Notes"; ListCount = 7; PWLID = 53 }
-            @{parametername = 'URL'; testvalue = "https://passworstate.local"; ListCount = 8; PWLID = 53 }
-            @{parametername = 'SiteID'; testvalue = ""; ListCount = 9; PWLID = 53 }
-            @{parametername = 'SiteLocation'; testvalue = ""; ListCount = 11; PWLID = 53 }
-            @{parametername = 'GenericField1'; testvalue = "TestField1"; ListCount = 11; PWLID = 53 }
-            @{parametername = 'GenericField2'; testvalue = "TestField2"; ListCount = 12; PWLID = 53 }
-            @{parametername = 'GenericField3'; testvalue = "TestField3"; ListCount = 13; PWLID = 53 }
-            @{parametername = 'GenericField4'; testvalue = "TestField4"; ListCount = 14; PWLID = 53 }
-            @{parametername = 'GenericField5'; testvalue = "TestField5"; ListCount = 15; PWLID = 53 }
-            @{parametername = 'GenericField6'; testvalue = "TestField6"; ListCount = 16; PWLID = 53 }
-            @{parametername = 'GenericField7'; testvalue = "TestField7"; ListCount = 17; PWLID = 53 }
-            @{parametername = 'GenericField8'; testvalue = "TestField8"; ListCount = 18; PWLID = 53 }
-            @{parametername = 'GenericField9'; testvalue = "TestField9"; ListCount = 19; PWLID = 53 }
-            @{parametername = 'GenericField10'; testvalue = "TestField10"; ListCount = 20; PWLID = 53 }
+            @{parametername = 'Title'; testvalue = 'Demo AD Username'; ListCount = 2; PWLID = 53 }
+            @{parametername = 'UserName'; testvalue = 'username1'; ListCount = 3; PWLID = 53 }
+            @{parametername = 'HostName'; testvalue = 'HostA'; ListCount = 4; PWLID = 53 }
+            @{parametername = 'Domain'; testvalue = 'MYDomain'; ListCount = 5; PWLID = 53 }
+            @{parametername = 'AccountType'; testvalue = ''; ListCount = 1; PWLID = 53 } # testvalue must be empty because the actual property is AccountTypeID
+            @{parametername = 'Description'; testvalue = 'Description for '; ListCount = 6; PWLID = 53 }
+            @{parametername = 'Notes'; testvalue = 'Same Notes'; ListCount = 7; PWLID = 53 }
+            @{parametername = 'URL'; testvalue = 'https://passworstate.local'; ListCount = 8; PWLID = 53 }
+            @{parametername = 'SiteID'; testvalue = ''; ListCount = 9; PWLID = 53 }
+            @{parametername = 'SiteLocation'; testvalue = ''; ListCount = 11; PWLID = 53 }
+            @{parametername = 'GenericField1'; testvalue = 'TestField1'; ListCount = 11; PWLID = 53 }
+            @{parametername = 'GenericField2'; testvalue = 'TestField2'; ListCount = 12; PWLID = 53 }
+            @{parametername = 'GenericField3'; testvalue = 'TestField3'; ListCount = 13; PWLID = 53 }
+            @{parametername = 'GenericField4'; testvalue = 'TestField4'; ListCount = 14; PWLID = 53 }
+            @{parametername = 'GenericField5'; testvalue = 'TestField5'; ListCount = 15; PWLID = 53 }
+            @{parametername = 'GenericField6'; testvalue = 'TestField6'; ListCount = 16; PWLID = 53 }
+            @{parametername = 'GenericField7'; testvalue = 'TestField7'; ListCount = 17; PWLID = 53 }
+            @{parametername = 'GenericField8'; testvalue = 'TestField8'; ListCount = 18; PWLID = 53 }
+            @{parametername = 'GenericField9'; testvalue = 'TestField9'; ListCount = 19; PWLID = 53 }
+            @{parametername = 'GenericField10'; testvalue = 'TestField10'; ListCount = 20; PWLID = 53 }
         ) {
             $Result = if ($parametername -ne '') {
                 ((Invoke-Expression -Command "$($FunctionName) -$($Parametername) '$($testvalue)' -PreventAuditing:`$True -Reason 'Audit reason specified'" ) | Measure-Object).Count
@@ -896,26 +909,26 @@ Describe 'Get-PasswordStatePassword' {
             }
         }
         It 'Should return <ListCount> for parameter <parametername> with PasswordListID <PWLID> and PreventAudit set to True' -ForEach @(
-            @{parametername = 'Title'; testvalue = "Demo AD Username"; ListCount = 2; PWLID = 53 }
-            @{parametername = 'UserName'; testvalue = "username1"; ListCount = 3; PWLID = 53 }
-            @{parametername = 'HostName'; testvalue = "HostA"; ListCount = 4; PWLID = 53 }
-            @{parametername = 'Domain'; testvalue = "MYDomain"; ListCount = 5; PWLID = 53 }
-            @{parametername = 'AccountType'; testvalue = ""; ListCount = 1; PWLID = 53 } # testvalue must be empty because the actual property is AccountTypeID
-            @{parametername = 'Description'; testvalue = "Description for "; ListCount = 6; PWLID = 53 }
-            @{parametername = 'Notes'; testvalue = "Same Notes"; ListCount = 7; PWLID = 53 }
-            @{parametername = 'URL'; testvalue = "https://passworstate.local"; ListCount = 8; PWLID = 53 }
-            @{parametername = 'SiteID'; testvalue = ""; ListCount = 9; PWLID = 53 }
-            @{parametername = 'SiteLocation'; testvalue = ""; ListCount = 11; PWLID = 53 }
-            @{parametername = 'GenericField1'; testvalue = "TestField1"; ListCount = 11; PWLID = 53 }
-            @{parametername = 'GenericField2'; testvalue = "TestField2"; ListCount = 12; PWLID = 53 }
-            @{parametername = 'GenericField3'; testvalue = "TestField3"; ListCount = 13; PWLID = 53 }
-            @{parametername = 'GenericField4'; testvalue = "TestField4"; ListCount = 14; PWLID = 53 }
-            @{parametername = 'GenericField5'; testvalue = "TestField5"; ListCount = 15; PWLID = 53 }
-            @{parametername = 'GenericField6'; testvalue = "TestField6"; ListCount = 16; PWLID = 53 }
-            @{parametername = 'GenericField7'; testvalue = "TestField7"; ListCount = 17; PWLID = 53 }
-            @{parametername = 'GenericField8'; testvalue = "TestField8"; ListCount = 18; PWLID = 53 }
-            @{parametername = 'GenericField9'; testvalue = "TestField9"; ListCount = 19; PWLID = 53 }
-            @{parametername = 'GenericField10'; testvalue = "TestField10"; ListCount = 20; PWLID = 53 }
+            @{parametername = 'Title'; testvalue = 'Demo AD Username'; ListCount = 2; PWLID = 53 }
+            @{parametername = 'UserName'; testvalue = 'username1'; ListCount = 3; PWLID = 53 }
+            @{parametername = 'HostName'; testvalue = 'HostA'; ListCount = 4; PWLID = 53 }
+            @{parametername = 'Domain'; testvalue = 'MYDomain'; ListCount = 5; PWLID = 53 }
+            @{parametername = 'AccountType'; testvalue = ''; ListCount = 1; PWLID = 53 } # testvalue must be empty because the actual property is AccountTypeID
+            @{parametername = 'Description'; testvalue = 'Description for '; ListCount = 6; PWLID = 53 }
+            @{parametername = 'Notes'; testvalue = 'Same Notes'; ListCount = 7; PWLID = 53 }
+            @{parametername = 'URL'; testvalue = 'https://passworstate.local'; ListCount = 8; PWLID = 53 }
+            @{parametername = 'SiteID'; testvalue = ''; ListCount = 9; PWLID = 53 }
+            @{parametername = 'SiteLocation'; testvalue = ''; ListCount = 11; PWLID = 53 }
+            @{parametername = 'GenericField1'; testvalue = 'TestField1'; ListCount = 11; PWLID = 53 }
+            @{parametername = 'GenericField2'; testvalue = 'TestField2'; ListCount = 12; PWLID = 53 }
+            @{parametername = 'GenericField3'; testvalue = 'TestField3'; ListCount = 13; PWLID = 53 }
+            @{parametername = 'GenericField4'; testvalue = 'TestField4'; ListCount = 14; PWLID = 53 }
+            @{parametername = 'GenericField5'; testvalue = 'TestField5'; ListCount = 15; PWLID = 53 }
+            @{parametername = 'GenericField6'; testvalue = 'TestField6'; ListCount = 16; PWLID = 53 }
+            @{parametername = 'GenericField7'; testvalue = 'TestField7'; ListCount = 17; PWLID = 53 }
+            @{parametername = 'GenericField8'; testvalue = 'TestField8'; ListCount = 18; PWLID = 53 }
+            @{parametername = 'GenericField9'; testvalue = 'TestField9'; ListCount = 19; PWLID = 53 }
+            @{parametername = 'GenericField10'; testvalue = 'TestField10'; ListCount = 20; PWLID = 53 }
         ) {
             $Result = if ($parametername -ne '') {
                 ((Invoke-Expression -Command "$($FunctionName) -$($Parametername) '$($testvalue)' -Reason 'Audit reason specified'" ) | Measure-Object).Count
@@ -929,26 +942,26 @@ Describe 'Get-PasswordStatePassword' {
             }
         }
         It 'Should have a <parametername> matching "<testvalue>"' -ForEach @(
-            @{parametername = 'Title'; testvalue = "Demo AD Username"; ListCount = 2; PWLID = 53 }
-            @{parametername = 'UserName'; testvalue = "username1"; ListCount = 3; PWLID = 53 }
-            @{parametername = 'HostName'; testvalue = "HostA"; ListCount = 4; PWLID = 53 }
-            @{parametername = 'Domain'; testvalue = "MYDomain"; ListCount = 5; PWLID = 53 }
-            @{parametername = 'AccountType'; testvalue = ""; ListCount = 1; PWLID = 53 } # testvalue must be empty because the actual property is AccountTypeID
-            @{parametername = 'Description'; testvalue = "Description for "; ListCount = 6; PWLID = 53 }
-            @{parametername = 'Notes'; testvalue = "Same Notes"; ListCount = 7; PWLID = 53 }
-            @{parametername = 'URL'; testvalue = "https://passworstate.local"; ListCount = 8; PWLID = 53 }
-            @{parametername = 'SiteID'; testvalue = ""; ListCount = 9; PWLID = 53 }
-            @{parametername = 'SiteLocation'; testvalue = ""; ListCount = 11; PWLID = 53 }
-            @{parametername = 'GenericField1'; testvalue = "TestField1"; ListCount = 11; PWLID = 53 }
-            @{parametername = 'GenericField2'; testvalue = "TestField2"; ListCount = 12; PWLID = 53 }
-            @{parametername = 'GenericField3'; testvalue = "TestField3"; ListCount = 13; PWLID = 53 }
-            @{parametername = 'GenericField4'; testvalue = "TestField4"; ListCount = 14; PWLID = 53 }
-            @{parametername = 'GenericField5'; testvalue = "TestField5"; ListCount = 15; PWLID = 53 }
-            @{parametername = 'GenericField6'; testvalue = "TestField6"; ListCount = 16; PWLID = 53 }
-            @{parametername = 'GenericField7'; testvalue = "TestField7"; ListCount = 17; PWLID = 53 }
-            @{parametername = 'GenericField8'; testvalue = "TestField8"; ListCount = 18; PWLID = 53 }
-            @{parametername = 'GenericField9'; testvalue = "TestField9"; ListCount = 19; PWLID = 53 }
-            @{parametername = 'GenericField10'; testvalue = "TestField10"; ListCount = 20; PWLID = 53 }
+            @{parametername = 'Title'; testvalue = 'Demo AD Username'; ListCount = 2; PWLID = 53 }
+            @{parametername = 'UserName'; testvalue = 'username1'; ListCount = 3; PWLID = 53 }
+            @{parametername = 'HostName'; testvalue = 'HostA'; ListCount = 4; PWLID = 53 }
+            @{parametername = 'Domain'; testvalue = 'MYDomain'; ListCount = 5; PWLID = 53 }
+            @{parametername = 'AccountType'; testvalue = ''; ListCount = 1; PWLID = 53 } # testvalue must be empty because the actual property is AccountTypeID
+            @{parametername = 'Description'; testvalue = 'Description for '; ListCount = 6; PWLID = 53 }
+            @{parametername = 'Notes'; testvalue = 'Same Notes'; ListCount = 7; PWLID = 53 }
+            @{parametername = 'URL'; testvalue = 'https://passworstate.local'; ListCount = 8; PWLID = 53 }
+            @{parametername = 'SiteID'; testvalue = ''; ListCount = 9; PWLID = 53 }
+            @{parametername = 'SiteLocation'; testvalue = ''; ListCount = 11; PWLID = 53 }
+            @{parametername = 'GenericField1'; testvalue = 'TestField1'; ListCount = 11; PWLID = 53 }
+            @{parametername = 'GenericField2'; testvalue = 'TestField2'; ListCount = 12; PWLID = 53 }
+            @{parametername = 'GenericField3'; testvalue = 'TestField3'; ListCount = 13; PWLID = 53 }
+            @{parametername = 'GenericField4'; testvalue = 'TestField4'; ListCount = 14; PWLID = 53 }
+            @{parametername = 'GenericField5'; testvalue = 'TestField5'; ListCount = 15; PWLID = 53 }
+            @{parametername = 'GenericField6'; testvalue = 'TestField6'; ListCount = 16; PWLID = 53 }
+            @{parametername = 'GenericField7'; testvalue = 'TestField7'; ListCount = 17; PWLID = 53 }
+            @{parametername = 'GenericField8'; testvalue = 'TestField8'; ListCount = 18; PWLID = 53 }
+            @{parametername = 'GenericField9'; testvalue = 'TestField9'; ListCount = 19; PWLID = 53 }
+            @{parametername = 'GenericField10'; testvalue = 'TestField10'; ListCount = 20; PWLID = 53 }
         ) {
             $ResultValues = Invoke-Expression -Command "$($FunctionName) -$($Parametername) '$($testvalue)' -Reason 'Audit reason specified'"
             foreach ($ResultValue in $ResultValues) {
@@ -959,7 +972,7 @@ Describe 'Get-PasswordStatePassword' {
             }
         }
         It 'Should have a <parametername> matching "<testvalue>" for alias <alias>' -ForEach @(
-            @{parametername = 'ADDomainNetBios'; testvalue = "MYDomain"; ListCount = 5; PWLID = 53; alias='Domain' }
+            @{parametername = 'ADDomainNetBios'; testvalue = 'MYDomain'; ListCount = 5; PWLID = 53; alias = 'Domain' }
         ) {
             $ResultValues = Invoke-Expression -Command "$($FunctionName) -$($Parametername) '$($testvalue)' -Reason 'Audit reason specified'"
             foreach ($ResultValue in $ResultValues) {
@@ -977,29 +990,29 @@ Describe 'Get-PasswordStatePassword' {
             Mock -CommandName 'Get-PasswordStateResource' -ModuleName 'passwordstate-management' -MockWith { $Global:TestJSON["PasswordSearch$($ParameterName)Response"] } -ParameterFilter { $uri -and $uri -match '\/searchpasswords\/(\d+){0,1}\?\w+=[^\&]+$' } -Verifiable
         }
         AfterAll {
-            Remove-Item -Path "$([environment]::GetFolderPath("UserProfile"))\Passwordstate.json" -Force -Confirm:$false -ErrorAction SilentlyContinue
+            Remove-Item -Path "$([environment]::GetFolderPath('UserProfile'))\Passwordstate.json" -Force -Confirm:$false -ErrorAction SilentlyContinue
         }
         It 'Should return <ListCount> for parameter <parametername> without PasswordListID' -ForEach @(
-            @{parametername = 'Title'; testvalue = "Demo AD Username"; ListCount = 2; PWLID = 53 }
-            @{parametername = 'UserName'; testvalue = "username1"; ListCount = 3; PWLID = 53 }
-            @{parametername = 'HostName'; testvalue = "HostA"; ListCount = 4; PWLID = 53 }
-            @{parametername = 'Domain'; testvalue = "MYDomain"; ListCount = 5; PWLID = 53 }
-            @{parametername = 'AccountType'; testvalue = ""; ListCount = 1; PWLID = 53 } # testvalue must be empty because the actual property is AccountTypeID
-            @{parametername = 'Description'; testvalue = "Description for "; ListCount = 6; PWLID = 53 }
-            @{parametername = 'Notes'; testvalue = "Same Notes"; ListCount = 7; PWLID = 53 }
-            @{parametername = 'URL'; testvalue = "https://passworstate.local"; ListCount = 8; PWLID = 53 }
-            @{parametername = 'SiteID'; testvalue = ""; ListCount = 9; PWLID = 53 }
-            @{parametername = 'SiteLocation'; testvalue = ""; ListCount = 11; PWLID = 53 }
-            @{parametername = 'GenericField1'; testvalue = "TestField1"; ListCount = 11; PWLID = 53 }
-            @{parametername = 'GenericField2'; testvalue = "TestField2"; ListCount = 12; PWLID = 53 }
-            @{parametername = 'GenericField3'; testvalue = "TestField3"; ListCount = 13; PWLID = 53 }
-            @{parametername = 'GenericField4'; testvalue = "TestField4"; ListCount = 14; PWLID = 53 }
-            @{parametername = 'GenericField5'; testvalue = "TestField5"; ListCount = 15; PWLID = 53 }
-            @{parametername = 'GenericField6'; testvalue = "TestField6"; ListCount = 16; PWLID = 53 }
-            @{parametername = 'GenericField7'; testvalue = "TestField7"; ListCount = 17; PWLID = 53 }
-            @{parametername = 'GenericField8'; testvalue = "TestField8"; ListCount = 18; PWLID = 53 }
-            @{parametername = 'GenericField9'; testvalue = "TestField9"; ListCount = 19; PWLID = 53 }
-            @{parametername = 'GenericField10'; testvalue = "TestField10"; ListCount = 20; PWLID = 53 }
+            @{parametername = 'Title'; testvalue = 'Demo AD Username'; ListCount = 2; PWLID = 53 }
+            @{parametername = 'UserName'; testvalue = 'username1'; ListCount = 3; PWLID = 53 }
+            @{parametername = 'HostName'; testvalue = 'HostA'; ListCount = 4; PWLID = 53 }
+            @{parametername = 'Domain'; testvalue = 'MYDomain'; ListCount = 5; PWLID = 53 }
+            @{parametername = 'AccountType'; testvalue = ''; ListCount = 1; PWLID = 53 } # testvalue must be empty because the actual property is AccountTypeID
+            @{parametername = 'Description'; testvalue = 'Description for '; ListCount = 6; PWLID = 53 }
+            @{parametername = 'Notes'; testvalue = 'Same Notes'; ListCount = 7; PWLID = 53 }
+            @{parametername = 'URL'; testvalue = 'https://passworstate.local'; ListCount = 8; PWLID = 53 }
+            @{parametername = 'SiteID'; testvalue = ''; ListCount = 9; PWLID = 53 }
+            @{parametername = 'SiteLocation'; testvalue = ''; ListCount = 11; PWLID = 53 }
+            @{parametername = 'GenericField1'; testvalue = 'TestField1'; ListCount = 11; PWLID = 53 }
+            @{parametername = 'GenericField2'; testvalue = 'TestField2'; ListCount = 12; PWLID = 53 }
+            @{parametername = 'GenericField3'; testvalue = 'TestField3'; ListCount = 13; PWLID = 53 }
+            @{parametername = 'GenericField4'; testvalue = 'TestField4'; ListCount = 14; PWLID = 53 }
+            @{parametername = 'GenericField5'; testvalue = 'TestField5'; ListCount = 15; PWLID = 53 }
+            @{parametername = 'GenericField6'; testvalue = 'TestField6'; ListCount = 16; PWLID = 53 }
+            @{parametername = 'GenericField7'; testvalue = 'TestField7'; ListCount = 17; PWLID = 53 }
+            @{parametername = 'GenericField8'; testvalue = 'TestField8'; ListCount = 18; PWLID = 53 }
+            @{parametername = 'GenericField9'; testvalue = 'TestField9'; ListCount = 19; PWLID = 53 }
+            @{parametername = 'GenericField10'; testvalue = 'TestField10'; ListCount = 20; PWLID = 53 }
         ) {
             $Result = if ($parametername -ne '') {
                 ((Invoke-Expression -Command "$($FunctionName) -$($Parametername) '$($testvalue)' -Reason 'Audit reason specified'" ) | Measure-Object).Count
@@ -1013,26 +1026,26 @@ Describe 'Get-PasswordStatePassword' {
             }
         }
         It 'Should return <ListCount> for parameter <parametername> with PasswordListID <PWLID>' -ForEach @(
-            @{parametername = 'Title'; testvalue = "Demo AD Username"; ListCount = 2; PWLID = 53 }
-            @{parametername = 'UserName'; testvalue = "username1"; ListCount = 3; PWLID = 53 }
-            @{parametername = 'HostName'; testvalue = "HostA"; ListCount = 4; PWLID = 53 }
-            @{parametername = 'Domain'; testvalue = "MYDomain"; ListCount = 5; PWLID = 53 }
-            @{parametername = 'AccountType'; testvalue = ""; ListCount = 1; PWLID = 53 } # testvalue must be empty because the actual property is AccountTypeID
-            @{parametername = 'Description'; testvalue = "Description for "; ListCount = 6; PWLID = 53 }
-            @{parametername = 'Notes'; testvalue = "Same Notes"; ListCount = 7; PWLID = 53 }
-            @{parametername = 'URL'; testvalue = "https://passworstate.local"; ListCount = 8; PWLID = 53 }
-            @{parametername = 'SiteID'; testvalue = ""; ListCount = 9; PWLID = 53 }
-            @{parametername = 'SiteLocation'; testvalue = ""; ListCount = 11; PWLID = 53 }
-            @{parametername = 'GenericField1'; testvalue = "TestField1"; ListCount = 11; PWLID = 53 }
-            @{parametername = 'GenericField2'; testvalue = "TestField2"; ListCount = 12; PWLID = 53 }
-            @{parametername = 'GenericField3'; testvalue = "TestField3"; ListCount = 13; PWLID = 53 }
-            @{parametername = 'GenericField4'; testvalue = "TestField4"; ListCount = 14; PWLID = 53 }
-            @{parametername = 'GenericField5'; testvalue = "TestField5"; ListCount = 15; PWLID = 53 }
-            @{parametername = 'GenericField6'; testvalue = "TestField6"; ListCount = 16; PWLID = 53 }
-            @{parametername = 'GenericField7'; testvalue = "TestField7"; ListCount = 17; PWLID = 53 }
-            @{parametername = 'GenericField8'; testvalue = "TestField8"; ListCount = 18; PWLID = 53 }
-            @{parametername = 'GenericField9'; testvalue = "TestField9"; ListCount = 19; PWLID = 53 }
-            @{parametername = 'GenericField10'; testvalue = "TestField10"; ListCount = 20; PWLID = 53 }
+            @{parametername = 'Title'; testvalue = 'Demo AD Username'; ListCount = 2; PWLID = 53 }
+            @{parametername = 'UserName'; testvalue = 'username1'; ListCount = 3; PWLID = 53 }
+            @{parametername = 'HostName'; testvalue = 'HostA'; ListCount = 4; PWLID = 53 }
+            @{parametername = 'Domain'; testvalue = 'MYDomain'; ListCount = 5; PWLID = 53 }
+            @{parametername = 'AccountType'; testvalue = ''; ListCount = 1; PWLID = 53 } # testvalue must be empty because the actual property is AccountTypeID
+            @{parametername = 'Description'; testvalue = 'Description for '; ListCount = 6; PWLID = 53 }
+            @{parametername = 'Notes'; testvalue = 'Same Notes'; ListCount = 7; PWLID = 53 }
+            @{parametername = 'URL'; testvalue = 'https://passworstate.local'; ListCount = 8; PWLID = 53 }
+            @{parametername = 'SiteID'; testvalue = ''; ListCount = 9; PWLID = 53 }
+            @{parametername = 'SiteLocation'; testvalue = ''; ListCount = 11; PWLID = 53 }
+            @{parametername = 'GenericField1'; testvalue = 'TestField1'; ListCount = 11; PWLID = 53 }
+            @{parametername = 'GenericField2'; testvalue = 'TestField2'; ListCount = 12; PWLID = 53 }
+            @{parametername = 'GenericField3'; testvalue = 'TestField3'; ListCount = 13; PWLID = 53 }
+            @{parametername = 'GenericField4'; testvalue = 'TestField4'; ListCount = 14; PWLID = 53 }
+            @{parametername = 'GenericField5'; testvalue = 'TestField5'; ListCount = 15; PWLID = 53 }
+            @{parametername = 'GenericField6'; testvalue = 'TestField6'; ListCount = 16; PWLID = 53 }
+            @{parametername = 'GenericField7'; testvalue = 'TestField7'; ListCount = 17; PWLID = 53 }
+            @{parametername = 'GenericField8'; testvalue = 'TestField8'; ListCount = 18; PWLID = 53 }
+            @{parametername = 'GenericField9'; testvalue = 'TestField9'; ListCount = 19; PWLID = 53 }
+            @{parametername = 'GenericField10'; testvalue = 'TestField10'; ListCount = 20; PWLID = 53 }
         ) {
             $Result = if ($parametername -ne '') {
                 ((Invoke-Expression -Command "$($FunctionName) -$($Parametername) '$($testvalue)' -Reason 'Audit reason specified'" ) | Measure-Object).Count
@@ -1046,26 +1059,26 @@ Describe 'Get-PasswordStatePassword' {
             }
         }
         It 'Should return <ListCount> for parameter <parametername> without PasswordListID and PreventAudit set to True' -ForEach @(
-            @{parametername = 'Title'; testvalue = "Demo AD Username"; ListCount = 2; PWLID = 53 }
-            @{parametername = 'UserName'; testvalue = "username1"; ListCount = 3; PWLID = 53 }
-            @{parametername = 'HostName'; testvalue = "HostA"; ListCount = 4; PWLID = 53 }
-            @{parametername = 'Domain'; testvalue = "MYDomain"; ListCount = 5; PWLID = 53 }
-            @{parametername = 'AccountType'; testvalue = ""; ListCount = 1; PWLID = 53 } # testvalue must be empty because the actual property is AccountTypeID
-            @{parametername = 'Description'; testvalue = "Description for "; ListCount = 6; PWLID = 53 }
-            @{parametername = 'Notes'; testvalue = "Same Notes"; ListCount = 7; PWLID = 53 }
-            @{parametername = 'URL'; testvalue = "https://passworstate.local"; ListCount = 8; PWLID = 53 }
-            @{parametername = 'SiteID'; testvalue = ""; ListCount = 9; PWLID = 53 }
-            @{parametername = 'SiteLocation'; testvalue = ""; ListCount = 11; PWLID = 53 }
-            @{parametername = 'GenericField1'; testvalue = "TestField1"; ListCount = 11; PWLID = 53 }
-            @{parametername = 'GenericField2'; testvalue = "TestField2"; ListCount = 12; PWLID = 53 }
-            @{parametername = 'GenericField3'; testvalue = "TestField3"; ListCount = 13; PWLID = 53 }
-            @{parametername = 'GenericField4'; testvalue = "TestField4"; ListCount = 14; PWLID = 53 }
-            @{parametername = 'GenericField5'; testvalue = "TestField5"; ListCount = 15; PWLID = 53 }
-            @{parametername = 'GenericField6'; testvalue = "TestField6"; ListCount = 16; PWLID = 53 }
-            @{parametername = 'GenericField7'; testvalue = "TestField7"; ListCount = 17; PWLID = 53 }
-            @{parametername = 'GenericField8'; testvalue = "TestField8"; ListCount = 18; PWLID = 53 }
-            @{parametername = 'GenericField9'; testvalue = "TestField9"; ListCount = 19; PWLID = 53 }
-            @{parametername = 'GenericField10'; testvalue = "TestField10"; ListCount = 20; PWLID = 53 }
+            @{parametername = 'Title'; testvalue = 'Demo AD Username'; ListCount = 2; PWLID = 53 }
+            @{parametername = 'UserName'; testvalue = 'username1'; ListCount = 3; PWLID = 53 }
+            @{parametername = 'HostName'; testvalue = 'HostA'; ListCount = 4; PWLID = 53 }
+            @{parametername = 'Domain'; testvalue = 'MYDomain'; ListCount = 5; PWLID = 53 }
+            @{parametername = 'AccountType'; testvalue = ''; ListCount = 1; PWLID = 53 } # testvalue must be empty because the actual property is AccountTypeID
+            @{parametername = 'Description'; testvalue = 'Description for '; ListCount = 6; PWLID = 53 }
+            @{parametername = 'Notes'; testvalue = 'Same Notes'; ListCount = 7; PWLID = 53 }
+            @{parametername = 'URL'; testvalue = 'https://passworstate.local'; ListCount = 8; PWLID = 53 }
+            @{parametername = 'SiteID'; testvalue = ''; ListCount = 9; PWLID = 53 }
+            @{parametername = 'SiteLocation'; testvalue = ''; ListCount = 11; PWLID = 53 }
+            @{parametername = 'GenericField1'; testvalue = 'TestField1'; ListCount = 11; PWLID = 53 }
+            @{parametername = 'GenericField2'; testvalue = 'TestField2'; ListCount = 12; PWLID = 53 }
+            @{parametername = 'GenericField3'; testvalue = 'TestField3'; ListCount = 13; PWLID = 53 }
+            @{parametername = 'GenericField4'; testvalue = 'TestField4'; ListCount = 14; PWLID = 53 }
+            @{parametername = 'GenericField5'; testvalue = 'TestField5'; ListCount = 15; PWLID = 53 }
+            @{parametername = 'GenericField6'; testvalue = 'TestField6'; ListCount = 16; PWLID = 53 }
+            @{parametername = 'GenericField7'; testvalue = 'TestField7'; ListCount = 17; PWLID = 53 }
+            @{parametername = 'GenericField8'; testvalue = 'TestField8'; ListCount = 18; PWLID = 53 }
+            @{parametername = 'GenericField9'; testvalue = 'TestField9'; ListCount = 19; PWLID = 53 }
+            @{parametername = 'GenericField10'; testvalue = 'TestField10'; ListCount = 20; PWLID = 53 }
         ) {
             $Result = if ($parametername -ne '') {
                 ((Invoke-Expression -Command "$($FunctionName) -$($Parametername) '$($testvalue)' -PreventAuditing:`$True -Reason 'Audit reason specified'" ) | Measure-Object).Count
@@ -1079,26 +1092,26 @@ Describe 'Get-PasswordStatePassword' {
             }
         }
         It 'Should return <ListCount> for parameter <parametername> with PasswordListID <PWLID> and PreventAudit set to True' -ForEach @(
-            @{parametername = 'Title'; testvalue = "Demo AD Username"; ListCount = 2; PWLID = 53 }
-            @{parametername = 'UserName'; testvalue = "username1"; ListCount = 3; PWLID = 53 }
-            @{parametername = 'HostName'; testvalue = "HostA"; ListCount = 4; PWLID = 53 }
-            @{parametername = 'Domain'; testvalue = "MYDomain"; ListCount = 5; PWLID = 53 }
-            @{parametername = 'AccountType'; testvalue = ""; ListCount = 1; PWLID = 53 } # testvalue must be empty because the actual property is AccountTypeID
-            @{parametername = 'Description'; testvalue = "Description for "; ListCount = 6; PWLID = 53 }
-            @{parametername = 'Notes'; testvalue = "Same Notes"; ListCount = 7; PWLID = 53 }
-            @{parametername = 'URL'; testvalue = "https://passworstate.local"; ListCount = 8; PWLID = 53 }
-            @{parametername = 'SiteID'; testvalue = ""; ListCount = 9; PWLID = 53 }
-            @{parametername = 'SiteLocation'; testvalue = ""; ListCount = 11; PWLID = 53 }
-            @{parametername = 'GenericField1'; testvalue = "TestField1"; ListCount = 11; PWLID = 53 }
-            @{parametername = 'GenericField2'; testvalue = "TestField2"; ListCount = 12; PWLID = 53 }
-            @{parametername = 'GenericField3'; testvalue = "TestField3"; ListCount = 13; PWLID = 53 }
-            @{parametername = 'GenericField4'; testvalue = "TestField4"; ListCount = 14; PWLID = 53 }
-            @{parametername = 'GenericField5'; testvalue = "TestField5"; ListCount = 15; PWLID = 53 }
-            @{parametername = 'GenericField6'; testvalue = "TestField6"; ListCount = 16; PWLID = 53 }
-            @{parametername = 'GenericField7'; testvalue = "TestField7"; ListCount = 17; PWLID = 53 }
-            @{parametername = 'GenericField8'; testvalue = "TestField8"; ListCount = 18; PWLID = 53 }
-            @{parametername = 'GenericField9'; testvalue = "TestField9"; ListCount = 19; PWLID = 53 }
-            @{parametername = 'GenericField10'; testvalue = "TestField10"; ListCount = 20; PWLID = 53 }
+            @{parametername = 'Title'; testvalue = 'Demo AD Username'; ListCount = 2; PWLID = 53 }
+            @{parametername = 'UserName'; testvalue = 'username1'; ListCount = 3; PWLID = 53 }
+            @{parametername = 'HostName'; testvalue = 'HostA'; ListCount = 4; PWLID = 53 }
+            @{parametername = 'Domain'; testvalue = 'MYDomain'; ListCount = 5; PWLID = 53 }
+            @{parametername = 'AccountType'; testvalue = ''; ListCount = 1; PWLID = 53 } # testvalue must be empty because the actual property is AccountTypeID
+            @{parametername = 'Description'; testvalue = 'Description for '; ListCount = 6; PWLID = 53 }
+            @{parametername = 'Notes'; testvalue = 'Same Notes'; ListCount = 7; PWLID = 53 }
+            @{parametername = 'URL'; testvalue = 'https://passworstate.local'; ListCount = 8; PWLID = 53 }
+            @{parametername = 'SiteID'; testvalue = ''; ListCount = 9; PWLID = 53 }
+            @{parametername = 'SiteLocation'; testvalue = ''; ListCount = 11; PWLID = 53 }
+            @{parametername = 'GenericField1'; testvalue = 'TestField1'; ListCount = 11; PWLID = 53 }
+            @{parametername = 'GenericField2'; testvalue = 'TestField2'; ListCount = 12; PWLID = 53 }
+            @{parametername = 'GenericField3'; testvalue = 'TestField3'; ListCount = 13; PWLID = 53 }
+            @{parametername = 'GenericField4'; testvalue = 'TestField4'; ListCount = 14; PWLID = 53 }
+            @{parametername = 'GenericField5'; testvalue = 'TestField5'; ListCount = 15; PWLID = 53 }
+            @{parametername = 'GenericField6'; testvalue = 'TestField6'; ListCount = 16; PWLID = 53 }
+            @{parametername = 'GenericField7'; testvalue = 'TestField7'; ListCount = 17; PWLID = 53 }
+            @{parametername = 'GenericField8'; testvalue = 'TestField8'; ListCount = 18; PWLID = 53 }
+            @{parametername = 'GenericField9'; testvalue = 'TestField9'; ListCount = 19; PWLID = 53 }
+            @{parametername = 'GenericField10'; testvalue = 'TestField10'; ListCount = 20; PWLID = 53 }
         ) {
             $Result = if ($parametername -ne '') {
                 ((Invoke-Expression -Command "$($FunctionName) -$($Parametername) '$($testvalue)' -Reason 'Audit reason specified'" ) | Measure-Object).Count
@@ -1112,26 +1125,26 @@ Describe 'Get-PasswordStatePassword' {
             }
         }
         It 'Should have a <parametername> matching "<testvalue>"' -ForEach @(
-            @{parametername = 'Title'; testvalue = "Demo AD Username"; ListCount = 2; PWLID = 53 }
-            @{parametername = 'UserName'; testvalue = "username1"; ListCount = 3; PWLID = 53 }
-            @{parametername = 'HostName'; testvalue = "HostA"; ListCount = 4; PWLID = 53 }
-            @{parametername = 'Domain'; testvalue = "MYDomain"; ListCount = 5; PWLID = 53 }
-            @{parametername = 'AccountType'; testvalue = ""; ListCount = 1; PWLID = 53 } # testvalue must be empty because the actual property is AccountTypeID
-            @{parametername = 'Description'; testvalue = "Description for "; ListCount = 6; PWLID = 53 }
-            @{parametername = 'Notes'; testvalue = "Same Notes"; ListCount = 7; PWLID = 53 }
-            @{parametername = 'URL'; testvalue = "https://passworstate.local"; ListCount = 8; PWLID = 53 }
-            @{parametername = 'SiteID'; testvalue = ""; ListCount = 9; PWLID = 53 }
-            @{parametername = 'SiteLocation'; testvalue = ""; ListCount = 11; PWLID = 53 }
-            @{parametername = 'GenericField1'; testvalue = "TestField1"; ListCount = 11; PWLID = 53 }
-            @{parametername = 'GenericField2'; testvalue = "TestField2"; ListCount = 12; PWLID = 53 }
-            @{parametername = 'GenericField3'; testvalue = "TestField3"; ListCount = 13; PWLID = 53 }
-            @{parametername = 'GenericField4'; testvalue = "TestField4"; ListCount = 14; PWLID = 53 }
-            @{parametername = 'GenericField5'; testvalue = "TestField5"; ListCount = 15; PWLID = 53 }
-            @{parametername = 'GenericField6'; testvalue = "TestField6"; ListCount = 16; PWLID = 53 }
-            @{parametername = 'GenericField7'; testvalue = "TestField7"; ListCount = 17; PWLID = 53 }
-            @{parametername = 'GenericField8'; testvalue = "TestField8"; ListCount = 18; PWLID = 53 }
-            @{parametername = 'GenericField9'; testvalue = "TestField9"; ListCount = 19; PWLID = 53 }
-            @{parametername = 'GenericField10'; testvalue = "TestField10"; ListCount = 20; PWLID = 53 }
+            @{parametername = 'Title'; testvalue = 'Demo AD Username'; ListCount = 2; PWLID = 53 }
+            @{parametername = 'UserName'; testvalue = 'username1'; ListCount = 3; PWLID = 53 }
+            @{parametername = 'HostName'; testvalue = 'HostA'; ListCount = 4; PWLID = 53 }
+            @{parametername = 'Domain'; testvalue = 'MYDomain'; ListCount = 5; PWLID = 53 }
+            @{parametername = 'AccountType'; testvalue = ''; ListCount = 1; PWLID = 53 } # testvalue must be empty because the actual property is AccountTypeID
+            @{parametername = 'Description'; testvalue = 'Description for '; ListCount = 6; PWLID = 53 }
+            @{parametername = 'Notes'; testvalue = 'Same Notes'; ListCount = 7; PWLID = 53 }
+            @{parametername = 'URL'; testvalue = 'https://passworstate.local'; ListCount = 8; PWLID = 53 }
+            @{parametername = 'SiteID'; testvalue = ''; ListCount = 9; PWLID = 53 }
+            @{parametername = 'SiteLocation'; testvalue = ''; ListCount = 11; PWLID = 53 }
+            @{parametername = 'GenericField1'; testvalue = 'TestField1'; ListCount = 11; PWLID = 53 }
+            @{parametername = 'GenericField2'; testvalue = 'TestField2'; ListCount = 12; PWLID = 53 }
+            @{parametername = 'GenericField3'; testvalue = 'TestField3'; ListCount = 13; PWLID = 53 }
+            @{parametername = 'GenericField4'; testvalue = 'TestField4'; ListCount = 14; PWLID = 53 }
+            @{parametername = 'GenericField5'; testvalue = 'TestField5'; ListCount = 15; PWLID = 53 }
+            @{parametername = 'GenericField6'; testvalue = 'TestField6'; ListCount = 16; PWLID = 53 }
+            @{parametername = 'GenericField7'; testvalue = 'TestField7'; ListCount = 17; PWLID = 53 }
+            @{parametername = 'GenericField8'; testvalue = 'TestField8'; ListCount = 18; PWLID = 53 }
+            @{parametername = 'GenericField9'; testvalue = 'TestField9'; ListCount = 19; PWLID = 53 }
+            @{parametername = 'GenericField10'; testvalue = 'TestField10'; ListCount = 20; PWLID = 53 }
         ) {
             $ResultValues = Invoke-Expression -Command "$($FunctionName) -$($Parametername) '$($testvalue)' -Reason 'Audit reason specified'"
             foreach ($ResultValue in $ResultValues) {
@@ -1142,7 +1155,7 @@ Describe 'Get-PasswordStatePassword' {
             }
         }
         It 'Should have a <parametername> matching "<testvalue>" for alias <alias>' -ForEach @(
-            @{parametername = 'ADDomainNetBios'; testvalue = "MYDomain"; ListCount = 5; PWLID = 53; alias='Domain' }
+            @{parametername = 'ADDomainNetBios'; testvalue = 'MYDomain'; ListCount = 5; PWLID = 53; alias = 'Domain' }
         ) {
             $ResultValues = Invoke-Expression -Command "$($FunctionName) -$($Parametername) '$($testvalue)' -Reason 'Audit reason specified'"
             foreach ($ResultValue in $ResultValues) {


### PR DESCRIPTION
Hi @dnewsholme 

after upgrading to 9653 of Passwordstate the `Get-PasswordstatePassword` function is broken since new API properties for the `Password` method of the passwordstate api are missing.

Changelog: [`Updated the API's to support all the Web Site Field ID's which are used with the browser extensions`](https://www.clickstudios.com.au/passwordstate-changelog.aspx)

I have added the following properties to the `PasswordResult` class, the `Get-PasswordstatePassword` function and function tests and all documentation files.

Should not break backward compatibility.

> I didn't update the module manifest, it's still on `1.0`. Don't know if you want to use `4.4.44`?

```pwsh
[Parameter(ParameterSetName = 'Specific', ValueFromPipelineByPropertyName, Position = 29)][ValidateLength(1, 200)][string]$WebGenericField1_ID,
[Parameter(ParameterSetName = 'Specific', ValueFromPipelineByPropertyName, Position = 30)][ValidateLength(1, 200)][string]$WebGenericField2_ID,
[Parameter(ParameterSetName = 'Specific', ValueFromPipelineByPropertyName, Position = 31)][ValidateLength(1, 200)][string]$WebGenericField3_ID,
[Parameter(ParameterSetName = 'Specific', ValueFromPipelineByPropertyName, Position = 32)][ValidateLength(1, 200)][string]$WebGenericField4_ID,
[Parameter(ParameterSetName = 'Specific', ValueFromPipelineByPropertyName, Position = 33)][ValidateLength(1, 200)][string]$WebGenericField5_ID,
[Parameter(ParameterSetName = 'Specific', ValueFromPipelineByPropertyName, Position = 34)][ValidateLength(1, 200)][string]$WebGenericField6_ID,
[Parameter(ParameterSetName = 'Specific', ValueFromPipelineByPropertyName, Position = 35)][ValidateLength(1, 200)][string]$WebGenericField7_ID,
[Parameter(ParameterSetName = 'Specific', ValueFromPipelineByPropertyName, Position = 36)][ValidateLength(1, 200)][string]$WebGenericField8_ID,
[Parameter(ParameterSetName = 'Specific', ValueFromPipelineByPropertyName, Position = 37)][ValidateLength(1, 200)][string]$WebGenericField9_ID,
[Parameter(ParameterSetName = 'Specific', ValueFromPipelineByPropertyName, Position = 38)][ValidateLength(1, 200)][string]$WebGenericField10_ID,
[Parameter(ParameterSetName = 'Specific', ValueFromPipelineByPropertyName, Position = 39)][ValidateLength(1, 200)][string]$WebUser_ID,
[Parameter(ParameterSetName = 'Specific', ValueFromPipelineByPropertyName, Position = 40)][ValidateLength(1, 200)][string]$WebPassword_ID,
[Parameter(ParameterSetName = 'Specific', ValueFromPipelineByPropertyName, Position = 41)][ValidateLength(1, 200)][string]$WebOTP_ID
```

![image](https://user-images.githubusercontent.com/6794362/200384624-0f3cdaea-7e23-42fc-993b-de6d85ff54ee.png)

Thanks,
René