### PR TITLE
Only run deploy step when on Daryls repo

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -51,7 +51,7 @@ jobs:
     name: build-and-publish
     runs-on: windows-latest
     needs: [windows-tests,linux-tests]
-    if: github.ref == 'refs/heads/master'
+    if: github.ref == 'refs/heads/master' && github.repository == 'dnewsholme/PasswordState-Management'
     steps:
       - uses: actions/checkout@v2
       - name: Install from PSGallery


### PR DESCRIPTION
I slightly improved your pipeline so it would only run the 'build and deploy' step when the pipeline executes on your own repo, since you are the only one who has the secret variables